### PR TITLE
[BPK-2403] Publish native bridges automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ buck-out/
 #Jest
 coverage
 
+# Native bridges script
+.native-release-info.json
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,9 @@ When a component is released for the first time on npm, remember to add the comp
 
 ### Native Android bridges
 
-Android bridges should be compiled and published into the internal Artifactory, to do so after the JS package has been released, run:
+Android bridges should be compiled and published into the internal Artifactory, this process is done automatically as part of the release.
+
+To publish it manually run:
 
 ```
 cd android

--- a/android/gradle-maven-push.gradle
+++ b/android/gradle-maven-push.gradle
@@ -7,6 +7,8 @@ if (localPropsFile.exists()) {
     localProps.load(localPropsFile.newDataInputStream())
 }
 
+def artifactoryURL = "https://artifactory.skyscannertools.net/artifactory/infrastructure-maven"
+
 task sourceJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier "source"
@@ -51,12 +53,24 @@ afterEvaluate { project ->
 
         repositories {
             maven {
-                url "https://artifactory.skyscannertools.net/artifactory/infrastructure-maven"
+                url "$artifactoryURL"
                 credentials {
                     username "${project.getJFrogUsername()}"
                     password "${project.getJFrogPassword()}"
                 }
             }
         }
+    }
+
+    task checkMavenCredentials(type: Exec) {
+        outputs.upToDateWhen { false }
+        workingDir './'
+        commandLine(['curl',
+                     '--silent',
+                     '--fail',
+                     '-I',
+                     '-u',
+                     "${project.getJFrogUsername()}:${project.getJFrogPassword()}",
+                     "$artifactoryURL"])
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,7 +1320,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -3601,6 +3601,17 @@
             "chardet": "^0.7.0",
             "iconv-lite": "^0.4.24",
             "tmp": "^0.0.33"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
           }
         },
         "iconv-lite": {
@@ -3972,13 +3983,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4034,7 +4045,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -4046,7 +4057,7 @@
         },
         "opn": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/opn/-/opn-3.0.3.tgz",
           "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
           "dev": true,
           "requires": {
@@ -4071,7 +4082,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
@@ -4367,6 +4378,17 @@
             "chardet": "^0.7.0",
             "iconv-lite": "^0.4.24",
             "tmp": "^0.0.33"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
           }
         },
         "find-cache-dir": {
@@ -5337,6 +5359,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -6697,7 +6720,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
@@ -7401,7 +7424,7 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         }
@@ -7825,7 +7848,7 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
@@ -8173,7 +8196,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8194,12 +8218,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8214,17 +8240,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8341,7 +8370,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8353,6 +8383,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8367,6 +8398,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -8374,12 +8406,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8398,6 +8432,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8478,7 +8513,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8490,6 +8526,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8575,7 +8612,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8611,6 +8649,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8630,6 +8669,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8673,12 +8713,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10581,6 +10623,17 @@
             "chardet": "^0.7.0",
             "iconv-lite": "^0.4.24",
             "tmp": "^0.0.33"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
           }
         },
         "globals": {
@@ -11332,6 +11385,17 @@
         "chardet": "^0.4.0",
         "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
       }
     },
     "extglob": {
@@ -13060,7 +13124,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -15555,7 +15619,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -17351,7 +17415,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
@@ -18429,7 +18493,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18527,7 +18591,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -18771,7 +18835,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -21106,7 +21171,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -22448,6 +22513,17 @@
             "chardet": "^0.7.0",
             "iconv-lite": "^0.4.24",
             "tmp": "^0.0.33"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
           }
         },
         "find-up": {
@@ -22512,13 +22588,13 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
         "loader-utils": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
@@ -24657,7 +24733,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -25476,13 +25552,13 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
         "loader-utils": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
@@ -25806,7 +25882,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -25852,7 +25928,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -25871,7 +25947,7 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -25948,12 +26024,37 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "tmpl": {
@@ -25970,7 +26071,7 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
@@ -27492,7 +27593,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "fix-bpk-dependencies": "node scripts/npm/check-bpk-dependencies.js --fix",
     "test": "npm run lint && npm run check-bpk-dependencies && jest --coverage && npm run flow-check-ios && npm run flow-check-android && npm run spellcheck",
     "check-owners": "npm whoami && ( node scripts/npm/get-owners.js | grep -E $(npm whoami) ) && node scripts/npm/check-owners.js",
-    "publish": "npm run check-owners && git pull --rebase && npm run flow stop && npm test && lerna publish",
+    "publish": "npm run check-owners && git pull --rebase && npm run flow stop && npm test && npm run publish:prepare && lerna publish && npm run publish:bridges",
+    "publish:prepare": "node scripts/npm/native-bridges.js prepare",
+    "publish:bridges": "node scripts/npm/native-bridges.js publish",
     "release": "npm run publish",
     "danger": "danger ci",
     "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
@@ -113,7 +115,8 @@
     "react-dom": "16.8.3",
     "react-native": "0.59.0",
     "react-native-linear-gradient": "^2.5.3",
-    "react-test-renderer": "16.8.3"
+    "react-test-renderer": "16.8.3",
+    "tmp": "^0.1.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/packages/react-native-bpk-component-calendar/src/android/build.gradle
+++ b/packages/react-native-bpk-component-calendar/src/android/build.gradle
@@ -32,7 +32,7 @@ android {
 
     versionName getVersionFromJsPackage(project)
   }
-}`
+}
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"

