### PR TITLE
[BPK-2126] Calendar bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - set -e
   - ./scripts/check-pristine-state package-lock.json ios/native.xcodeproj/project.pbxproj ios/native/Info.plist
   - npm run danger
-  - npm test
+  - TZ=Europe/London npm test
 
 cache:
   directories:

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'Backpack Native' do
 
@@ -23,6 +23,9 @@ target 'Backpack Native' do
   pod 'glog', podspec: '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', podspec: '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
+  # RN Bridging Pods
+  pod 'Backpack', '~> 6.0.0'
+  pod 'react-native-bpk-component-calendar', path: '../packages/react-native-bpk-component-calendar'
 
   # Third party pods
   pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - Backpack (6.0.0):
+    - FSCalendar (~> 2.8)
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.4.0):
     - React
@@ -7,9 +9,13 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
+  - FSCalendar (2.8.0)
   - glog (0.3.5)
   - React (0.57.7):
     - React/Core (= 0.57.7)
+  - react-native-bpk-component-calendar (0.0.1):
+    - Backpack (~> 6.0.0)
+    - React
   - react-native-maps (0.23.0):
     - React
   - React/Core (0.57.7):
@@ -50,10 +56,12 @@ PODS:
   - yoga (0.57.7.React)
 
 DEPENDENCIES:
+  - Backpack (~> 6.0.0)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - react-native-bpk-component-calendar (from `../packages/react-native-bpk-component-calendar`)
   - react-native-maps (from `../packages/react-native-bpk-component-map/node_modules/react-native-maps`)
   - React/Core (from `../node_modules/react-native`)
   - React/CxxBridge (from `../node_modules/react-native`)
@@ -67,7 +75,9 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - Backpack
     - boost-for-react-native
+    - FSCalendar
 
 EXTERNAL SOURCES:
   BVLinearGradient:
@@ -80,21 +90,26 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   React:
     :path: "../node_modules/react-native"
+  react-native-bpk-component-calendar:
+    :path: "../packages/react-native-bpk-component-calendar"
   react-native-maps:
     :path: "../packages/react-native-bpk-component-map/node_modules/react-native-maps"
   yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  Backpack: a9a3c704beed3e180c19ee1d1c26eeae2713f49f
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: 6d8909e3fc6b089defa4b89d967441fa6827a2ee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
+  FSCalendar: 3a5ed3636e2ba1b83ebebfcf0c2603105a6f5efe
   glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
+  react-native-bpk-component-calendar: 97dc3fe80e416867b37a7109c379a3defb564af6
   react-native-maps: 066c2afcc89e18726377bcc685315f989ca22449
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: a820fd1dbae2729bbf89b107411a41e83d79792a
+PODFILE CHECKSUM: 38726a947f3ee65935c1fb42800e2e5243fb0d0d
 
 COCOAPODS: 1.5.3

--- a/ios/native.xcodeproj/project.pbxproj
+++ b/ios/native.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
@@ -17,10 +18,10 @@
 		8E33D9A4365E4F84826CF0C6 /* iconMapping.json in Resources */ = {isa = PBXBuildFile; fileRef = 3CA50A36B56148BD95AF98C2 /* iconMapping.json */; };
 		93A11238766E920180390589 /* libPods-Backpack Native.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDC175C9DB0F0B9CBD71B51 /* libPods-Backpack Native.a */; };
 		C8B831744C5A4256BD1B5010 /* BpkIcon.eot in Resources */ = {isa = PBXBuildFile; fileRef = 8C8F437769B54A038A210159 /* BpkIcon.eot */; };
+		CD97D274772C442994C3117B /* BpkIconIOS.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */; };
 		D66FC4882109D8610063B1A6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D66FC4872109D8610063B1A6 /* Main.storyboard */; };
 		D66FC4912109DA3C0063B1A6 /* StorybookViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D66FC4902109DA3C0063B1A6 /* StorybookViewController.m */; };
 		E19140ED6394488C9626FE7A /* BpkIcon.woff in Resources */ = {isa = PBXBuildFile; fileRef = E436C94A65D1410092B05450 /* BpkIcon.woff */; };
