### PR TITLE
Remove package-lock versions

### DIFF
--- a/packages/react-native-bpk-component-animate-height/package-lock.json
+++ b/packages/react-native-bpk-component-animate-height/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-animate-height",
-	"version": "2.0.78",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-badge/package-lock.json
+++ b/packages/react-native-bpk-component-badge/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-badge",
-	"version": "2.2.16",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-banner-alert/package-lock.json
+++ b/packages/react-native-bpk-component-banner-alert/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-banner-alert",
-	"version": "5.0.35",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-boilerplate/package-lock.json
+++ b/packages/react-native-bpk-component-boilerplate/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-boilerplate",
-	"version": "0.0.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-button-link/package-lock.json
+++ b/packages/react-native-bpk-component-button-link/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-button-link",
-	"version": "4.4.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-button/package-lock.json
+++ b/packages/react-native-bpk-component-button/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-button",
-	"version": "9.2.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-calendar/package-lock.json
+++ b/packages/react-native-bpk-component-calendar/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-calendar",
-	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-card/package-lock.json
+++ b/packages/react-native-bpk-component-card/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-card",
-	"version": "1.4.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-carousel-indicator/package-lock.json
+++ b/packages/react-native-bpk-component-carousel-indicator/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-carousel-indicator",
-	"version": "1.0.66",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-carousel/package-lock.json
+++ b/packages/react-native-bpk-component-carousel/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-carousel",
-	"version": "1.0.66",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-chip/package-lock.json
+++ b/packages/react-native-bpk-component-chip/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-chip",
-	"version": "3.2.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-dialog/package-lock.json
+++ b/packages/react-native-bpk-component-dialog/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-dialog",
-	"version": "1.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-flat-list/package-lock.json
+++ b/packages/react-native-bpk-component-flat-list/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-flat-list",
-	"version": "3.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-horizontal-nav/package-lock.json
+++ b/packages/react-native-bpk-component-horizontal-nav/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-horizontal-nav",
-	"version": "4.0.25",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-icon/package-lock.json
+++ b/packages/react-native-bpk-component-icon/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-icon",
-	"version": "1.16.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-image/package-lock.json
+++ b/packages/react-native-bpk-component-image/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-image",
-	"version": "1.1.43",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-map/package-lock.json
+++ b/packages/react-native-bpk-component-map/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-map",
-	"version": "1.0.29",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-navigation-bar/package-lock.json
+++ b/packages/react-native-bpk-component-navigation-bar/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-navigation-bar",
-	"version": "5.1.16",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-nudger/package-lock.json
+++ b/packages/react-native-bpk-component-nudger/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-nudger",
-	"version": "2.0.33",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-panel/package-lock.json
+++ b/packages/react-native-bpk-component-panel/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-panel",
-	"version": "1.0.50",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-phone-input/package-lock.json
+++ b/packages/react-native-bpk-component-phone-input/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-phone-input",
-	"version": "3.0.32",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-picker/package-lock.json
+++ b/packages/react-native-bpk-component-picker/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-picker",
-	"version": "3.0.36",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-progress/package-lock.json
+++ b/packages/react-native-bpk-component-progress/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-progress",
-	"version": "1.0.52",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-section-list/package-lock.json
+++ b/packages/react-native-bpk-component-section-list/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-section-list",
-	"version": "3.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-select/package-lock.json
+++ b/packages/react-native-bpk-component-select/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-select",
-	"version": "2.1.30",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-spinner/package-lock.json
+++ b/packages/react-native-bpk-component-spinner/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-spinner",
-	"version": "1.0.88",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-star-rating/package-lock.json
+++ b/packages/react-native-bpk-component-star-rating/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-star-rating",
-	"version": "1.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-switch/package-lock.json
+++ b/packages/react-native-bpk-component-switch/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-switch",
-	"version": "1.0.88",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-text-input/package-lock.json
+++ b/packages/react-native-bpk-component-text-input/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-text-input",
-	"version": "3.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-text/package-lock.json
+++ b/packages/react-native-bpk-component-text/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-text",
-	"version": "4.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-touchable-native-feedback/package-lock.json
+++ b/packages/react-native-bpk-component-touchable-native-feedback/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-touchable-native-feedback",
-	"version": "1.1.55",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-component-touchable-overlay/package-lock.json
+++ b/packages/react-native-bpk-component-touchable-overlay/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-component-touchable-overlay",
-	"version": "1.2.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-styles/package-lock.json
+++ b/packages/react-native-bpk-styles/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-styles",
-	"version": "1.1.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-native-bpk-theming/package-lock.json
+++ b/packages/react-native-bpk-theming/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "react-native-bpk-theming",
-	"version": "1.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
We already did this in the `backpack` repo as they are not providing any value and lerna often fails to update them properly as part of the release process.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_

Unfold all long diffs:
```
const toClick = document.getElementsByClassName("load-diff-button btn-link width-full");
for (let i = toClick.length - 1; i >= 0; i -= 1){
toClick[i].click();
}
```