### PR TITLE
[BPK-2685] Add flag to force backpack-android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,19 @@ allprojects {
             }
         }
     }
+
+    // Force dependency resolution of backpack-android to a specific version
+    if (project.hasProperty("backpack-version")) {
+        afterEvaluate { project ->
+            project.configurations.all {
+                resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                    if (details.requested.name == "backpack-android") {
+                        details.useVersion project["backpack-version"]
+                    }
+                }
+            }
+        }
+    }
 }
 
 ext {


### PR DESCRIPTION
This new flag will be used to test latest versions of backpack-android against the android bridges in our ci

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