--- a/scripts/npm/native-bridges.js
+++ b/scripts/npm/native-bridges.js
@@ -56,12 +56,12 @@ const ERRORS = {
   invalidEnv: (
     packages,
     cmd,
-  ) => `Your local envirnment is not ready to publish native Android bridges.
+  ) => `Your local environment is not ready to publish native Android bridges.
 As part of this release the following bridges need to be published:
 
 ${JSON.stringify(packages.map(p => p.name))}
 
-Check CONTRIBUTION.md to learn how to configure your local environment.
+Check CONTRIBUTING.md to learn how to configure your local environment.
 
 For more details about this error execute:
   ${yellow(`(cd android && ./gradlew ${cmd})`)}\n`,

--- a/scripts/npm/native-bridges.js
+++ b/scripts/npm/native-bridges.js
@@ -1,0 +1,229 @@
+/*
+ *
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2019 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-disable no-console */
+
+/**
+ * Helper script to publish native Android bridges when the
+ * RN package is published.
+ *
+ * This scripts works in two phases:
+ *
+ * 1. Prepare
+ * Should be called before the release to validade the environment and store
+ * the list of native packages to be published
+ *
+ * 2. Publish
+ * Should be called after the RN packages have been released to publish the native
+ * bridges
+ *
+ * Example:
+ *
+ *    "node native-bridges.js prepare && npm run publish && node native-bridges.js publish"
+ */
+
+const { promisify } = require('util');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+const { red, yellow, green } = require('colors');
+const lernaChanged = require('@lerna/changed');
+const tmp = require('tmp');
+
+const access = promisify(fs.access);
+const readFile = promisify(fs.readFile);
+const unlink = promisify(fs.unlink);
+
+const RELEASE_FILE = '.native-release-info.json';
+const ERRORS = {
+  invalidEnv: (
+    packages,
+    cmd,
+  ) => `Your local envirnment is not ready to publish native Android bridges.
+As part of this release the following bridges need to be published:
+
+${JSON.stringify(packages.map(p => p.name))}
+
+Check CONTRIBUTION.md to learn how to configure your local environment.
+
+For more details about this error execute:
+  ${yellow(`(cd android && ./gradlew ${cmd})`)}\n`,
+
+  cantPublish: (
+    pkgName,
+    cmd,
+    logFileName,
+  ) => `Unable to publish native bridge for ${pkgName}.
+To publish it manually execute:
+  ${yellow(`(cd android && ./gradlew ${cmd})`)}
+
+Check CONTRIBUTION.md to learn how to configure your local environment.
+
+For a complete log check:
+  ${yellow(`${logFileName}`)}\n`,
+};
+
+const disableOutput = () => {
+  const origLog = console.log;
+  console.log = () => {};
+  return () => {
+    console.log = origLog;
+  };
+};
+
+const filterPromise = (array, callback) =>
+  new Promise((resolve, reject) => {
+    const results = [];
+    let resolved = 0;
+    const toResolve = array.length;
+
+    const resolveItem = () => {
+      resolved += 1;
+      if (resolved === toResolve) {
+        resolve(results);
+      }
+    };
+
+    array.forEach((item, idx) => {
+      callback(item)
+        .then(include => {
+          if (include) results.push(item);
+          resolveItem(item, idx);
+        })
+        .catch(reject);
+    });
+  });
+
+const hasAndroidBridge = ({ location }) =>
+  access(`${location}/src/android/build.gradle`)
+    .then(() => true)
+    .catch(() => false);
+
+const getStaleAndroidBridges = () => {
+  const cfg = {
+    cwd: process.cwd(),
+    _: [],
+    json: true,
+    loglevel: 'error',
+  };
+
+  const restoreLog = disableOutput();
+  const command = lernaChanged(cfg);
+
+  return command
+    .then(() => JSON.parse(command.result.text))
+    .then(pkgs => {
+      restoreLog();
+      return filterPromise(pkgs, pkg =>
+        Promise.resolve(!pkg.private && hasAndroidBridge(pkg)),
+      );
+    });
+};
+
+const gradleExec = (cmd, stdout = null, stderr = null) => {
+  const gradleScript = `${process.cwd()}/android/gradlew`;
+  const gradle = spawn(gradleScript, cmd, {
+    cwd: `${process.cwd()}/android`,
+  });
+
+  if (stdout) gradle.stdout.pipe(stdout);
+  if (stderr) gradle.stderr.pipe(stderr);
+
+  return new Promise((resolve, reject) => {
+    gradle.on('close', code => {
+      if (code !== 0) {
+        reject(code);
+      } else {
+        resolve();
+      }
+    });
+  });
+};
+
+const checkEnv = packages => {
+  const { name } = packages[0]; // We check only for the first one as it should be the same for all
+  const cmd = `:${name}:checkMavenCredentials`;
+  return gradleExec([`:${name}:checkMavenCredentials`]).catch(() => {
+    throw new Error(ERRORS.invalidEnv(packages, cmd));
+  });
+};
+
+const createReleaseInfo = packages => {
+  const file = fs.createWriteStream(RELEASE_FILE);
+  file.write(JSON.stringify(packages));
+  file.end();
+};
+
+const readReleaseInfo = () =>
+  readFile(RELEASE_FILE)
+    .then(json => {
+      if (!json || `${json}` === '') return [];
+      return JSON.parse(json);
+    })
+    .catch(e => {
+      throw new Error(
+        'Release info file not found. Did you call `native-bridges.js prepare` before the release?',
+        e,
+      );
+    });
+
+const deleteReleaseInfo = () =>
+  access(RELEASE_FILE)
+    .then(() => unlink(RELEASE_FILE))
+    .catch(() => {}); // We don't care if the file doesn't exist
+
+const publishBridges = packages =>
+  Promise.all(
+    packages.map(({ name }) => {
+      console.log(`Publishing native Android bridge for ${yellow(name)}`);
+
+      const logFileName = tmp.tmpNameSync();
+      const logFile = fs.createWriteStream(logFileName);
+
+      const cmd = `:${name}:publish`;
+      return gradleExec([cmd], logFile, logFile).catch(() => {
+        throw new Error(ERRORS.cantPublish(name, cmd, logFileName));
+      });
+    }),
+  );
+
+(async () => {
+  const action = process.argv[2];
+
+  try {
+    if (action === 'prepare') {
+      const staleBridges = await getStaleAndroidBridges();
+      await createReleaseInfo(staleBridges);
+
+      if (staleBridges.length > 0) {
+        await checkEnv(staleBridges);
+      }
+    } else if (action === 'publish') {
+      const staleBridges = await readReleaseInfo();
+      await publishBridges(staleBridges);
+      await deleteReleaseInfo();
+    }
+
+    console.log(green('All good! 👍\n'));
+  } catch (e) {
+    console.error(red(e));
+    process.exit(1);
+  }
+})();

--- a/scripts/npm/native-bridges.js
+++ b/scripts/npm/native-bridges.js
@@ -27,7 +27,7 @@
  * This scripts works in two phases:
  *
  * 1. Prepare
- * Should be called before the release to validade the environment and store
+ * Should be called before the release to validate the environment and store
  * the list of native packages to be published
  *
  * 2. Publish


### PR DESCRIPTION
This PR introduces a script to publish all native bridges (only calendar for now) after a release is done. 

The script works by first recording the list of packages that are to be released, and ensuring the env is configured correctly if native bridges need to be released. This relies on `lerna changed` to find which packages are going to be released.

After the RN packages have been released the script is called again to publish the native packages based on the information saved on the first step.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