-		CD97D274772C442994C3117B /* BpkIconIOS.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 		349CF328083441A0845E0C8D /* BpkIcon.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.ttf; path = "../node_modules/bpk-svgs/dist/font/BpkIcon.ttf"; sourceTree = "<group>"; };
 		3CA50A36B56148BD95AF98C2 /* iconMapping.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = iconMapping.json; path = "../node_modules/bpk-svgs/dist/font/iconMapping.json"; sourceTree = "<group>"; };
 		6B59545B47D6FA3C28AB6F8B /* Pods-Backpack Native.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack Native.release.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack Native/Pods-Backpack Native.release.xcconfig"; sourceTree = "<group>"; };
+		83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIconIOS.ttf; path = "../node_modules/bpk-svgs/dist/font/BpkIconIOS.ttf"; sourceTree = "<group>"; };
 		8C8F437769B54A038A210159 /* BpkIcon.eot */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.eot; path = "../node_modules/bpk-svgs/dist/font/BpkIcon.eot"; sourceTree = "<group>"; };
 		ABDC175C9DB0F0B9CBD71B51 /* libPods-Backpack Native.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Backpack Native.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3896E08C3804FF089E1E50B /* libRCTRestart.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTRestart.a; sourceTree = "<group>"; };
@@ -65,7 +67,6 @@
 		D66FC4902109DA3C0063B1A6 /* StorybookViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = StorybookViewController.m; sourceTree = "<group>"; tabWidth = 4; };
 		E436C94A65D1410092B05450 /* BpkIcon.woff */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.woff; path = "../node_modules/bpk-svgs/dist/font/BpkIcon.woff"; sourceTree = "<group>"; };
 		FBB4289347D8862ADA374625 /* Pods-Backpack Native.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack Native.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack Native/Pods-Backpack Native.debug.xcconfig"; sourceTree = "<group>"; };
-		83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */ = {isa = PBXFileReference; name = "BpkIconIOS.ttf"; path = "../node_modules/bpk-svgs/dist/font/BpkIconIOS.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -236,6 +237,7 @@
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				2FF57E3C5DE8BECE596708E7 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -413,6 +415,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+		};
+		2FF57E3C5DE8BECE596708E7 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Backpack Native/Pods-Backpack Native-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Backpack/Icon.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Icon.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Backpack Native/Pods-Backpack Native-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/react-native-bpk-component-calendar/README.md
+++ b/packages/react-native-bpk-component-calendar/README.md
@@ -1,0 +1,75 @@
+# react-native-bpk-component-calendar
+
+> Backpack React Native calendar component.
+
+## Installation
+
+```sh
+npm install react-native-bpk-component-calendar --save-dev
+```
+
+Because this package ships with native code, it is also necessary to add some native dependencies to your RN project:
+
+### Android
+TODO - NEED TO WRITE THIS BIT
+
+### iOS
+Having installed the NPM package, you need to add the following dependencies to your Podfile:
+
+ - `react-native-bpk-component-calendar`, using a relative path via `node_modules`
+
+For example:
+```
+  pod 'react-native-bpk-component-calendar', path: '../node_modules/react-native-bpk-component-calendar'
+```
+
+## Usage
+
+```js
+import React, { Component } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+import BpkCalendar, { SELECTION_TYPES } from 'react-native-bpk-component-calendar';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacingBase,
+  },
+});
+
+export default () => (
+  <View style={styles.container}>
+    <BpkCalendar
+      selectionType={SELECTION_TYPES.single}
+      selectedDates={[new Date()]}
+      onChangeSelectedDates={newDates => {
+        console.warn("Date selection changed");
+      }}
+    />
+  </View>
+);
+```
+
+## Props
+
+### BpkCalendar
+
+| Property                | PropType               | Required   | Default Value          |
+| ----------------------- | ---------------------- | ---------- | ---------------------- |
+| locale                  | string                 | true       | -                      |
+| maxDate                 | Date                   | false      | null                   |
+| minDate                 | Date                   | false      | null                   |
+| onChangeSelectedDates   | function               | false      | null                   |
+| selectedDates           | Array(Date)            | false      | null                   |
+| selectionType           | oneOf(SELECTION_TYPES) | false      | SELECTION_TYPES.single |
+
+#### locale
+
+TODO explain locale
+
+#### selectedDates
+
+* When `selectionType` is `SELECTION_TYPES.single`, you should only include zero or one entries in the `selectedDates` array.
+* When `selectionType` is `SELECTION_TYPES.range`, you should only include zero, one or two entries in the `selectedDates` array.

--- a/packages/react-native-bpk-component-calendar/index.js
+++ b/packages/react-native-bpk-component-calendar/index.js
@@ -1,0 +1,29 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import BpkCalendar, { type Props as BpkCalendarProps } from './src/BpkCalendar';
+import {
+  SELECTION_TYPES,
+  type SelectionType as BpkCalendarSelectionType,
+} from './src/common-types';
+
+export type { BpkCalendarProps, BpkCalendarSelectionType };
+export default BpkCalendar;
+export { SELECTION_TYPES };

