### PR TITLE
[No JIRA] Update Storybook theme to be easier to see

### DIFF
--- a/storybook/themeAttributes.js
+++ b/storybook/themeAttributes.js
@@ -18,16 +18,27 @@
 
 import { Platform } from 'react-native';
 
+const londonTheme = {
+  primaryColor300: '#F28494',
+  primaryColor500: '#ED1B28',
+  primaryColor600: '#D11622',
+  primaryColor700: '#B1121C',
+  secondaryColor300: '#6889AB',
+  secondaryColor500: '#013A76',
+  secondaryColor600: '#002F61',
+  secondaryColor700: '#00254B',
+};
+
 const theme = {
-  contentColor: '#2d244c',
-  contentGray: '#757380',
-  secondaryColor: '#e8c410',
+  contentColor: londonTheme.secondaryColor500,
+  contentGray: londonTheme.secondaryColor300,
+  secondaryColor: londonTheme.secondaryColor500,
   // Because it's a theme, Backpack tokens shouldn't be used.
   // eslint-disable-next-line backpack/use-tokens
   backgroundColor: '#fff',
   brandColors: {
-    gradientStart: '#fce134',
-    gradientEnd: '#f8c42d',
+    gradientStart: londonTheme.primaryColor500,
+    gradientEnd: londonTheme.primaryColor600,
   },
 };
 


### PR DESCRIPTION
The primary colour was a subtle navy blue colour before which sometimes made it hard to tell if a theme had been applied at all. With this change, we use the same 'London' theme that we use in the apps, which is easier to see.

Couple of screenshots:

![Simulator Screen Shot - iPhone 8 - 2019-03-19 at 09 15 17](https://user-images.githubusercontent.com/73652/54594147-f8365100-4a27-11e9-9f5d-ce56bf8b0e92.png)
![Simulator Screen Shot - iPhone 8 - 2019-03-19 at 09 15 04](https://user-images.githubusercontent.com/73652/54594148-f8cee780-4a27-11e9-9845-40f118513b34.png)
![Simulator Screen Shot - iPhone 8 - 2019-03-19 at 09 14 37](https://user-images.githubusercontent.com/73652/54594149-f8cee780-4a27-11e9-9966-f1dae96e966d.png)

