### PR TITLE
[NO-JIRA] Update backpack-android version for dialog

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.10'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()

--- a/packages/react-native-bpk-component-dialog/src/android/build.gradle
+++ b/packages/react-native-bpk-component-dialog/src/android/build.gradle
@@ -36,5 +36,5 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
-  implementation("com.github.skyscanner:backpack-android:8.0.0")
+  implementation("com.github.skyscanner:backpack-android:9.9.0")
 }


### PR DESCRIPTION
Update because we recently changed the signature of `addActionButton(BpkButton)` to `addActionButton(View)` and because bridges are precompiled this was still referencing the old signature and failing ci.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