--- a/packages/react-native-bpk-component-calendar/package-lock.json
+++ b/packages/react-native-bpk-component-calendar/package-lock.json
@@ -1,0 +1,218 @@
+{
+	"name": "react-native-bpk-component-calendar",
+	"version": "0.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"bpk-svgs": {
+			"version": "6.0.11",
+			"resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-6.0.11.tgz",
+			"integrity": "sha512-eDGd5omIozrnC9hNIjVC4M7TRR5T3WzHc/vwRSWEc7dJHqOyyEXJrVfClbHY7bNFkKT2mVes+c8WTVinI/V4Xg==",
+			"dev": true
+		},
+		"bpk-tokens": {
+			"version": "27.4.4",
+			"resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-27.4.4.tgz",
+			"integrity": "sha512-x9jqpPFZfaMl16ll84XugzPBGrOVmgCXCBbJ3MHYdcG1+9SNjwMo49KKffcs8vemhmVyEg6c30ERJbg3fcD0UA==",
+			"requires": {
+				"color": "^3.0.0"
+			}
+		},
+		"brcast": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+			"dev": true
+		},
+		"color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+			"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+			"requires": {
+				"color-convert": "^1.9.1",
+				"color-string": "^1.5.2"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-string": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+			"requires": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+		},
+		"is-function": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+			"dev": true
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"prop-types": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"requires": {
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"react-native-bpk-component-button-link": {
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-button-link/-/react-native-bpk-component-button-link-4.0.12.tgz",
+			"integrity": "sha512-SNq77dP5W6smAyqGcV7bxp1jdFtOd31ixEeZdAdfdRperEM9wplfUxkxLGSBXjeQlr7wwacMXGhwzh5JT1bSSg==",
+			"dev": true,
+			"requires": {
+				"bpk-tokens": "^27.4.4",
+				"lodash": "^4.17.4",
+				"prop-types": "^15.5.8",
+				"react-native-bpk-component-icon": "^1.10.23",
+				"react-native-bpk-component-text": "^4.0.5",
+				"react-native-bpk-component-touchable-native-feedback": "^1.1.42",
+				"react-native-bpk-theming": "^1.0.88"
+			}
+		},
+		"react-native-bpk-component-icon": {
+			"version": "1.10.23",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-icon/-/react-native-bpk-component-icon-1.10.23.tgz",
+			"integrity": "sha512-LrgzPnk3ltyF2sLM7IxOBGjJRsjPhgAEbmaKnPbWM8i2DxkNHDtCQubianPDckkNHGmb877zvgs+mPukn0zc9Q==",
+			"dev": true,
+			"requires": {
+				"bpk-svgs": "^6.0.6",
+				"bpk-tokens": "^27.4.4",
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-native-bpk-component-picker": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-picker/-/react-native-bpk-component-picker-3.0.15.tgz",
+			"integrity": "sha512-UdZB4Ye8xng5z6+qreN8F2XLu9vtMjUJ2iutAXHeGIH1nRFfHwfgfTkVMp9XnSTGFyMH0a4wLIcX8MP44Zk76w==",
+			"dev": true,
+			"requires": {
+				"bpk-tokens": "^27.4.4",
+				"prop-types": "^15.5.8",
+				"react-native-bpk-component-button-link": "^4.0.12",
+				"react-native-bpk-component-icon": "^1.10.23",
+				"react-native-bpk-component-text": "^4.0.5",
+				"react-native-bpk-component-touchable-native-feedback": "^1.1.42",
+				"react-native-bpk-component-touchable-overlay": "^1.1.5"
+			}
+		},
+		"react-native-bpk-component-text": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-text/-/react-native-bpk-component-text-4.0.5.tgz",
+			"integrity": "sha512-DpFAZeD9eqx2SWuOsXGeZOSeJXnzvIAtYMpOljNzpyjPH58OMjTIE3IPTO5yCApbp5zv6t2FpRbJ7ednFmdBtg==",
+			"dev": true,
+			"requires": {
+				"bpk-tokens": "^27.4.4",
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-native-bpk-component-touchable-native-feedback": {
+			"version": "1.1.42",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-touchable-native-feedback/-/react-native-bpk-component-touchable-native-feedback-1.1.42.tgz",
+			"integrity": "sha512-0mMsQ5UsFjphAiZcxPSlEAMMkMuXSc9YdhPWaM0S90fsHmkCIBYgLc42hND2IAGd9N1mzVgW2lNz3Xu1P1zfPw==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-native-bpk-component-touchable-overlay": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-component-touchable-overlay/-/react-native-bpk-component-touchable-overlay-1.1.5.tgz",
+			"integrity": "sha512-dpYePMQVEZ9QRnwfN2r6rnSUf/cW5kU9BJSChIQwHdcgSKa4VJ4IGLnq1evNeS//EXFHnsIVnXNEbDNrIproOw==",
+			"dev": true,
+			"requires": {
+				"bpk-tokens": "^27.4.4",
+				"prop-types": "^15.5.8"
+			}
+		},
+		"react-native-bpk-theming": {
+			"version": "1.0.88",
+			"resolved": "https://registry.npmjs.org/react-native-bpk-theming/-/react-native-bpk-theming-1.0.88.tgz",
+			"integrity": "sha512-UFoDMWT96lqyL7vLuVmCI0Ut2R7esbNZNKuOPaNJ3/TiUqznGDBrpSdgHvYUzKes/8C2thwdkJs7dLHnvr005g==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.4",
+				"theming": "^1.1.0"
+			}
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"requires": {
+				"is-arrayish": "^0.3.1"
+			}
+		},
+		"theming": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+			"integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+			"dev": true,
+			"requires": {
+				"brcast": "^3.0.1",
+				"is-function": "^1.0.1",
+				"is-plain-object": "^2.0.1",
+				"prop-types": "^15.5.8"
+			}
+		}
+	}
+}

--- a/packages/react-native-bpk-component-calendar/package.json
+++ b/packages/react-native-bpk-component-calendar/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-native-bpk-component-calendar",
+  "private": true,
+  "version": "0.0.1",
+  "main": "index.js",
+  "description": "Backpack React Native calendar component.",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Skyscanner/backpack.git"
+  },
+  "author": "Backpack Design System <backpack@skyscanner.net>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "react": "^16.0.0-alpha.1",
+    "react-native": ">= 0.47.0"
+  },
+  "dependencies": {
+    "bpk-tokens": "^27.4.4",
+    "prop-types": "^15.5.8"
+  },
+  "devDependencies": {
+    "react-native-bpk-component-picker": "^3.0.16",
+    "react-native-bpk-component-select": "^2.1.13",
+    "react-native-bpk-component-text-input": "^3.0.11"
+  }
+}

--- a/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
+++ b/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-bpk-component-calendar"
+  s.version      = package['version']
+  s.summary      = "Backpack calendar component for React Native"
+
+  s.authors      = { "backpack" => "backpacksquad@skyscanner.net" }
+  s.homepage     = "https://backpack.github.io/components/calendar?platform=ios"
+  s.license      = "MIT"
+  s.platform     = :ios, "10.0"
+
+  s.source       = { :git => "https://github.com/Skyscanner/backpack-react-native.git" }
+  s.source_files  = "src/ios/CalendarBridge/**/*.{h,m}"
+
+  s.dependency 'React'
+  s.dependency 'Backpack', '~> 6.0.0'
+end

--- a/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.android.js
+++ b/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.android.js
@@ -1,0 +1,50 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import commonTests from './BpkCalendar-test.common';
+
+jest.mock('react-native', () => {
+  const MARSHMALLOW = 23;
+  const reactNative = jest.requireActual('react-native');
+  jest
+    .spyOn(reactNative.Platform, 'select')
+    .mockImplementation(obj => obj.android || obj.default);
+  reactNative.Platform.OS = 'android';
+
+  // We rely on BpkTouchableNativeFeedback to handle the ripple effect on older devices
+  // so in this test suite we're assuming API > 23 where the ripple is supported
+  Object.defineProperty(reactNative.Platform, 'Version', {
+    value: MARSHMALLOW,
+  });
+
+  return reactNative;
+});
+
+jest.mock('bpk-tokens/tokens/base.react.native', () =>
+  jest.requireActual('bpk-tokens/tokens/base.react.native.android.js'),
+);
+
+jest.mock('./BpkCalendar', () =>
+  jest.requireActual('./BpkCalendar.android.js'),
+);
+
+describe('Android', () => {
+  commonTests();
+});

