### PR TITLE
[BPK-2573] Update pods' Backpack ios dependency

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,11 @@
 # Unreleased
 
 > Place your changes below this line.
+**Breaking:**
+
+- `bpk-component-calendar`:
+- `bpk-component-dialog`:
+  - Updraded Backpack cocoapod dependency to `10.0.0`.
 
 ## How to write a good changelog entry
 

--- a/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
+++ b/packages/react-native-bpk-component-calendar/react-native-bpk-component-calendar.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "src/ios/CalendarBridge/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Backpack', '~> 8.0'
+  s.dependency 'Backpack', '~> 10.0'
 end

--- a/packages/react-native-bpk-component-dialog/react-native-bpk-component-dialog.podspec
+++ b/packages/react-native-bpk-component-dialog/react-native-bpk-component-dialog.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "src/ios/DialogBridge/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Backpack', '~> 8.0'
+  s.dependency 'Backpack', '~> 10.0'
 end


### PR DESCRIPTION
Just bumping the pod version. There's nothing that should break this in the changelog for backpack-ios

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)