### PR TITLE
[BPK-2605]: iconOnly buttons should stay circular regardless of theming

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+- react-native-bpk-component-button
+  - `iconOnly` buttons now apply `boarderRadius` theming when applied, to remain pill shaped.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -24,7 +24,7 @@ target 'Backpack Native' do
   pod 'Folly', podspec: '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   # RN Bridging Pods
-  pod 'Backpack', '~> 10.0.0'
+  pod 'Backpack', '~> 11.0.0'
   pod 'react-native-bpk-component-calendar', path: '../packages/react-native-bpk-component-calendar'
   pod 'react-native-bpk-component-dialog', path: '../packages/react-native-bpk-component-dialog'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Backpack (10.0.0):
+  - Backpack (11.0.1):
     - FSCalendar (~> 2.8)
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.5.3):
@@ -13,11 +13,11 @@ PODS:
   - glog (0.3.5)
   - React (0.59.0):
     - React/Core (= 0.59.0)
-  - react-native-bpk-component-calendar (1.0.0):
-    - Backpack (~> 10.0)
+  - react-native-bpk-component-calendar (1.0.2):
+    - Backpack (~> 11.0)
     - React
-  - react-native-bpk-component-dialog (1.0.0):
-    - Backpack (~> 10.0)
+  - react-native-bpk-component-dialog (1.0.2):
+    - Backpack (~> 11.0)
     - React
   - react-native-maps (0.24.2):
     - React
@@ -67,7 +67,7 @@ PODS:
   - yoga (0.59.0.React)
 
 DEPENDENCIES:
-  - Backpack (~> 10.0.0)
+  - Backpack (~> 11.0.0)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
@@ -112,7 +112,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Backpack: e40cec639240018e29f932b7cf42b2f712593c91
+  Backpack: 4dee2ec4fee0dd927d59573f23074a522719f778
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: b0b70acf63ee888829b7c2ebbf6b50e227396e55
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
@@ -120,11 +120,11 @@ SPEC CHECKSUMS:
   FSCalendar: 3a5ed3636e2ba1b83ebebfcf0c2603105a6f5efe
   glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
   React: 1d605e098d69bdf08960787f3446f0a9dc2e2ccf
-  react-native-bpk-component-calendar: 8f013d5a593d47dfa7797bbb79d032cfe620bcd5
-  react-native-bpk-component-dialog: 6ae79f72cc15fd80e23cdb9c9a91871b0cc99973
+  react-native-bpk-component-calendar: ed449b9fc3964c3e0862b895b76882602ce138c6
+  react-native-bpk-component-dialog: 97ae8501f2dfd42e344e13e74c4efcbe0996854a
   react-native-maps: bb480348a3fe1e5a811fed1ba3387b329161c5cc
   yoga: 128daf064cacaede0c3bb27424b6b4c71052e6cd
 
-PODFILE CHECKSUM: 6bf4fa3cd9135744d81d22a7dfe47110b339a46e
+PODFILE CHECKSUM: b76feb925a8320cf79dc66989e8e20b0ecdc0e47
 
 COCOAPODS: 1.5.3

