### PR TITLE
Backpack RN Dialog events update fix

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,3 +31,5 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
 - `bpk-component-horcrux`:
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
 
+- `bpk-component-dialog`:
+  - Fixed issue where `BpkDialog` failed in iOS when updating the actions.

--- a/packages/react-native-bpk-component-dialog/src/NativeDialog.ios.js
+++ b/packages/react-native-bpk-component-dialog/src/NativeDialog.ios.js
@@ -59,7 +59,7 @@ class BpkDialog extends Component<Props> {
     this.eventSubscriptions = [];
   }
 
-  componentDidMount() {
+  setUpEvents = () => {
     if (BpkDialogEventEmitter) {
       const { actions, scrimAction } = this.props;
       this.eventSubscriptions.push(
@@ -82,6 +82,16 @@ class BpkDialog extends Component<Props> {
         );
       }
     }
+  };
+
+  componentDidMount() {
+    this.setUpEvents();
+  }
+
+  componentDidUpdate() {
+    this.eventSubscriptions.forEach(subscriber => subscriber.remove());
+    this.eventSubscriptions = [];
+    this.setUpEvents();
   }
 
   componentWillUnmount() {

--- a/packages/react-native-bpk-component-dialog/stories.js
+++ b/packages/react-native-bpk-component-dialog/stories.js
@@ -60,12 +60,18 @@ const disabledScrimAction = {
   callback: () => {},
 };
 
-type DialogState = {
+type Props = {
   ...$Exact<BpkDialogProps>,
+  updatesState: boolean,
+};
+
+type State = {
+  ...$Exact<BpkDialogProps>,
+  updatesState: boolean,
   text: string,
 };
 
-class TriggerDialogComponent extends Component<BpkDialogProps, DialogState> {
+class TriggerDialogComponent extends Component<Props, State> {
   constructor(props) {
     super(props);
 
@@ -78,13 +84,24 @@ class TriggerDialogComponent extends Component<BpkDialogProps, DialogState> {
       scrimAction: props.scrimAction,
       isOpen: false,
       text: 'No action',
+      updatesState: props.updatesState,
     };
   }
 
   openDialog = () => this.setState({ isOpen: true });
 
+  updateState = () => this.setState({ actions: this.props.actions.reverse() });
+
   render() {
-    const { text, dialogType, title, description, icon, isOpen } = this.state;
+    const {
+      text,
+      dialogType,
+      title,
+      description,
+      icon,
+      isOpen,
+      updatesState,
+    } = this.state;
 
     let actions: Array<ActionButton> = [];
     if (this.state.actions) {
@@ -92,6 +109,9 @@ class TriggerDialogComponent extends Component<BpkDialogProps, DialogState> {
         text: action.text,
         type: action.type,
         callback: () => {
+          if (updatesState) {
+            this.updateState();
+          }
           this.setState({
             isOpen: false,
             text: `Action: ${action.text}`,
@@ -150,6 +170,7 @@ storiesOf('react-native-bpk-component-dialog', module)
   .addDecorator(CenterDecorator)
   .add('docs:simple', () => (
     <TriggerDialogComponent
+      updatesState={false}
       dialogType={DIALOG_TYPE.alert}
       title={dialogTitle}
       description={dialogDescription}
@@ -161,6 +182,7 @@ storiesOf('react-native-bpk-component-dialog', module)
   ))
   .add('docs:option', () => (
     <TriggerDialogComponent
+      updatesState={false}
       dialogType={DIALOG_TYPE.alert}
       title={dialogTitle}
       description={dialogDescription}
@@ -172,6 +194,7 @@ storiesOf('react-native-bpk-component-dialog', module)
   ))
   .add('docs:no-scrim-action', () => (
     <TriggerDialogComponent
+      updatesState={false}
       dialogType={DIALOG_TYPE.alert}
       title={dialogTitle}
       description={dialogDescription}
@@ -183,6 +206,7 @@ storiesOf('react-native-bpk-component-dialog', module)
   ))
   .add('docs:only-title', () => (
     <TriggerDialogComponent
+      updatesState={false}
       dialogType={DIALOG_TYPE.alert}
       title={dialogTitle}
       description={null}
@@ -194,6 +218,7 @@ storiesOf('react-native-bpk-component-dialog', module)
   ))
   .add('docs:bottom', () => (
     <TriggerDialogComponent
+      updatesState={false}
       dialogType={DIALOG_TYPE.bottomSheet}
       title={dialogTitle}
       description={dialogDescription}
@@ -205,6 +230,19 @@ storiesOf('react-native-bpk-component-dialog', module)
   ))
   .add('docs:all-buttons', () => (
     <TriggerDialogComponent
+      updatesState={false}
+      dialogType={DIALOG_TYPE.bottomSheet}
+      title={dialogTitle}
+      description={dialogDescription}
+      icon={dialogIcon}
+      actions={allActions}
+      scrimAction={defaultScrimAction}
+      isOpen
+    />
+  ))
+  .add('docs:update-dialog', () => (
+    <TriggerDialogComponent
+      updatesState
       dialogType={DIALOG_TYPE.bottomSheet}
       title={dialogTitle}
       description={dialogDescription}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

RN `BpkDialog` was failing in iOS when the actions were updated. After **updating**, The event emitter kept the old actions and tried to execute them. These actions were null and the app crashed.

With this fix, the all old actions are removed from the event emitter before updating them.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
