### PR TITLE
Integrate RCTBPKCalendar with SimpleDate

### DIFF
--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendar.m
@@ -68,28 +68,31 @@ NS_ASSUME_NONNULL_BEGIN
     NSDate *localDate = [RCTBPKCalendarDateUtils convertDateToLocal:minDate
                                                       localCalendar:self.gregorian
                                                         utcCalendar:self.utcCalendar];
-    [super setMinDate:localDate];
+    BPKSimpleDate *simpleDate = [super simpleDateFromDate:localDate];
+    [super setMinDate:simpleDate];
 }
 
 - (void)setMaxDate:(NSDate *)maxDate {
     NSDate *localDate = [RCTBPKCalendarDateUtils convertDateToLocal:maxDate
                                                       localCalendar:self.gregorian
                                                         utcCalendar:self.utcCalendar];
-    [super setMaxDate:localDate];
+    BPKSimpleDate *simpleDate = [super simpleDateFromDate:localDate];
+    [super setMaxDate:simpleDate];
 }
 
 - (void)setSelectedDates:(NSArray<NSDate *> *)selectedDates {
-    NSMutableArray *localDates = [[NSMutableArray alloc] initWithCapacity:selectedDates.count];
+    NSMutableArray *simpleDates = [[NSMutableArray alloc] initWithCapacity:selectedDates.count];
 
     for (NSDate *utcDate in selectedDates) {
         NSDate *localDate = [RCTBPKCalendarDateUtils convertDateToLocal:utcDate
                                                           localCalendar:self.gregorian
                                                             utcCalendar:self.utcCalendar];
-        [localDates addObject:localDate];
+        BPKSimpleDate *simpleDate = [super simpleDateFromDate:localDate];
+        [simpleDates addObject:simpleDate];
     }
 
 
-    [super setSelectedDates:localDates];
+    [super setSelectedDates:simpleDates];
 }
 
 @end

--- a/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.m
+++ b/packages/react-native-bpk-component-calendar/src/ios/CalendarBridge/RCTBPKCalendarManager.m
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(forceRender:(nonnull NSNumber *)reactTag) {
 
          if ([view isKindOfClass:[BPKCalendar class]]) {
              BPKCalendar *calendar = (BPKCalendar *)view;
-             NSArray<NSDate* > *selectedDates = calendar.selectedDates;
+             NSArray<BPKSimpleDate* > *selectedDates = calendar.selectedDates;
 
              calendar.selectedDates = @[];
              [calendar reloadData];
@@ -90,16 +90,17 @@ RCT_EXPORT_METHOD(forceRender:(nonnull NSNumber *)reactTag) {
  * `RCTBPKCalendarManager` acts as the delegate of all of the `RCTBPKCalendar` views. This is just one
  * pattern and it's perfectly fine to call `onDateSelection` from the `RCTBPKCalendar` directly.
  */
-- (void)calendar:(RCTBPKCalendar *)calendar didChangeDateSelection:(NSArray<NSDate *> *)dateList {
+- (void)calendar:(RCTBPKCalendar *)calendar didChangeDateSelection:(NSArray<BPKSimpleDate *> *)dateList {
     if (!calendar.onDateSelection) {
         return;
     }
 
     NSMutableArray<NSNumber *> * dateArray = [[NSMutableArray alloc] initWithCapacity:dateList.count];
-    for (NSDate *date in dateList) {
+    for (BPKSimpleDate *date in dateList) {
         // The React Native interface uses UTC dates regardless of the local time zone
         // Thus we need to convert the dates to UTC instead of the local time zone here.
-        NSDate *dateInUTC = [RCTBPKCalendarDateUtils convertDateToUTC:date
+        NSDate* localDate = [calendar dateFromSimpleDate:date];
+        NSDate *dateInUTC = [RCTBPKCalendarDateUtils convertDateToUTC:localDate
                                                         localCalendar:calendar.gregorian
                                                           utcCalendar:calendar.utcCalendar];
         [dateArray addObject:@([dateInUTC timeIntervalSince1970])];


### PR DESCRIPTION
The update integrates RCTBPKCalendar with the new interface of BPKCalendar, which is using SimpleDates.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
