### PR TITLE
[BPK-2126] Use UTC for calendar RN interface

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,7 +1,12 @@
 # Unreleased
 
+**Breaking:**
+
+- react-native-bpk-component-calendar:
+  - Changed all input and output dates to use `UTC`.
+
 **Added:**
 
 - react-native-bpk-component-calendar:
   - added brdige for the android calendar.
- 
+

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -24,11 +24,15 @@ target 'Backpack Native' do
   pod 'Folly', podspec: '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   # RN Bridging Pods
-  pod 'Backpack', '~> 6.0.0'
+  pod 'Backpack', '~> 6.1.1'
   pod 'react-native-bpk-component-calendar', path: '../packages/react-native-bpk-component-calendar'
 
   # Third party pods
   pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'
   pod 'react-native-maps', path: '../packages/react-native-bpk-component-map/node_modules/react-native-maps'
+
+  target 'Backpack Native Tests' do
+    inherit! :search_paths
+  end
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Backpack (6.0.0):
+  - Backpack (6.1.1):
     - FSCalendar (~> 2.8)
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.4.0):
@@ -13,8 +13,8 @@ PODS:
   - glog (0.3.5)
   - React (0.57.7):
     - React/Core (= 0.57.7)
-  - react-native-bpk-component-calendar (0.0.1):
-    - Backpack (~> 6.0.0)
+  - react-native-bpk-component-calendar (0.0.2):
+    - Backpack (~> 6.1.0)
     - React
   - react-native-maps (0.23.0):
     - React
@@ -56,7 +56,7 @@ PODS:
   - yoga (0.57.7.React)
 
 DEPENDENCIES:
-  - Backpack (~> 6.0.0)
+  - Backpack (~> 6.1.1)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
@@ -98,7 +98,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Backpack: a9a3c704beed3e180c19ee1d1c26eeae2713f49f
+  Backpack: b14839fcce112efda3435aea9758f9de77672af6
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: 6d8909e3fc6b089defa4b89d967441fa6827a2ee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
@@ -106,10 +106,10 @@ SPEC CHECKSUMS:
   FSCalendar: 3a5ed3636e2ba1b83ebebfcf0c2603105a6f5efe
   glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  react-native-bpk-component-calendar: 97dc3fe80e416867b37a7109c379a3defb564af6
+  react-native-bpk-component-calendar: a41a5628f3525333dbe6a263601c74a666745e59
   react-native-maps: 066c2afcc89e18726377bcc685315f989ca22449
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: 38726a947f3ee65935c1fb42800e2e5243fb0d0d
+PODFILE CHECKSUM: 6117e2a18dadc7ce4d56da15b1f688dc55f78eda
 
 COCOAPODS: 1.5.3

--- a/ios/native.xcodeproj/project.pbxproj
+++ b/ios/native.xcodeproj/project.pbxproj
@@ -19,8 +19,10 @@
 		93A11238766E920180390589 /* libPods-Backpack Native.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ABDC175C9DB0F0B9CBD71B51 /* libPods-Backpack Native.a */; };
 		C8B831744C5A4256BD1B5010 /* BpkIcon.eot in Resources */ = {isa = PBXBuildFile; fileRef = 8C8F437769B54A038A210159 /* BpkIcon.eot */; };
 		CD97D274772C442994C3117B /* BpkIconIOS.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */; };
+		D61144CB2200516700F76EAE /* RCTBPKCalendarDateUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D61144CA2200516700F76EAE /* RCTBPKCalendarDateUtilsTests.m */; };
 		D66FC4882109D8610063B1A6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D66FC4872109D8610063B1A6 /* Main.storyboard */; };
 		D66FC4912109DA3C0063B1A6 /* StorybookViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D66FC4902109DA3C0063B1A6 /* StorybookViewController.m */; };
+		E120F32FF8B3695B5E878AC8 /* libPods-Backpack Native Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 967DA828F1B29C9BC73AEB4E /* libPods-Backpack Native Tests.a */; };
 		E19140ED6394488C9626FE7A /* BpkIcon.woff in Resources */ = {isa = PBXBuildFile; fileRef = E436C94A65D1410092B05450 /* BpkIcon.woff */; };
 /* End PBXBuildFile section */
 
