### PR TITLE
[NO-JIRA] Fix Calendar pod dependency on Backpack

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,3 +1,8 @@
 # Unreleased
 
+**Fixed:**
+
+ - react-native-bpk-component-calendar: 0.3.3 => 0.3.4
+   - Fixed semver range of Backpack pod dependency to allow `8.0.0 <= version < 9.0.0`.
+
 

--- a/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
+++ b/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "src/ios/CalendarBridge/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Backpack', '~> 8.0.0'
+  s.dependency 'Backpack', '~> 8.0'
 end


### PR DESCRIPTION
The pod semver range we had for Backpack previously allowed `8.0.0 <= version < 8.1.0`

Have fixed this now according to the [Cocoapod semver range docs](http://guides.cocoapods.org/using/the-podfile.html#specifying-pod-versions) to allow  `8.0.0 <= version < 9.0.0`

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)