### PR TITLE
Fix the title color in NavigationBar on Android

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- react-native-bpk-component-navigation-bar:
+  - `navigationBarTintColor` changes the title color.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar-test.android.js
+++ b/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar-test.android.js
@@ -94,6 +94,31 @@ describe('android', () => {
       expect(tree).toMatchSnapshot();
     });
 
+    it('should render correctly with custom theme', () => {
+      const tree = renderer
+        .create(
+          <BpkNavigationBar
+            title="Backpack"
+            leadingButton={
+              <BpkNavigationBarButtonAndroid
+                title="Back"
+                icon="long-arrow-left"
+                onPress={jest.fn()}
+              />
+            }
+            theme={{
+              navigationBarBackgroundColor: 'white',
+              navigationBarTintColor: 'red',
+              navigationBarDisabledTintColor: 'red',
+              navigationBarStatusBarStyle: 'light-content',
+              navigationBarStatusBarColor: 'transparent',
+            }}
+          />,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
     it('should render correctly with trailing button', () => {
       const tree = renderer
         .create(

--- a/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
+++ b/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.android.js
@@ -162,6 +162,22 @@ class BpkNavigationBar extends Component<Props, {}> {
 
     let titleView = null;
 
+    if (this.theme) {
+      const {
+        navigationBarTintColor,
+        navigationBarDisabledTintColor,
+        navigationBarBackgroundColor,
+      } = this.theme;
+
+      titleStyle.push({ color: navigationBarTintColor });
+      outerBarStyle.push({
+        backgroundColor: navigationBarBackgroundColor,
+      });
+      tintColor = navigationBarTintColor;
+      disabledTintColor = navigationBarDisabledTintColor;
+      touchableColor = navigationBarTintColor;
+    }
+
     // This if ensures Flow correctly refines the type of
     // title in the body of the if to `'string' | TitleWithIcon
     if (
@@ -192,22 +208,6 @@ class BpkNavigationBar extends Component<Props, {}> {
           })}
         </View>
       );
-    }
-
-    if (this.theme) {
-      const {
-        navigationBarTintColor,
-        navigationBarDisabledTintColor,
-        navigationBarBackgroundColor,
-      } = this.theme;
-
-      titleStyle.push({ color: navigationBarTintColor });
-      outerBarStyle.push({
-        backgroundColor: navigationBarBackgroundColor,
-      });
-      tintColor = navigationBarTintColor;
-      disabledTintColor = navigationBarDisabledTintColor;
-      touchableColor = navigationBarTintColor;
     }
 
     if (hasSubtitleView) {

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.android.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.android.js.snap
@@ -646,6 +646,133 @@ exports[`android BpkNavigationBar should render correctly with custom style 1`] 
 </View>
 `;
 
+exports[`android BpkNavigationBar should render correctly with custom theme 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "rgb(0, 178, 214)",
+        "elevation": 3,
+        "flexDirection": "column",
+        "paddingHorizontal": 8,
+        "width": "100%",
+      },
+      Object {
+        "backgroundColor": "white",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "height": 56,
+          "justifyContent": "space-between",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderRadius": 40,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Back"
+        accessible={true}
+        isTVSelectable={true}
+        nativeBackgroundAndroid={
+          Object {
+            "borderless": true,
+            "color": 872349696,
+            "type": "RippleAndroid",
+          }
+        }
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(82, 76, 97)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Array [
+                Object {
+                  "padding": 8,
+                },
+                Object {
+                  "color": "red",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          },
+          Object {
+            "bottom": 15,
+            "end": 72,
+            "position": "absolute",
+            "start": 72,
+          },
+        ]
+      }
+    >
+      <Text
+        allowFontScaling={false}
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={
+          Array [
+            Object {
+              "color": "rgb(82, 76, 97)",
+              "fontFamily": "sans-serif",
+              "fontSize": 20,
+              "fontWeight": "400",
+              "letterSpacing": -0.4,
+            },
+            Object {
+              "fontFamily": "sans-serif-medium",
+            },
+            Array [
+              Object {
+                "color": "red",
+              },
+              null,
+            ],
+          ]
+        }
+      >
+        Backpack
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`android BpkNavigationBar should render correctly with trailing button 1`] = `
 <View
   style={


### PR DESCRIPTION
`navigationBarTintColor` in theme was not changing the title color in NavigationBar, only the icon. Now it changes both. Bug was only on Android, iOS was fine.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
