### PR TITLE
[BPK-2441] Make iOS buttons consistent

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,2 +1,5 @@
 # Unreleased
 
+**Fixed:**
+- react-native-bpk-component-button:
+  - Aligned iOS secondary and destructive buttons to iOS native buttons.

--- a/packages/react-native-bpk-component-button/src/BpkBorderedButton.ios.js
+++ b/packages/react-native-bpk-component-button/src/BpkBorderedButton.ios.js
@@ -33,11 +33,13 @@ import { type IconType } from './common-types';
 type ViewProps = ElementProps<typeof View>;
 type ViewStyleProp = $PropertyType<ViewProps, 'style'>;
 
+const BORDER_WIDTH = buttonBorderWidth;
+
 const styles = StyleSheet.create({
   button: {
     alignItems: 'center',
-    borderWidth: buttonBorderWidth,
     flexDirection: 'row',
+    borderWidth: BORDER_WIDTH,
     justifyContent: 'center',
     paddingVertical: spacingMd - buttonBorderWidth,
     paddingHorizontal: spacingBase - spacingSm - buttonBorderWidth,
@@ -108,6 +110,10 @@ const BpkBorderedButton = (props: Props) => {
 
   return (
     <BpkTouchableOverlay
+      overlayStyle={{
+        borderColor,
+        borderWidth: BORDER_WIDTH,
+      }}
       borderRadius={borderRadius}
       disabled={disabled}
       {...rest}

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -396,6 +396,10 @@ exports[`iOS BpkButton should render correctly with type="destructive" 1`] = `
         Object {
           "borderRadius": 40,
         },
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 2,
+        },
       ]
     }
   />
@@ -481,6 +485,10 @@ exports[`iOS BpkButton should render correctly with type="destructive" and disab
         },
         Object {
           "borderRadius": 40,
+        },
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 2,
         },
       ]
     }
@@ -921,6 +929,10 @@ exports[`iOS BpkButton should render correctly with type="secondary" 1`] = `
         Object {
           "borderRadius": 40,
         },
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 2,
+        },
       ]
     }
   />
@@ -1006,6 +1018,10 @@ exports[`iOS BpkButton should render correctly with type="secondary" and disable
         },
         Object {
           "borderRadius": 40,
+        },
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 2,
         },
       ]
     }
@@ -1718,6 +1734,10 @@ exports[`iOS BpkButton should support the "secondary" property 1`] = `
         Object {
           "borderRadius": 40,
         },
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 2,
+        },
       ]
     }
   />
@@ -2115,6 +2135,10 @@ exports[`iOS should support the "large" and secondary property 1`] = `
         },
         Object {
           "borderRadius": 40,
+        },
+        Object {
+          "borderColor": "rgb(230, 228, 235)",
+          "borderWidth": 2,
         },
       ]
     }

--- a/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
+++ b/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
@@ -110,6 +110,10 @@ exports[`iOS BpkNudger should render correctly 1`] = `
           Object {
             "borderRadius": 40,
           },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
+          },
         ]
       }
     />
@@ -234,6 +238,10 @@ exports[`iOS BpkNudger should render correctly 1`] = `
           Object {
             "borderRadius": 40,
           },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
+          },
         ]
       }
     />
@@ -351,6 +359,10 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
           },
           Object {
             "borderRadius": 40,
+          },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
           },
         ]
       }
@@ -476,6 +488,10 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
           Object {
             "borderRadius": 40,
           },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
+          },
         ]
       }
     />
@@ -592,6 +608,10 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
           },
           Object {
             "borderRadius": 40,
+          },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
           },
         ]
       }
@@ -717,6 +737,10 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
           },
           Object {
             "borderRadius": 40,
+          },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
           },
         ]
       }
@@ -836,6 +860,10 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
           Object {
             "borderRadius": 40,
           },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
+          },
         ]
       }
     />
@@ -959,6 +987,10 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
           },
           Object {
             "borderRadius": 40,
+          },
+          Object {
+            "borderColor": "rgb(230, 228, 235)",
+            "borderWidth": 2,
           },
         ]
       }


### PR DESCRIPTION
Align RN iOS button border design to that on iOS Native

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

## before: 
![Screenshot 2019-05-03 at 15 56 45 (2)](https://user-images.githubusercontent.com/30267516/57145929-1d0a3c00-6dbc-11e9-90e7-183fe04bd8c1.png)


## after:
![after](https://user-images.githubusercontent.com/30267516/57145792-dddbeb00-6dbb-11e9-83f2-cc85d8f337fc.png)
