### PR TITLE
[NO-JIRA] Remove backpack-android version range

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 **Fixed:**
+
 - react-native-bpk-component-button:
   - Aligned iOS secondary and destructive buttons to iOS native buttons.
   - Tweaked the theming props for border radius. See *Theme props* section of https://backpack.github.io/components/button/?platform=native.
+
+- react-native-bpk-component-calendar:
+  - Remove version range for `backpack-android'.

--- a/packages/react-native-bpk-component-calendar/src/android/build.gradle
+++ b/packages/react-native-bpk-component-calendar/src/android/build.gradle
@@ -36,21 +36,5 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
-  implementation("com.github.skyscanner:backpack-android") {
-    version {
-      // We follow semver so anything in between majors should work. It is very important to keep this
-      // information correct in case the host application already has `backpack-android` as a dependency
-      // in a different major version, we want the build to fail in such cases and not a runtime error.
-      //
-      // It's important to note that the gradle documentation suggests the syntax for this should be
-      // [1, 2[ (yes with [` at the end), but we publish the compiled version in a maven repository and for
-      // maven the correct syntax is [1, 2). Given that `)` at the end also works for gradle we are
-      // using this syntax instead.
-      //
-      // see: https://docs.gradle.org/current/userguide/declaring_dependencies.html#sub:declaring_dependency_rich_version
-      // see: https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8855
-      // see: http://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html
-      strictly "[7.4,9.0)"
-    }
-  }
+  implementation "com.github.skyscanner:backpack-android:8.0.0"
 }


### PR DESCRIPTION
This is not playing well with the app's build caching mechanism so we will disable it for now. Because of how we publish it (on maven) it is also not serving the original purpose so disabling it will not have any negative effect.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