@@ -57,11 +59,15 @@
 		349CF328083441A0845E0C8D /* BpkIcon.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.ttf; path = "../node_modules/bpk-svgs/dist/font/BpkIcon.ttf"; sourceTree = "<group>"; };
 		3CA50A36B56148BD95AF98C2 /* iconMapping.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = iconMapping.json; path = "../node_modules/bpk-svgs/dist/font/iconMapping.json"; sourceTree = "<group>"; };
 		6B59545B47D6FA3C28AB6F8B /* Pods-Backpack Native.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack Native.release.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack Native/Pods-Backpack Native.release.xcconfig"; sourceTree = "<group>"; };
-		83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIconIOS.ttf; path = "../node_modules/bpk-svgs/dist/font/BpkIconIOS.ttf"; sourceTree = "<group>"; };
+		83C39DAE966144799B2F2FB7 /* BpkIconIOS.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIconIOS.ttf; path = "../node_modules/bpk-svgs/dist/font/BpkIconIOS.ttf"; sourceTree = "<group>"; };
 		8C8F437769B54A038A210159 /* BpkIcon.eot */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = BpkIcon.eot; path = "../node_modules/bpk-svgs/dist/font/BpkIcon.eot"; sourceTree = "<group>"; };
+		967DA828F1B29C9BC73AEB4E /* libPods-Backpack Native Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Backpack Native Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDC175C9DB0F0B9CBD71B51 /* libPods-Backpack Native.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Backpack Native.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3896E08C3804FF089E1E50B /* libRCTRestart.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTRestart.a; sourceTree = "<group>"; };
+		C63703994133B719A6838A67 /* Pods-Backpack Native Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack Native Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack Native Tests/Pods-Backpack Native Tests.release.xcconfig"; sourceTree = "<group>"; };
+		C97A3DDE34691C31B4D830BA /* Pods-Backpack Native Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Backpack Native Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Backpack Native Tests/Pods-Backpack Native Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		D60ACAA41FD8532E009E5946 /* he-IL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "he-IL"; path = "he-IL.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
+		D61144CA2200516700F76EAE /* RCTBPKCalendarDateUtilsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTBPKCalendarDateUtilsTests.m; sourceTree = "<group>"; };
 		D66FC4872109D8610063B1A6 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		D66FC48F2109DA3C0063B1A6 /* StorybookViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorybookViewController.h; sourceTree = "<group>"; };
 		D66FC4902109DA3C0063B1A6 /* StorybookViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = StorybookViewController.m; sourceTree = "<group>"; tabWidth = 4; };
@@ -74,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E120F32FF8B3695B5E878AC8 /* libPods-Backpack Native Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				00E356F01AD99517003FC87E /* Supporting Files */,
+				D61144CA2200516700F76EAE /* RCTBPKCalendarDateUtilsTests.m */,
 			);
 			path = nativeTests;
 			sourceTree = "<group>";
