### PR TITLE
[BPK-1719] Disable font scaling on labels above accessory views

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 **Fixed:**
 
+- react-native-bpk-component-text-input:
+  - Disabled font scaling for the label when an accessory view is present.
+- react-native-bpk-component-phone-input:
+  - Disabled font scaling for the label.
+
 - react-native-bpk-component-button:
   - Secondary and destructive buttons now correctly have white backgrounds instead of transparent.
 

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
@@ -18,6 +18,7 @@ exports[`Android BpkPhoneNumberInput should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -179,6 +180,7 @@ exports[`Android BpkPhoneNumberInput should render correctly with \`editable\` f
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
@@ -18,6 +18,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -202,6 +203,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly with \`editable\` false
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -226,6 +226,7 @@ class BpkTextInput extends Component<Props, State> {
             numberOfLines={1}
             ellipsizeMode="tail"
             style={animatedLabelStyle}
+            allowFontScaling={!hasAccessoryView}
           >
             {label}
           </Animated.Text>

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -18,6 +18,7 @@ exports[`RTL BpkTextInput should ignore when placeholder is provided, as element
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -91,6 +92,7 @@ exports[`RTL BpkTextInput should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -164,6 +166,7 @@ exports[`RTL BpkTextInput should render correctly with \`accessoryView\` 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -239,6 +242,7 @@ exports[`RTL BpkTextInput should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -315,6 +319,7 @@ exports[`RTL BpkTextInput should render correctly with custom style 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -388,6 +393,7 @@ exports[`RTL BpkTextInput should render correctly with description 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -481,6 +487,7 @@ exports[`RTL BpkTextInput should render correctly with description, valid=false 
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -601,6 +608,7 @@ exports[`RTL BpkTextInput should render correctly with editable=false 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -674,6 +682,7 @@ exports[`RTL BpkTextInput should render correctly with inputRef set 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -747,6 +756,7 @@ exports[`RTL BpkTextInput should render correctly with mask="99/99" 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -820,6 +830,7 @@ exports[`RTL BpkTextInput should render correctly with mask="9999-9999-9999-9999
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -893,6 +904,7 @@ exports[`RTL BpkTextInput should render correctly with valid 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -993,6 +1005,7 @@ exports[`RTL BpkTextInput should render correctly with valid false 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -1093,6 +1106,7 @@ exports[`RTL BpkTextInput should render correctly with valid false and a validat
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -1213,6 +1227,7 @@ exports[`RTL BpkTextInput should render correctly with value 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -18,6 +18,7 @@ exports[`Android BpkTextInput should ignore when placeholder is provided, as ele
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -91,6 +92,7 @@ exports[`Android BpkTextInput should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -164,6 +166,7 @@ exports[`Android BpkTextInput should render correctly with \`accessoryView\` 1`]
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -239,6 +242,7 @@ exports[`Android BpkTextInput should render correctly with arbitrary props 1`] =
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -315,6 +319,7 @@ exports[`Android BpkTextInput should render correctly with custom style 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -388,6 +393,7 @@ exports[`Android BpkTextInput should render correctly with description 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -481,6 +487,7 @@ exports[`Android BpkTextInput should render correctly with description, valid=fa
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -601,6 +608,7 @@ exports[`Android BpkTextInput should render correctly with editable=false 1`] = 
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -674,6 +682,7 @@ exports[`Android BpkTextInput should render correctly with inputRef set 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -747,6 +756,7 @@ exports[`Android BpkTextInput should render correctly with mask="99/99" 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -820,6 +830,7 @@ exports[`Android BpkTextInput should render correctly with mask="9999-9999-9999-
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -893,6 +904,7 @@ exports[`Android BpkTextInput should render correctly with valid 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -993,6 +1005,7 @@ exports[`Android BpkTextInput should render correctly with valid false 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -1093,6 +1106,7 @@ exports[`Android BpkTextInput should render correctly with valid false and a val
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -1213,6 +1227,7 @@ exports[`Android BpkTextInput should render correctly with value 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -18,6 +18,7 @@ exports[`iOS BpkTextInput should ignore when placeholder is provided, as element
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -91,6 +92,7 @@ exports[`iOS BpkTextInput should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -164,6 +166,7 @@ exports[`iOS BpkTextInput should render correctly with \`accessoryView\` 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -239,6 +242,7 @@ exports[`iOS BpkTextInput should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -315,6 +319,7 @@ exports[`iOS BpkTextInput should render correctly with custom style 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -388,6 +393,7 @@ exports[`iOS BpkTextInput should render correctly with description 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -481,6 +487,7 @@ exports[`iOS BpkTextInput should render correctly with description, valid=false 
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -601,6 +608,7 @@ exports[`iOS BpkTextInput should render correctly with editable=false 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -674,6 +682,7 @@ exports[`iOS BpkTextInput should render correctly with inputRef set 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -747,6 +756,7 @@ exports[`iOS BpkTextInput should render correctly with mask="99/99" 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -820,6 +830,7 @@ exports[`iOS BpkTextInput should render correctly with mask="9999-9999-9999-9999
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -893,6 +904,7 @@ exports[`iOS BpkTextInput should render correctly with valid 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -993,6 +1005,7 @@ exports[`iOS BpkTextInput should render correctly with valid false 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -1093,6 +1106,7 @@ exports[`iOS BpkTextInput should render correctly with valid false and a validat
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={
@@ -1213,6 +1227,7 @@ exports[`iOS BpkTextInput should render correctly with value 1`] = `
     }
   >
     <Text
+      allowFontScaling={true}
       ellipsizeMode="tail"
       numberOfLines={1}
       style={


### PR DESCRIPTION
I tried various things but I couldn't think of a better way 😭 

We can always revisit this in the future.

Badge, Icon, PickerMenu and TitleView (from nav bar) all do this too, so there's a precedent for it.