--- a/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.common.js
+++ b/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.common.js
@@ -1,0 +1,216 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-console */
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import BpkCalendar from './BpkCalendar';
+import { SELECTION_TYPES } from './common-types';
+
+const defaultProps = {
+  locale: 'en_GB',
+};
+
+const commonTests = () => {
+  describe('BpkCalendar', () => {
+    it('should render correctly', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            {...defaultProps}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with minDate', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            {...defaultProps}
+            minDate={new Date(2019, 4, 19)}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with maxDate', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            {...defaultProps}
+            maxDate={new Date(2020, 4, 19)}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with both minDate and maxDate', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            {...defaultProps}
+            minDate={new Date(2019, 4, 19)}
+            maxDate={new Date(2020, 4, 19)}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with selection type "single" and selected dates', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            selectedDates={[new Date(2019, 4, 19)]}
+            {...defaultProps}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with selection type "range" and selected dates', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            selectedDates={[new Date(2019, 4, 19), new Date(2019, 4, 21)]}
+            {...defaultProps}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    // TODO: Enable these when Android is merged
+
+    // it('should error with selection type "single" and selectedDates.length > 1', () => {
+    //   jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+    //   renderer.create(
+    //     <BpkCalendar
+    //       selectionType={SELECTION_TYPES.single}
+    //       selectedDates={[new Date(2019, 4, 19), new Date(2019, 4, 20)]}
+    //       {...defaultProps}
+    //     />,
+    //   );
+    //   expect(console.error).toHaveBeenCalled();
+    // });
+
+    // it('should error if when maxDate is before minDate', () => {
+    //   expect(() => {
+    //     renderer.create(
+    //       <BpkCalendar
+    //         selectionType={SELECTION_TYPES.single}
+    //         minDate={new Date(2020, 4, 19)}
+    //         maxDate={new Date(2019, 4, 19)}
+    //         {...defaultProps}
+    //       />,
+    //     );
+    //   }).toThrowError('BpkCalendar: "minDate" must be before "maxDate"');
+    // });
+
+    // it('should error with selection type "range" and selectedDates.length > 2', () => {
+    //   jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
+    //   renderer.create(
+    //     <BpkCalendar
+    //       selectionType={SELECTION_TYPES.range}
+    //       selectedDates={[
+    //         new Date(2019, 4, 19),
+    //         new Date(2019, 4, 20),
+    //         new Date(2019, 4, 21),
+    //       ]}
+    //       {...defaultProps}
+    //     />,
+    //   );
+    //   expect(console.error).toHaveBeenCalled();
+    // });
+
+    it('should render correctly with selection type "multiple" and selected dates', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.multiple}
+            selectedDates={[
+              new Date(2019, 4, 19),
+              new Date(2019, 4, 21),
+              new Date(2019, 4, 29),
+            ]}
+            {...defaultProps}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    Object.keys(SELECTION_TYPES).forEach(selectionType => {
+      it(`should render correctly for selectionType={'${selectionType}'}`, () => {
+        const tree = renderer
+          .create(
+            <BpkCalendar selectionType={selectionType} {...defaultProps} />,
+          )
+          .toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+    });
+
+    it('should render correctly with custom style', () => {
+      const styles = StyleSheet.create({
+        custom: {
+          flex: 1,
+        },
+      });
+
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            {...defaultProps}
+            style={styles.custom}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render correctly with arbitrary props', () => {
+      const tree = renderer
+        .create(
+          <BpkCalendar
+            selectionType={SELECTION_TYPES.single}
+            {...defaultProps}
+            testID="123" // <- Arbitrary prop.
+          />,
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+};
+export default commonTests;

--- a/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.ios.js
+++ b/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.ios.js
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import commonTests from './BpkCalendar-test.common';
+
+describe('iOS', () => {
+  commonTests();
+});

--- a/packages/react-native-bpk-component-calendar/src/BpkCalendar.android.js
+++ b/packages/react-native-bpk-component-calendar/src/BpkCalendar.android.js
@@ -1,0 +1,67 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import {
+  type StyleObj,
+  Text,
+  StyleSheet,
+  View,
+  ViewPropTypes,
+} from 'react-native';
+
+/* eslint-disable */
+const styles = StyleSheet.create({
+  base: {
+    backgroundColor: 'red',
+  },
+});
+/* eslint-enable */
+
+export type Props = {
+  style: ?StyleObj,
+};
+
+const BpkCalendar = (props: Props) => {
+  const { style: userStyle, ...rest } = props;
+
+  const style = [styles.base];
+  if (userStyle) {
+    style.push(userStyle);
+  }
+
+  /* eslint-disable */
+  return (
+    <View style={style} {...rest}>
+      <Text>THIS COMPONENT HAS NOT BEEN BRIDGED YET</Text>
+    </View>
+  );
+  /* eslint-enable */
+};
+
+BpkCalendar.propTypes = {
+  style: ViewPropTypes.style,
+};
+
+BpkCalendar.defaultProps = {
+  style: null,
+};
+
+export default BpkCalendar;

--- a/packages/react-native-bpk-component-calendar/src/BpkCalendar.ios.js
+++ b/packages/react-native-bpk-component-calendar/src/BpkCalendar.ios.js
@@ -1,0 +1,76 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React from 'react';
+import { requireNativeComponent } from 'react-native';
+
+import {
+  commonPropTypes,
+  commonDefaultProps,
+  type CommonProps,
+} from './common-types';
+
+const RCTBPKCalendar = requireNativeComponent('RCTBPKCalendar');
+
+export type Props = {
+  ...$Exact<CommonProps>,
+};
+
+const BpkCalendar = (props: Props) => {
+  const {
+    minDate,
+    maxDate,
+    onChangeSelectedDates,
+    selectedDates,
+    ...rest
+  } = props;
+
+  if (minDate && maxDate) {
+    if (minDate > maxDate) {
+      // It's safer to throw an error rather than use a prop type because if
+      // we let this get rendered it will crash the calendar.
+      throw new Error(`BpkCalendar: "minDate" must be before "maxDate".`);
+    }
+  }
+
+  return (
+    <RCTBPKCalendar
+      minDate={minDate}
+      maxDate={maxDate}
+      onDateSelection={event => {
+        if (event.nativeEvent.selectedDates) {
+          const convertedDates = event.nativeEvent.selectedDates.map(
+            dateString => new Date(Date.parse(dateString)),
+          );
+          if (onChangeSelectedDates) {
+            onChangeSelectedDates(convertedDates);
+          }
+        }
+      }}
+      selectedDates={selectedDates}
+      {...rest}
+    />
+  );
+};
+
+BpkCalendar.propTypes = commonPropTypes;
+BpkCalendar.defaultProps = commonDefaultProps;
+
+export default BpkCalendar;

--- a/packages/react-native-bpk-component-calendar/src/__snapshots__/BpkCalendar-test.android.js.snap
+++ b/packages/react-native-bpk-component-calendar/src/__snapshots__/BpkCalendar-test.android.js.snap
@@ -1,0 +1,243 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Android BpkCalendar should render correctly 1`] = `
+<View
+  locale="en_GB"
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly for selectionType={'multiple'} 1`] = `
+<View
+  locale="en_GB"
+  selectionType="multiple"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly for selectionType={'range'} 1`] = `
+<View
+  locale="en_GB"
+  selectionType="range"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly for selectionType={'single'} 1`] = `
+<View
+  locale="en_GB"
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with arbitrary props 1`] = `
+<View
+  locale="en_GB"
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+  testID="123"
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with both minDate and maxDate 1`] = `
+<View
+  locale="en_GB"
+  maxDate={2020-05-18T23:00:00.000Z}
+  minDate={2019-05-18T23:00:00.000Z}
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with custom style 1`] = `
+<View
+  locale="en_GB"
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+      Object {
+        "flex": 1,
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with maxDate 1`] = `
+<View
+  locale="en_GB"
+  maxDate={2020-05-18T23:00:00.000Z}
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with minDate 1`] = `
+<View
+  locale="en_GB"
+  minDate={2019-05-18T23:00:00.000Z}
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with selection type "multiple" and selected dates 1`] = `
+<View
+  locale="en_GB"
+  selectedDates={
+    Array [
+      2019-05-18T23:00:00.000Z,
+      2019-05-20T23:00:00.000Z,
+      2019-05-28T23:00:00.000Z,
+    ]
+  }
+  selectionType="multiple"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with selection type "range" and selected dates 1`] = `
+<View
+  locale="en_GB"
+  selectedDates={
+    Array [
+      2019-05-18T23:00:00.000Z,
+      2019-05-20T23:00:00.000Z,
+    ]
+  }
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;
+
+exports[`Android BpkCalendar should render correctly with selection type "single" and selected dates 1`] = `
+<View
+  locale="en_GB"
+  selectedDates={
+    Array [
+      2019-05-18T23:00:00.000Z,
+    ]
+  }
+  selectionType="single"
+  style={
+    Array [
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
+  }
+>
+  <Text>
+    THIS COMPONENT HAS NOT BEEN BRIDGED YET
+  </Text>
+</View>
+`;

--- a/packages/react-native-bpk-component-calendar/src/__snapshots__/BpkCalendar-test.ios.js.snap
+++ b/packages/react-native-bpk-component-calendar/src/__snapshots__/BpkCalendar-test.ios.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iOS BpkCalendar should render correctly 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly for selectionType={'multiple'} 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="multiple"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly for selectionType={'range'} 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="range"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly for selectionType={'single'} 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with arbitrary props 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={null}
+  testID="123"
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with both minDate and maxDate 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={2020-05-18T23:00:00.000Z}
+  minDate={2019-05-18T23:00:00.000Z}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with custom style 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with maxDate 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={2020-05-18T23:00:00.000Z}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with minDate 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={2019-05-18T23:00:00.000Z}
+  onDateSelection={[Function]}
+  selectedDates={Array []}
+  selectionType="single"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with selection type "multiple" and selected dates 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={
+    Array [
+      2019-05-18T23:00:00.000Z,
+      2019-05-20T23:00:00.000Z,
+      2019-05-28T23:00:00.000Z,
+    ]
+  }
+  selectionType="multiple"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with selection type "range" and selected dates 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={
+    Array [
+      2019-05-18T23:00:00.000Z,
+      2019-05-20T23:00:00.000Z,
+    ]
+  }
+  selectionType="single"
+  style={null}
+/>
+`;
+
+exports[`iOS BpkCalendar should render correctly with selection type "single" and selected dates 1`] = `
+<RCTBPKCalendar
+  locale="en_GB"
+  maxDate={null}
+  minDate={null}
+  onDateSelection={[Function]}
+  selectedDates={
+    Array [
+      2019-05-18T23:00:00.000Z,
+    ]
+  }
+  selectionType="single"
+  style={null}
+/>
+`;

--- a/packages/react-native-bpk-component-calendar/src/common-types.js
+++ b/packages/react-native-bpk-component-calendar/src/common-types.js
@@ -1,0 +1,92 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import { ViewPropTypes, type StyleObj } from 'react-native';
+import PropTypes from 'prop-types';
+
+export const SELECTION_TYPES = {
+  single: 'single',
+  range: 'range',
+  multiple: 'multiple',
+};
+
+export type SelectionType = $Keys<typeof SELECTION_TYPES>;
+
+export type CommonProps = {
+  locale: string,
+  minDate: ?Date,
+  maxDate: ?Date,
+  onChangeSelectedDates: ?(Date[]) => mixed,
+  selectedDates: Date[],
+  selectionType: SelectionType,
+  style: ?StyleObj,
+};
+
+const selectedDatesPropType = (
+  props: { [string]: any },
+  propName: string,
+  componentName: string,
+  ...rest: [any]
+) => {
+  if (props[propName]) {
+    const selectedDatesCount = props[propName].length;
+    if (
+      props.selectionType === SELECTION_TYPES.single &&
+      selectedDatesCount > 1
+    ) {
+      return new Error(
+        `${componentName}: When "selectionType" is "single", only supply one date to "selectedDates"`,
+      );
+    }
+    if (
+      props.selectionType === SELECTION_TYPES.range &&
+      selectedDatesCount > 2
+    ) {
+      return new Error(
+        `${componentName}: When "selectionType" is "range", only supply one or two dates to "selectedDates"`,
+      );
+    }
+  }
+  return PropTypes.arrayOf(PropTypes.instanceOf(Date))(
+    props,
+    propName,
+    componentName,
+    ...rest,
+  );
+};
+
+export const commonPropTypes = {
+  locale: PropTypes.string.isRequired,
+  minDate: PropTypes.instanceOf(Date),
+  maxDate: PropTypes.instanceOf(Date),
+  onChangeSelectedDates: PropTypes.func,
+  selectedDates: selectedDatesPropType,
+  selectionType: PropTypes.oneOf(Object.keys(SELECTION_TYPES)),
+  style: ViewPropTypes.style,
+};
+
+export const commonDefaultProps = {
+  minDate: null,
+  maxDate: null,
+  onChangeSelectedDates: null,
+  selectedDates: [],
+  selectionType: SELECTION_TYPES.single,
+  style: null,
+};

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge.xcodeproj/project.pbxproj
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge.xcodeproj/project.pbxproj
@@ -1,0 +1,296 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D209D38B21E8F24F00488CC6 /* RCTCalendarViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D209D38821E8F24F00488CC6 /* RCTCalendarViewManager.m */; };
+		D209D38C21E8F24F00488CC6 /* RCTConvert+RCTCalendarView.m in Sources */ = {isa = PBXBuildFile; fileRef = D209D38921E8F24F00488CC6 /* RCTConvert+RCTCalendarView.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D20C6DBB21E7D42500CBB30E /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		D209D38721E8F24F00488CC6 /* RCTConvert+RCTCalendarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+RCTCalendarView.h"; sourceTree = "<group>"; };
+		D209D38821E8F24F00488CC6 /* RCTCalendarViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTCalendarViewManager.m; sourceTree = "<group>"; };
+		D209D38921E8F24F00488CC6 /* RCTConvert+RCTCalendarView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+RCTCalendarView.m"; sourceTree = "<group>"; };
+		D209D38A21E8F24F00488CC6 /* RCTCalendarViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTCalendarViewManager.h; sourceTree = "<group>"; };
+		D20C6DBD21E7D42500CBB30E /* libCalendarBridge.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCalendarBridge.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D20C6DBA21E7D42500CBB30E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D20C6DB421E7D42500CBB30E = {
+			isa = PBXGroup;
+			children = (
+				D20C6DBF21E7D42500CBB30E /* CalendarBridge */,
+				D20C6DBE21E7D42500CBB30E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D20C6DBE21E7D42500CBB30E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D20C6DBD21E7D42500CBB30E /* libCalendarBridge.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D20C6DBF21E7D42500CBB30E /* CalendarBridge */ = {
+			isa = PBXGroup;
+			children = (
+				D209D38A21E8F24F00488CC6 /* RCTCalendarViewManager.h */,
+				D209D38821E8F24F00488CC6 /* RCTCalendarViewManager.m */,
+				D209D38721E8F24F00488CC6 /* RCTConvert+RCTCalendarView.h */,
+				D209D38921E8F24F00488CC6 /* RCTConvert+RCTCalendarView.m */,
+			);
+			path = CalendarBridge;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D20C6DBC21E7D42500CBB30E /* CalendarBridge */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D20C6DC621E7D42500CBB30E /* Build configuration list for PBXNativeTarget "CalendarBridge" */;
+			buildPhases = (
+				D20C6DB921E7D42500CBB30E /* Sources */,
+				D20C6DBA21E7D42500CBB30E /* Frameworks */,
+				D20C6DBB21E7D42500CBB30E /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CalendarBridge;
+			productName = CalendarBridge;
+			productReference = D20C6DBD21E7D42500CBB30E /* libCalendarBridge.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D20C6DB521E7D42500CBB30E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "George Gillams";
+				TargetAttributes = {
+					D20C6DBC21E7D42500CBB30E = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = D20C6DB821E7D42500CBB30E /* Build configuration list for PBXProject "CalendarBridge" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = D20C6DB421E7D42500CBB30E;
+			productRefGroup = D20C6DBE21E7D42500CBB30E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D20C6DBC21E7D42500CBB30E /* CalendarBridge */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D20C6DB921E7D42500CBB30E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D209D38B21E8F24F00488CC6 /* RCTCalendarViewManager.m in Sources */,
+				D209D38C21E8F24F00488CC6 /* RCTConvert+RCTCalendarView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		D20C6DC421E7D42500CBB30E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		D20C6DC521E7D42500CBB30E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D20C6DC721E7D42500CBB30E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = U9XKRL39B6;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D20C6DC821E7D42500CBB30E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = U9XKRL39B6;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D20C6DB821E7D42500CBB30E /* Build configuration list for PBXProject "CalendarBridge" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D20C6DC421E7D42500CBB30E /* Debug */,
+				D20C6DC521E7D42500CBB30E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D20C6DC621E7D42500CBB30E /* Build configuration list for PBXNativeTarget "CalendarBridge" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D20C6DC721E7D42500CBB30E /* Debug */,
+				D20C6DC821E7D42500CBB30E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D20C6DB521E7D42500CBB30E /* Project object */;
+}

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.h
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.h
@@ -1,0 +1,26 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <React/RCTViewManager.h>
+#import <Backpack/Calendar.h>
+
+@interface RCTBPKCalendar : BPKCalendar
+
+@property (nonatomic, copy) RCTBubblingEventBlock onDateSelection;
+
+@end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.m
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "RCTBPKCalendar.h"
+
+@implementation RCTBPKCalendar
+
+@end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.h
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.h
@@ -1,0 +1,23 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <React/RCTViewManager.h>
+
+@interface RCTBPKCalendarManager : RCTViewManager
+
+@end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.m
@@ -1,0 +1,69 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "RCTBPKCalendarManager.h"
+#import "RCTConvert+RCTBPKCalendar.h"
+#import "RCTBPKCalendar.h"
+
+@interface RCTBPKCalendarManager() <BPKCalendarDelegate>
+
+@end
+
+
+@implementation RCTBPKCalendarManager
+
+RCT_EXPORT_MODULE()
+
+- (UIView *)view {
+    RCTBPKCalendar *calendar = [[RCTBPKCalendar alloc] initWithFrame:CGRectZero];
+
+    calendar.delegate = self;
+    return calendar;
+}
+
+RCT_EXPORT_VIEW_PROPERTY(minDate, NSDate)
+RCT_EXPORT_VIEW_PROPERTY(maxDate, NSDate)
+RCT_EXPORT_VIEW_PROPERTY(selectionType, BPKCalendarSelection)
+RCT_EXPORT_VIEW_PROPERTY(locale, NSLocale)
+RCT_EXPORT_VIEW_PROPERTY(selectedDates, NSArray<NSDate *> *)
+
+RCT_EXPORT_VIEW_PROPERTY(onDateSelection, RCTBubblingEventBlock)
+
+#pragma mark RCTCalendarViewDelegate
+
+/*
+ * `RCTBPKCalendarManager` acts as the delegate of all of the `RCTBPKCalendar` views. This is just one
+ * pattern and it's perfectly fine to call `onDateSelection` from the `RCTBPKCalendar` directly.
+ */
+- (void)calendar:(RCTBPKCalendar *)calendar didChangeDateSelection:(NSArray<NSDate *> *)dateList {
+    if (!calendar.onDateSelection) {
+        return;
+    }
+
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    [dateFormat setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'"];
+
+    NSMutableArray * stringArray = [[NSMutableArray alloc]init];
+    for (NSDate *date in dateList) {
+        [stringArray addObject:[dateFormat stringFromDate:date]];
+    }
+
+    calendar.onDateSelection(@{@"selectedDates": stringArray});
+}
+
+@end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTConvert+RCTBPKCalendar.h
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTConvert+RCTBPKCalendar.h
@@ -1,0 +1,28 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <CoreLocation/CoreLocation.h>
+#import <Backpack/Calendar.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (RCTBPKCalendar)
+
++ (BPKCalendarSelection)BPKCalendarSelection:(id)json;
++ (NSArray<NSDate *> *)NSDateArray:(id)json;
+
+@end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTConvert+RCTBPKCalendar.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTConvert+RCTBPKCalendar.m
@@ -1,0 +1,31 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "RCTConvert+RCTBPKCalendar.h"
+#import <React/RCTConvert+CoreLocation.h>
+
+@implementation RCTConvert (RCTBPKCalendar)
+
+RCT_ENUM_CONVERTER(BPKCalendarSelection, (@{
+                                            @"single": @(BPKCalendarSelectionSingle),
+                                            @"multiple": @(BPKCalendarSelectionMultiple),
+                                            @"range": @(BPKCalendarSelectionRange)
+                                            }), BPKCalendarSelectionSingle, integerValue)
+RCT_ARRAY_CONVERTER(NSDate)
+
+@end

--- a/packages/react-native-bpk-component-calendar/stories.js
+++ b/packages/react-native-bpk-component-calendar/stories.js
@@ -1,0 +1,202 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* @flow */
+
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import BpkTextInput from 'react-native-bpk-component-text-input';
+import BpkPicker, { BpkPickerItem } from 'react-native-bpk-component-picker';
+import BpkSelect from 'react-native-bpk-component-select';
+
+import CenterDecorator from '../../storybook/CenterDecorator';
+import BpkCalendar, {
+  SELECTION_TYPES,
+  type BpkCalendarSelectionType,
+} from './index';
+
+/* eslint-disable react/no-multi-comp */
+
+class BpkCalendarExample extends Component<
+  {
+    onChangeSelectedDates?: (Date[]) => mixed,
+    selectionType: BpkCalendarSelectionType,
+  },
+  {
+    selectedDates: Date[],
+  },
+> {
+  constructor(props) {
+    super(props);
+    this.state = { selectedDates: [] };
+  }
+
+  render() {
+    return (
+      <BpkCalendar
+        locale="en_GB"
+        selectionType={this.props.selectionType}
+        onChangeSelectedDates={newDates => {
+          if (this.props.onChangeSelectedDates) {
+            this.props.onChangeSelectedDates(newDates);
+          }
+          this.setState({ selectedDates: newDates });
+        }}
+        style={{ flexGrow: 1 }}
+        selectedDates={this.state.selectedDates}
+      />
+    );
+  }
+}
+
+class ExampleWithLinkedInputs extends Component<
+  {
+    range: boolean,
+  },
+  {
+    selectedDates: Date[],
+  },
+> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selectedDates: [],
+    };
+  }
+
+  onChangeText = value => {
+    let { selectedDates } = this.state;
+    if (value === '') {
+      selectedDates = [];
+    }
+    this.setState({ selectedDates });
+  };
+
+  handleNewDates = newDates => {
+    this.setState({
+      selectedDates: newDates,
+    });
+  };
+
+  render() {
+    const { range } = this.props;
+    const { selectedDates } = this.state;
+    return (
+      <View style={{ flex: 1 }}>
+        <BpkTextInput
+          label={range ? 'Start date' : 'Selected date'}
+          value={selectedDates[0] ? selectedDates[0].toLocaleDateString() : ''}
+          onChangeText={this.onChangeText}
+        />
+        {range && (
+          <BpkTextInput
+            editable={!!selectedDates[0]}
+            label="End date"
+            value={
+              selectedDates[1] ? selectedDates[1].toLocaleDateString() : ''
+            }
+            onChangeText={this.onChangeText}
+          />
+        )}
+        <BpkCalendarExample
+          selectionType={range ? SELECTION_TYPES.range : SELECTION_TYPES.single}
+          selectedDates={this.state.selectedDates}
+          onChangeSelectedDates={this.handleNewDates}
+        />
+      </View>
+    );
+  }
+}
+
+class ChangeableSelectionTypeStory extends Component<
+  {},
+  {
+    pickerOpen: boolean,
+    selectionType: BpkCalendarSelectionType,
+  },
+> {
+  constructor() {
+    super();
+    this.state = {
+      pickerOpen: false,
+      selectionType: SELECTION_TYPES.single,
+    };
+  }
+
+  onSelectionTypeChange = (selectionType: string | number) => {
+    const maybe = Object.keys(SELECTION_TYPES).find(x => x === selectionType);
+
+    if (maybe) {
+      this.setState({
+        selectionType: maybe,
+      });
+    }
+  };
+
+  togglePicker = () => {
+    this.setState(prevState => ({ pickerOpen: !prevState.pickerOpen }));
+  };
+
+  render() {
+    return (
+      <View style={{ flowDirection: 'column', flex: 1 }}>
+        <BpkSelect
+          onPress={this.togglePicker}
+          label={this.state.selectionType}
+        />
+        <BpkCalendarExample selectionType={this.state.selectionType} />
+        <BpkPicker
+          doneLabel="Done"
+          isOpen={this.state.pickerOpen}
+          onClose={this.togglePicker}
+          onValueChange={this.onSelectionTypeChange}
+          selectedValue={this.state.selectionType}
+        >
+          {Object.keys(SELECTION_TYPES).map(selectionType => (
+            <BpkPickerItem
+              key={selectionType}
+              label={selectionType}
+              value={selectionType}
+            />
+          ))}
+        </BpkPicker>
+      </View>
+    );
+  }
+}
+
+storiesOf('react-native-bpk-component-calendar', module)
+  .addDecorator(CenterDecorator)
+  .add('docs:single', () => (
+    <BpkCalendarExample selectionType={SELECTION_TYPES.single} />
+  ))
+  .add('docs:multiple', () => (
+    <BpkCalendarExample selectionType={SELECTION_TYPES.multiple} />
+  ))
+  .add('docs:range', () => (
+    <BpkCalendarExample selectionType={SELECTION_TYPES.range} />
+  ))
+  .add('Changeable selection type', () => <ChangeableSelectionTypeStory />)
+  .add('Hooked up to input field (single)', () => (
+    <ExampleWithLinkedInputs range={false} />
+  ))
+  .add('Hooked up to input field (range)', () => (
+    <ExampleWithLinkedInputs range />
+  ));

--- a/packages/react-native-bpk-component-map/package-lock.json
+++ b/packages/react-native-bpk-component-map/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-native-bpk-component-map",
-	"version": "1.0.22",
+	"version": "1.0.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/storybook/storybook.js
+++ b/storybook/storybook.js
@@ -57,6 +57,7 @@ configure(() => {
   require('../packages/react-native-bpk-component-banner-alert/stories');
   require('../packages/react-native-bpk-component-button-link/stories');
   require('../packages/react-native-bpk-component-button/stories');
+  require('../packages/react-native-bpk-component-calendar/stories');
   require('../packages/react-native-bpk-component-card/stories');
   require('../packages/react-native-bpk-component-carousel-indicator/stories');
   require('../packages/react-native-bpk-component-carousel/stories');


### PR DESCRIPTION
# Roadmap

## [Test repo](https://github.com/georgegillams/test-bridged-rn-component)

## iOS
 - [x] Create a boilerplate component for each platform
 - [x] Create iOS source files/project for bridging
 - [x] ~Add BPKCalendar cocoa dependency to iOS source files/project~
 - [x] Define setup / build processes etc for `react-native-bpk-component-calendar` given it's use of iOS subproject
 - [x] Implement react native iOS bridge component

## Android
 - [ ] Create Android source files/project for bridging
 - [ ] Implement react native Android bridge component
 - [ ] Try to combine RN iOS and Android bridge components (should have the same API)

# Current questions
 - [x] How should our `.gitignore` file look by the end of this?
 - [x] ~How do we ensure that the latest version of BPKCalendar is being referenced by the iOS bridging project?~
 - [x] Can we combine the RN iOS and Android bridge components (should have the same API)?

# Todo (added by Shaun)

- [x] Add lots more tests
- [x] Custom prop type for `selectedDates`
- [x] enum for selection type
- [x] Readme
- [x] Add Flow types
- [x] Common types file to share with Android
- [x] Add lots more stories including ones for screenshots
- [x] Replace hard-coded 300 and 500 from iOS side
- [x] Make locale required on user side
- [x] Determine if we should be setting defaults for minDate and maxDate or requiring them from the user and change if necessary
- [x] Protect against mindate that's greater than maxdate (app crashes if we try and do that)
- [ ] Document possible locales
- [x] Fix version number
- [x] Add missing dev deps
- [x] Rename props to fit with conventions
- [x] Fix issue where setting `selectedDates` has no effect on the calendar (it doesn't highlight them). You can see this by setting `selectedDates` to an initial value and seeing that the day doesn't get highlighed.
- [x] When we switch selectionType the calendar looks weird until you click about. Maybe we need to force a re-render.
- [x] Export the selectionType enum over the bridge so it isn't duplicated on the iOS and JS side.
- [x] Rename Obj-c files - `RCT` prefix is for internal React code and we shouldn't use it.