### PR TITLE
[BPK-2340] Fix calendar bridge rendering

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ allprojects {
 }
 
 ext {
-    backpackVersion     = "5.0.0"
+    backpackVersion     = "6.1.0"
     compileSdkVersion   = 28
     targetSdkVersion    = 28
     minSdkVersion       = 21

--- a/packages/react-native-bpk-component-calendar/src/android/build.gradle
+++ b/packages/react-native-bpk-component-calendar/src/android/build.gradle
@@ -36,5 +36,5 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
-  implementation "com.github.skyscanner:backpack-android:5.0.0"
+  implementation "com.github.skyscanner:backpack-android:6.1.0"
 }

--- a/packages/react-native-bpk-component-calendar/src/android/src/main/java/net/skyscanner/backpack/reactnative/calendar/CalendarViewManager.kt
+++ b/packages/react-native-bpk-component-calendar/src/android/src/main/java/net/skyscanner/backpack/reactnative/calendar/CalendarViewManager.kt
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
+import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import net.skyscanner.backpack.calendar.model.CalendarDay
 import net.skyscanner.backpack.calendar.model.CalendarRange
@@ -31,11 +32,15 @@ import java.lang.IllegalArgumentException
 import java.text.SimpleDateFormat
 import java.util.*
 
-class CalendarViewManager : SimpleViewManager<RNCalendarView>() {
+class CalendarViewManager : ViewGroupManager<RNCalendarView>() {
 
   companion object {
     const val VIEW_NAME = "AndroidBPKCalendarView"
   }
+
+  // This means we are not relying on RN's css to layout children and doing it ourselves.
+  // see RNCalendarView.requestLayout
+  override fun needsCustomLayoutForChildren() = true
 
   override fun getName() = VIEW_NAME
 


### PR DESCRIPTION
This fixes all bugs we had with rendering the calendar, especially the year pill. An added benefit is that we've been able to remove all rn related code from `backpack-android` and all the custom layout logic lives here now. 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