--- a/ios/native.xcodeproj/project.pbxproj
+++ b/ios/native.xcodeproj/project.pbxproj
@@ -320,8 +320,10 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
+				"he-IL",
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15412,7 +15412,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
+++ b/packages/react-native-bpk-component-button/src/BpkButton-test.common.js
@@ -193,6 +193,28 @@ const commonTests = () => {
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
+
+    it('should not apply border radius when a theme', () => {
+      const theme = {
+        buttonPrimaryTextColor: 'red',
+        buttonPrimaryGradientStartColor: 'green',
+        buttonPrimaryGradientEndColor: 'blue',
+        buttonBorderRadius: 4,
+      };
+      const tree = renderer
+        .create(
+          <BpkThemeProvider theme={theme}>
+            <BpkButton
+              iconOnly
+              icon="baggage"
+              title="Lorem ipsum"
+              onPress={onPressFn}
+            />
+          </BpkThemeProvider>,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
   });
 };
 

--- a/packages/react-native-bpk-component-button/src/BpkButton.android.js
+++ b/packages/react-native-bpk-component-button/src/BpkButton.android.js
@@ -119,7 +119,7 @@ const BpkButton = (props: Props) => {
       accessibilityComponentType="button"
       accessibilityLabel={accessibilityLabel || title}
       accessibilityTraits={accessibilityTraits}
-      borderRadius={borderRadiusForTheme(themeAttributes)}
+      borderRadius={borderRadiusForTheme(themeAttributes, iconOnly)}
       {...buttonColors}
       {...rest}
     >

--- a/packages/react-native-bpk-component-button/src/BpkButton.ios.js
+++ b/packages/react-native-bpk-component-button/src/BpkButton.ios.js
@@ -132,7 +132,7 @@ const BpkButton = (props: Props) => {
       accessibilityComponentType="button"
       accessibilityLabel={accessibilityLabel || title}
       accessibilityTraits={accessibilityTraits}
-      borderRadius={borderRadiusForTheme(themeAttributes)}
+      borderRadius={borderRadiusForTheme(themeAttributes, iconOnly)}
       {...buttonColorsForType(type, themeAttributes, disabled)}
       {...rest}
     >

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -1757,6 +1757,100 @@ exports[`Android BpkButton should support the "secondary" property 1`] = `
 </View>
 `;
 
+exports[`Android BpkButtonThemed should not apply border radius when a theme 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "elevation": 2,
+        "overflow": "hidden",
+      },
+      Object {
+        "borderRadius": 40,
+      },
+    ]
+  }
+>
+  <View
+    accessibilityLabel="Lorem ipsum"
+    accessible={true}
+    isTVSelectable={true}
+    nativeBackgroundAndroid={
+      Object {
+        "borderless": true,
+        "color": null,
+        "type": "RippleAndroid",
+      }
+    }
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingHorizontal": 12,
+          "paddingVertical": 8,
+        },
+        Object {
+          "backgroundColor": "green",
+          "borderRadius": 40,
+        },
+        Object {
+          "flexDirection": "row-reverse",
+        },
+        Object {
+          "paddingHorizontal": 10,
+        },
+      ]
+    }
+  >
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "color": "rgb(82, 76, 97)",
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "marginEnd": 4,
+            },
+            Object {
+              "color": "red",
+            },
+            Object {
+              "marginEnd": 0,
+              "marginStart": 4,
+            },
+            Object {
+              "marginEnd": 0,
+              "marginStart": 0,
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`Android BpkButtonThemed should render correctly 1`] = `
 <View
   style={

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -1744,6 +1744,113 @@ exports[`iOS BpkButton should support the "secondary" property 1`] = `
 </View>
 `;
 
+exports[`iOS BpkButtonThemed should not apply border radius when a theme 1`] = `
+<View
+  accessibilityComponentType="button"
+  accessibilityLabel="Lorem ipsum"
+  accessibilityTraits={
+    Array [
+      "button",
+    ]
+  }
+  accessible={true}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+>
+  <View
+    colors={
+      Array [
+        "green",
+        "blue",
+      ]
+    }
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "center",
+          "paddingHorizontal": 12,
+          "paddingVertical": 8,
+        },
+        null,
+        Object {
+          "borderRadius": 40,
+        },
+        Object {
+          "flexDirection": "row-reverse",
+        },
+        Object {
+          "paddingHorizontal": 8,
+        },
+      ]
+    }
+  >
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(82, 76, 97)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "color": "rgb(82, 76, 97)",
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "marginEnd": 4,
+            },
+            Object {
+              "color": "red",
+            },
+            Object {
+              "marginEnd": 0,
+              "marginStart": 4,
+            },
+            Object {
+              "marginEnd": 0,
+              "marginStart": 0,
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(37, 32, 51)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        Object {
+          "borderRadius": 40,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`iOS BpkButtonThemed should render correctly 1`] = `
 <View
   accessibilityComponentType="button"

--- a/packages/react-native-bpk-component-button/src/theming-functions.js
+++ b/packages/react-native-bpk-component-button/src/theming-functions.js
@@ -42,8 +42,13 @@ function valueOrDefault<T>(
   return (haystack && haystack[needle]) || defaultValue;
 }
 
-export const borderRadiusForTheme = (themeAttributes: ?Theme): number =>
-  valueOrDefault(themeAttributes, 'buttonBorderRadius', borderRadiusPill);
+export const borderRadiusForTheme = (
+  themeAttributes: ?Theme,
+  iconOnly: boolean,
+): number =>
+  iconOnly
+    ? borderRadiusPill
+    : valueOrDefault(themeAttributes, 'buttonBorderRadius', borderRadiusPill);
 
 export const backgroundColorForType = (
   type: ButtonType,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