@@ -173,6 +181,8 @@
 			children = (
 				FBB4289347D8862ADA374625 /* Pods-Backpack Native.debug.xcconfig */,
 				6B59545B47D6FA3C28AB6F8B /* Pods-Backpack Native.release.xcconfig */,
+				C97A3DDE34691C31B4D830BA /* Pods-Backpack Native Tests.debug.xcconfig */,
+				C63703994133B719A6838A67 /* Pods-Backpack Native Tests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -203,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				ABDC175C9DB0F0B9CBD71B51 /* libPods-Backpack Native.a */,
+				967DA828F1B29C9BC73AEB4E /* libPods-Backpack Native Tests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -214,6 +225,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "Backpack Native Tests" */;
 			buildPhases = (
+				B20BA0FEC10E3BCE40A8EEA6 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
@@ -434,6 +446,24 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Backpack Native/Pods-Backpack Native-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		B20BA0FEC10E3BCE40A8EEA6 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Backpack Native Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -441,6 +471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D61144CB2200516700F76EAE /* RCTBPKCalendarDateUtilsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -501,6 +532,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C97A3DDE34691C31B4D830BA /* Pods-Backpack Native Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -525,6 +557,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C63703994133B719A6838A67 /* Pods-Backpack Native Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;

--- a/ios/nativeTests/RCTBPKCalendarDateUtilsTests.m
+++ b/ios/nativeTests/RCTBPKCalendarDateUtilsTests.m
@@ -1,0 +1,72 @@
+//
+//  RCTBPKCalendarDateUtilsTests.m
+//  Backpack Native Tests
+//
+//  Created by Hugo Tunius on 29/01/2019.
+//  Copyright © 2019 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <react-native-bpk-component-calendar/RCTBPKCalendarDateUtils.h>
+
+@interface RCTBPKCalendarDateUtilsTests : XCTestCase
+@property(nonatomic, strong) NSCalendar *localCalendar;
+@property(nonatomic, strong) NSCalendar *utcCalendar;
+
+@property(nonatomic, readonly) NSDate *midnight20190124UTC;
+@property(nonatomic, readonly) NSDate *midnight20190124BST;
+@end
+
+@implementation RCTBPKCalendarDateUtilsTests
+
+- (NSDate *)midnight20190124UTC {
+  return [NSDate dateWithTimeIntervalSince1970:1548288000];
+}
+
+- (NSDate *)midnight20190124BST {
+  return [NSDate dateWithTimeIntervalSince1970:1548298800];
+}
+
+- (void)setUp {
+  self.localCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+  // Brasilia Standard Time
+  self.localCalendar.timeZone = [[NSTimeZone alloc] initWithName:@"America/Fortaleza"];
+
+  self.utcCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+  self.utcCalendar.timeZone = [[NSTimeZone alloc] initWithName:@"UTC"];
+}
+
+- (void)testUTCtoLocal {
+  NSDate *result = [RCTBPKCalendarDateUtils convertDateToLocal:self.midnight20190124UTC
+                                                 localCalendar:self.localCalendar
+                                                   utcCalendar:self.utcCalendar];
+
+  XCTAssertEqualObjects(result, self.midnight20190124BST);
+}
+
+- (void)testLocalToUTC {
+  NSDate *result = [RCTBPKCalendarDateUtils convertDateToUTC:self.midnight20190124BST
+                                                 localCalendar:self.localCalendar
+                                                   utcCalendar:self.utcCalendar];
+
+  XCTAssertEqualObjects(result, self.midnight20190124UTC);
+}
+
+- (void)testInverseLocal {
+  NSDate *originalDate = [self.localCalendar dateWithEra:1 year:2017 month:05 day:25 hour:0 minute:0 second:0 nanosecond:0];
+
+  NSDate *utcDate = [RCTBPKCalendarDateUtils convertDateToUTC:originalDate
+                                                localCalendar:self.localCalendar
+                                                  utcCalendar:self.utcCalendar];
+
+  NSDate *result = [RCTBPKCalendarDateUtils convertDateToLocal:utcDate
+                                                 localCalendar:self.localCalendar
+                                                   utcCalendar:self.utcCalendar];
+
+
+  XCTAssertEqualObjects(originalDate, result);
+  XCTAssertNotEqualObjects(originalDate, utcDate);
+}
+
+@end

--- a/packages/react-native-bpk-component-calendar/README.md
+++ b/packages/react-native-bpk-component-calendar/README.md
@@ -22,8 +22,28 @@ For example:
 ```
   pod 'react-native-bpk-component-calendar', path: '../node_modules/react-native-bpk-component-calendar'
 ```
+## Time Zones
+
+`BpkCalendar` uses dates at the `UTC` midnight boundary exclusively for selected dates and expects that format for `minDate` and `maxDate`. If `BpkCalendar` is used with dates that are **not** `UTC` it will behave in undefined ways and most likely not work.
+
+To create dates to be used with the component we recommend the following
+
+```javascript
+// Min date of the calendar at 2019-01-02
+const minDate = new Date(Date.UTC(2019, 0, 2));
+```
+
+To format the dates for display use
+
+```javascript
+const locale = 'en-GB';
+const formatter = new Intl.DateTimeFormat(locale, { timeZone: 'UTC' });
+
+const formattedDate = formatter.format(date);
+```
 
 ## Usage
+
 
 ```js
 import React, { Component } from 'react';

--- a/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
+++ b/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "src/ios/CalendarBridge/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Backpack', '~> 6.0.0'
+  s.dependency 'Backpack', '~> 6.1.0'
 end

--- a/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.common.js
+++ b/packages/react-native-bpk-component-calendar/src/BpkCalendar-test.common.js
@@ -48,7 +48,7 @@ const commonTests = () => {
           <BpkCalendar
             selectionType={SELECTION_TYPES.single}
             {...defaultProps}
-            minDate={new Date(2019, 4, 19)}
+            minDate={new Date(Date.UTC(2019, 4, 19))}
           />,
         )
         .toJSON();
@@ -61,7 +61,7 @@ const commonTests = () => {
           <BpkCalendar
             selectionType={SELECTION_TYPES.single}
             {...defaultProps}
-            maxDate={new Date(2020, 4, 19)}
+            maxDate={new Date(Date.UTC(2020, 4, 19))}
           />,
         )
         .toJSON();
@@ -74,8 +74,8 @@ const commonTests = () => {
           <BpkCalendar
             selectionType={SELECTION_TYPES.single}
             {...defaultProps}
-            minDate={new Date(2019, 4, 19)}
-            maxDate={new Date(2020, 4, 19)}
+            minDate={new Date(Date.UTC(2019, 4, 19))}
+            maxDate={new Date(Date.UTC(2020, 4, 19))}
           />,
         )
         .toJSON();
@@ -87,7 +87,7 @@ const commonTests = () => {
         .create(
           <BpkCalendar
             selectionType={SELECTION_TYPES.single}
-            selectedDates={[new Date(2019, 4, 19)]}
+            selectedDates={[new Date(Date.UTC(2019, 4, 19))]}
             {...defaultProps}
           />,
         )
@@ -100,7 +100,10 @@ const commonTests = () => {
         .create(
           <BpkCalendar
             selectionType={SELECTION_TYPES.single}
-            selectedDates={[new Date(2019, 4, 19), new Date(2019, 4, 21)]}
+            selectedDates={[
+              new Date(Date.UTC(2019, 4, 19)),
+              new Date(Date.UTC(2019, 4, 21)),
+            ]}
             {...defaultProps}
           />,
         )
@@ -157,9 +160,9 @@ const commonTests = () => {
           <BpkCalendar
             selectionType={SELECTION_TYPES.multiple}
             selectedDates={[
-              new Date(2019, 4, 19),
-              new Date(2019, 4, 21),
-              new Date(2019, 4, 29),
+              new Date(Date.UTC(2019, 4, 19)),
+              new Date(Date.UTC(2019, 4, 21)),
+              new Date(Date.UTC(2019, 4, 29)),
             ]}
             {...defaultProps}
           />,

--- a/packages/react-native-bpk-component-calendar/src/NativeCalendar.android.js
+++ b/packages/react-native-bpk-component-calendar/src/NativeCalendar.android.js
@@ -54,7 +54,7 @@ const parseDateToNative = date => {
   if (date) {
     // Return as unix timestamp because the only number data type that allows null
     // in the native side is Integer, and the original milliseconds will overflow it.
-    return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 1000;
+    return date.getTime() / 1000;
   }
   return date;
 };

--- a/packages/react-native-bpk-component-calendar/src/NativeCalendar.ios.js
+++ b/packages/react-native-bpk-component-calendar/src/NativeCalendar.ios.js
@@ -57,7 +57,7 @@ const BpkCalendar = (props: Props) => {
       onDateSelection={event => {
         if (event.nativeEvent.selectedDates) {
           const convertedDates = event.nativeEvent.selectedDates.map(
-            dateStr => new Date(dateStr),
+            timestamp => new Date(timestamp * 1000),
           );
           if (onChangeSelectedDates) {
             onChangeSelectedDates(convertedDates);

--- a/packages/react-native-bpk-component-calendar/src/__snapshots__/BpkCalendar-test.ios.js.snap
+++ b/packages/react-native-bpk-component-calendar/src/__snapshots__/BpkCalendar-test.ios.js.snap
@@ -64,8 +64,8 @@ exports[`iOS BpkCalendar should render correctly with arbitrary props 1`] = `
 exports[`iOS BpkCalendar should render correctly with both minDate and maxDate 1`] = `
 <RCTBPKCalendar
   locale="en_GB"
-  maxDate={2020-05-18T23:00:00.000Z}
-  minDate={2019-05-18T23:00:00.000Z}
+  maxDate={2020-05-19T00:00:00.000Z}
+  minDate={2019-05-19T00:00:00.000Z}
   onDateSelection={[Function]}
   selectedDates={Array []}
   selectionType="single"
@@ -92,7 +92,7 @@ exports[`iOS BpkCalendar should render correctly with custom style 1`] = `
 exports[`iOS BpkCalendar should render correctly with maxDate 1`] = `
 <RCTBPKCalendar
   locale="en_GB"
-  maxDate={2020-05-18T23:00:00.000Z}
+  maxDate={2020-05-19T00:00:00.000Z}
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
@@ -105,7 +105,7 @@ exports[`iOS BpkCalendar should render correctly with minDate 1`] = `
 <RCTBPKCalendar
   locale="en_GB"
   maxDate={null}
-  minDate={2019-05-18T23:00:00.000Z}
+  minDate={2019-05-19T00:00:00.000Z}
   onDateSelection={[Function]}
   selectedDates={Array []}
   selectionType="single"
@@ -121,9 +121,9 @@ exports[`iOS BpkCalendar should render correctly with selection type "multiple" 
   onDateSelection={[Function]}
   selectedDates={
     Array [
-      2019-05-18T23:00:00.000Z,
-      2019-05-20T23:00:00.000Z,
-      2019-05-28T23:00:00.000Z,
+      2019-05-19T00:00:00.000Z,
+      2019-05-21T00:00:00.000Z,
+      2019-05-29T00:00:00.000Z,
     ]
   }
   selectionType="multiple"
@@ -139,8 +139,8 @@ exports[`iOS BpkCalendar should render correctly with selection type "range" and
   onDateSelection={[Function]}
   selectedDates={
     Array [
-      2019-05-18T23:00:00.000Z,
-      2019-05-20T23:00:00.000Z,
+      2019-05-19T00:00:00.000Z,
+      2019-05-21T00:00:00.000Z,
     ]
   }
   selectionType="single"
@@ -156,7 +156,7 @@ exports[`iOS BpkCalendar should render correctly with selection type "single" an
   onDateSelection={[Function]}
   selectedDates={
     Array [
-      2019-05-18T23:00:00.000Z,
+      2019-05-19T00:00:00.000Z,
     ]
   }
   selectionType="single"

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.h
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.h
@@ -22,5 +22,5 @@
 @interface RCTBPKCalendar : BPKCalendar
 
 @property (nonatomic, copy) RCTBubblingEventBlock onDateSelection;
-
+@property(nonatomic, strong, readonly) NSCalendar *utcCalendar;
 @end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.m
@@ -18,6 +18,79 @@
 
 #import "RCTBPKCalendar.h"
 
+#import "RCTBPKCalendarDateUtils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+@interface RCTBPKCalendar()
+@property(nonatomic, strong) NSCalendar *utcCalendar;
+
+- (void)setupCalendar;
+@end
+
 @implementation RCTBPKCalendar
 
+- (instancetype)init {
+    self = [super init];
+
+    if (self) {
+        [self setupCalendar];
+    }
+
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+
+    if (self) {
+        [self setupCalendar];
+    }
+
+    return self;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+
+    if (self) {
+        [self setupCalendar];
+    }
+
+    return self;
+}
+
+- (void)setupCalendar {
+    self.utcCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    self.utcCalendar.timeZone = [[NSTimeZone alloc] initWithName:@"UTC"];
+}
+
+- (void)setMinDate:(NSDate *)minDate {
+    NSDate *localDate = [RCTBPKCalendarDateUtils convertDateToLocal:minDate
+                                                      localCalendar:self.gregorian
+                                                        utcCalendar:self.utcCalendar];
+    [super setMinDate:localDate];
+}
+
+- (void)setMaxDate:(NSDate *)maxDate {
+    NSDate *localDate = [RCTBPKCalendarDateUtils convertDateToLocal:maxDate
+                                                      localCalendar:self.gregorian
+                                                        utcCalendar:self.utcCalendar];
+    [super setMaxDate:localDate];
+}
+
+- (void)setSelectedDates:(NSArray<NSDate *> *)selectedDates {
+    NSMutableArray *localDates = [[NSMutableArray alloc] initWithCapacity:selectedDates.count];
+
+    for (NSDate *utcDate in selectedDates) {
+        NSDate *localDate = [RCTBPKCalendarDateUtils convertDateToLocal:utcDate
+                                                          localCalendar:self.gregorian
+                                                            utcCalendar:self.utcCalendar];
+        [localDates addObject:localDate];
+    }
+
+
+    [super setSelectedDates:localDates];
+}
+
 @end
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarDateUtils.h
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarDateUtils.h
@@ -1,0 +1,67 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTBPKCalendarDateUtils : NSObject
+
+/**
+ * Convert a date in the local time zone to UTC by discarding time zone information.
+ * For example converts the date `1548298800` or `2019-01-24T00:00:00-03:00` to `1548288000` or `2019-01-24T00:00:00Z`
+ * when the local time zone is Brasilia Standard Time.
+ * **Note:** This changes the underlying date, it's not just a time zone conversion.
+ *
+ * This is the inverse of + (NSDate *)convertDateToLocal:(NSDate *)utcDate
+ *                                         localCalendar:(NSCalendar *)localCalendar
+ *                                           utcCalendar:(NSCalendar *)utcCalendar;
+ *
+ * @param localDate The date in the local timezone.
+ * @param localCalendar The gregorian calendar the local date was created in.
+ * @param utcCalendar The gregorian UTC calendar to use.
+ * @return The same date in UTC with the timezone data discarded.
+ */
++ (NSDate *)convertDateToUTC:(NSDate *)localDate
+               localCalendar:(NSCalendar *)localCalendar
+                 utcCalendar:(NSCalendar *)utcCalendar;
+
+/**
+ * Convert a date in UTC to the local time zone by discarding time zone information.
+ * For example converts the date `1548288000` or `2019-01-24T00:00:00Z` to `1548298800` or `2019-01-24T00:00:00-03:00`
+ * when the local time zone is Brasilia Standard Time.
+ * **Note:** This changes the underlying date, it's not just a time zone conversion.
+ *
+ * This is the inverse of + (NSDate *)convertDateToUTC:(NSDate *)localDate
+ *                                       localCalendar:(NSCalendar *)localCalendar
+ *                                         utcCalendar:(NSCalendar *)utcCalendar;
+ *
+ * @param utcDate The date in UTC.
+ * @param localCalendar The gregorian calendar the local date was created in.
+ * @param utcCalendar The gregorian UTC calendar to use.
+
+ * @return The same date in the local time zone with the timezone data discarded.
+ */
++ (NSDate *)convertDateToLocal:(NSDate *)utcDate
+                 localCalendar:(NSCalendar *)localCalendar
+                   utcCalendar:(NSCalendar *)utcCalendar;
+
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarDateUtils.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarDateUtils.m
@@ -1,0 +1,42 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "RCTBPKCalendarDateUtils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+@implementation RCTBPKCalendarDateUtils
+
+
++ (NSDate *)convertDateToUTC:(NSDate *)localDate
+               localCalendar:(NSCalendar *)localCalendar
+                 utcCalendar:(NSCalendar *)utcCalendar {
+    NSDateComponents *dateComponents = [localCalendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:localDate];
+
+    return [utcCalendar dateFromComponents:dateComponents];
+}
+
++ (NSDate *)convertDateToLocal:(NSDate *)utcDate
+                 localCalendar:(NSCalendar *)localCalendar
+                   utcCalendar:(NSCalendar *)utcCalendar {
+    NSDateComponents *utcComponents = [utcCalendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:utcDate];
+
+    return [localCalendar dateFromComponents:utcComponents];
+}
+
+@end
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.m
@@ -19,6 +19,7 @@
 #import "RCTBPKCalendarManager.h"
 #import "RCTConvert+RCTBPKCalendar.h"
 #import "RCTBPKCalendar.h"
+#import "RCTBPKCalendarDateUtils.h"
 
 @interface RCTBPKCalendarManager() <BPKCalendarDelegate>
 
@@ -55,15 +56,17 @@ RCT_EXPORT_VIEW_PROPERTY(onDateSelection, RCTBubblingEventBlock)
         return;
     }
 
-    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-    [dateFormat setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'"];
-
-    NSMutableArray * stringArray = [[NSMutableArray alloc]init];
+    NSMutableArray<NSNumber *> * dateArray = [[NSMutableArray alloc] initWithCapacity:dateList.count];
     for (NSDate *date in dateList) {
-        [stringArray addObject:[dateFormat stringFromDate:date]];
+        // The React Native interface uses UTC dates regardless of the local time zone
+        // Thus we need to convert the dates to UTC instead of the local time zone here.
+        NSDate *dateInUTC = [RCTBPKCalendarDateUtils convertDateToUTC:date
+                                                        localCalendar:calendar.gregorian
+                                                          utcCalendar:calendar.utcCalendar];
+        [dateArray addObject:@([dateInUTC timeIntervalSince1970])];
     }
 
-    calendar.onDateSelection(@{@"selectedDates": stringArray});
+    calendar.onDateSelection(@{@"selectedDates": dateArray});
 }
 
 @end

--- a/packages/react-native-bpk-component-calendar/stories.js
+++ b/packages/react-native-bpk-component-calendar/stories.js
@@ -55,6 +55,12 @@ const locales = {
   pt_BR: 'pt-br',
 };
 
+const formatDateForDisplay = (date: Date, locale: string) => {
+  const formatter = new Intl.DateTimeFormat(locale, { timeZone: 'UTC' });
+
+  return formatter.format(date);
+};
+
 /* eslint-disable react/no-multi-comp */
 
 class BpkCalendarExample extends Component<
@@ -127,7 +133,11 @@ class ExampleWithLinkedInputs extends Component<
       <View style={styles.base}>
         <BpkTextInput
           label={range ? 'Start date' : 'Selected date'}
-          value={selectedDates[0] ? selectedDates[0].toLocaleDateString() : ''}
+          value={
+            selectedDates[0]
+              ? formatDateForDisplay(selectedDates[0], locales.en_GB)
+              : ''
+          }
           onChangeText={this.onChangeText}
         />
         {range && (
@@ -135,7 +145,9 @@ class ExampleWithLinkedInputs extends Component<
             editable={!!selectedDates[0]}
             label="End date"
             value={
-              selectedDates[1] ? selectedDates[1].toLocaleDateString() : ''
+              selectedDates[1]
+                ? formatDateForDisplay(selectedDates[1], locales.en_GB)
+                : ''
             }
             onChangeText={this.onChangeText}
           />
@@ -242,17 +254,20 @@ storiesOf('react-native-bpk-component-calendar', module)
     <BpkCalendarExample
       style={styles.calendarOnly}
       selectionType={SELECTION_TYPES.single}
-      minDate={new Date(2019, 0, 2)}
-      maxDate={new Date(2020, 11, 31)}
+      minDate={new Date(Date.UTC(2019, 0, 2))}
+      maxDate={new Date(Date.UTC(2020, 11, 31))}
     />
   ))
   .add('With selected dates', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
       selectionType={SELECTION_TYPES.range}
-      minDate={new Date(2019, 0, 2)}
-      maxDate={new Date(2020, 11, 31)}
-      selectedDates={[new Date(2019, 0, 3), new Date(2019, 0, 7)]}
+      minDate={new Date(Date.UTC(2019, 0, 2))}
+      maxDate={new Date(Date.UTC(2020, 11, 31))}
+      selectedDates={[
+        new Date(Date.UTC(2019, 0, 3)),
+        new Date(Date.UTC(2019, 0, 7)),
+      ]}
     />
   ))
   .add('With different locale', () => (


### PR DESCRIPTION
Change the calendar to use UTC for the selected dates to align with
Android. Depends on merging https://github.com/Skyscanner/backpack-ios/pull/165 and then releasing `backpack-ios`.

The tests I added will not currently run on CI because we don't have CI set up to run on the macOS infrastructure of Travis. This needs to be changed, but I suggest we do another PR for it