### PR TITLE
Update fonts.gradle to correct bpk-svg default

### DIFF
--- a/packages/react-native-bpk-component-icon/fonts.gradle
+++ b/packages/react-native-bpk-component-icon/fonts.gradle
@@ -4,7 +4,7 @@
 
 def config = project.hasProperty("bpkicon") ? project.bpkicon : [];
 
-def iconFontsDir = config.iconFontsDir ?: "./node_modules/bpk-svgs/dist/font";
+def iconFontsDir = config.iconFontsDir ?: "../../node_modules/bpk-svgs/dist/font";
 def iconFontNames = config.iconFontNames ?: [ "*.ttf" ];
 
 gradle.projectsEvaluated {


### PR DESCRIPTION
When installing the backpack icons with npm and following the installation steps for android the icons won't be installed because of the path to bpk-svgs which gets installed in the node_modules. The need for using gradle options to make this work is not mentioned in the installation steps