### PR TITLE
[HELIOS-1370] New Prop: 'titleProps' for react-native-bpk-component-section-list

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -267,6 +267,7 @@ stubStyle
 subtitleView
 textProps
 textStyle
+titleProps
 titleWithIcon
 toggleExpandedButtonLabel
 trailingButton

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,6 +23,8 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
 
 - react-native-bpk-component-infinity-gauntlet:
   - New `timeStone` prop for controlling time. See &lt;link to docs site&gt;.
+- react-native-bpk-component-flat-list and react-native-bpk-component-flat-list:
+  - New `titleProps` prop for passing props through to the underlying text instance.
 
 
 **Fixed:**

--- a/packages/react-native-bpk-component-flat-list/README.md
+++ b/packages/react-native-bpk-component-flat-list/README.md
@@ -55,6 +55,7 @@ export default class App extends Component {
       title={country.name}
       image={<Image source={require(FLAG_IMAGES[country.id])} />}
       onPress={this.getItemOnPressCallback(country.id)}
+      titleProps={{ weight: 'regular' }}
     />
   );
 
@@ -84,6 +85,7 @@ Inherits all props from React Native's [FlatList](https://facebook.github.io/rea
 | title              | string                                | true     | -             |
 | image              | element                               | false    | null          |
 | selected           | bool                                  | false    | false         |
+| titleProps         | object                                | false    | {}            |
 
 ### BpkFlatListItemSeparator
 

--- a/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem-test.common.js
+++ b/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem-test.common.js
@@ -74,6 +74,27 @@ const commonTests = () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should pass through titleProps to the title', () => {
+    const titleProps = {
+      numberOfLines: 7,
+      testID: 'ID_for_testing',
+    };
+    const tree = renderer.create(
+      <BpkFlatListItem
+        title="List item with pass through props"
+        onPress={onPressFn}
+        titleProps={titleProps}
+      />,
+    );
+    const bpkText = tree.root.findAll(
+      descendant =>
+        descendant.type.name === 'BpkText' &&
+        descendant.props.testID === 'ID_for_testing',
+    );
+    expect(bpkText.length).toEqual(1);
+    expect(bpkText[0].props).toMatchSnapshot();
+  });
 };
 
 export default commonTests;

--- a/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.android.js
+++ b/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.android.js
@@ -80,7 +80,7 @@ class BpkFlatListItem extends React.PureComponent<FlatListItemProps> {
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;
 
   render() {
-    const { image, title, selected, theme, ...rest } = this.props;
+    const { image, title, selected, theme, titleProps, ...rest } = this.props;
     let tintColorFinal = tintColor;
     const textStyles = [styles.text];
     const themeAttributes = getThemeAttributes(
@@ -117,7 +117,7 @@ class BpkFlatListItem extends React.PureComponent<FlatListItemProps> {
         <View style={styles.outer}>
           <View style={styles.content}>
             {styledImage}
-            <BpkText textStyle="base" style={textStyles}>
+            <BpkText textStyle="base" style={textStyles} {...titleProps}>
               {title}
             </BpkText>
           </View>

--- a/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
+++ b/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
@@ -79,7 +79,15 @@ class BpkFlatListItem extends React.PureComponent<FlatListItemProps> {
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;
 
   render() {
-    const { image, title, selected, style, theme, ...rest } = this.props;
+    const {
+      image,
+      title,
+      selected,
+      style,
+      theme,
+      titleProps,
+      ...rest
+    } = this.props;
 
     const iconStyles = [styles.tick];
     const textStyles = [styles.text];
@@ -117,7 +125,7 @@ class BpkFlatListItem extends React.PureComponent<FlatListItemProps> {
       >
         <View style={styles.content}>
           {styledImage}
-          <BpkText textStyle="base" style={textStyles}>
+          <BpkText textStyle="base" style={textStyles} {...titleProps}>
             {title}
           </BpkText>
         </View>

--- a/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.android.js.snap
@@ -313,6 +313,27 @@ exports[`Android BpkFlatListItem should support the "selected" property 1`] = `
 </View>
 `;
 
+exports[`Android should pass through titleProps to the title 1`] = `
+Object {
+  "children": "List item with pass through props",
+  "emphasize": null,
+  "numberOfLines": 7,
+  "style": Array [
+    Object {
+      "color": "rgb(17, 18, 54)",
+      "flex": 1,
+    },
+    Object {
+      "color": "rgb(17, 18, 54)",
+    },
+  ],
+  "testID": "ID_for_testing",
+  "textStyle": "base",
+  "theme": null,
+  "weight": "regular",
+}
+`;
+
 exports[`Android should support theming when selected 1`] = `
 <View
   accessibilityLabel="List item"

--- a/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
@@ -322,6 +322,23 @@ exports[`iOS BpkFlatListItem should support the "selected" property 1`] = `
 </View>
 `;
 
+exports[`iOS should pass through titleProps to the title 1`] = `
+Object {
+  "children": "List item with pass through props",
+  "emphasize": null,
+  "numberOfLines": 7,
+  "style": Array [
+    Object {
+      "flex": 1,
+    },
+  ],
+  "testID": "ID_for_testing",
+  "textStyle": "base",
+  "theme": null,
+  "weight": "regular",
+}
+`;
+
 exports[`iOS should support theming when selected 1`] = `
 <View
   accessibilityLabel="List item"

--- a/packages/react-native-bpk-component-flat-list/src/common-types.js
+++ b/packages/react-native-bpk-component-flat-list/src/common-types.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import { View, ViewPropTypes } from 'react-native';
 import { type Element, type ElementProps } from 'react';
 import { type Theme } from 'react-native-bpk-theming';
+import { type BpkTextProps } from 'react-native-bpk-component-text';
 
 import { themePropType } from './theming';
 
@@ -37,6 +38,7 @@ export type FlatListItemProps = {
   image: ?FlatListItemImage,
   style: ViewStyleProp,
   theme: ?Theme,
+  titleProps?: $Shape<BpkTextProps>,
 };
 
 export const LIST_ITEM_PROP_TYPES = {

--- a/packages/react-native-bpk-component-section-list/README.md
+++ b/packages/react-native-bpk-component-section-list/README.md
@@ -82,6 +82,7 @@ export default class App extends Component {
       title={airport.name}
       image={<Image source={require(FLAG_IMAGES[section.country])} />}
       onPress={this.getItemOnPressCallback(airportId)}
+      titleProps={{ numberOfLines: 1 }}
     />
   );
 
@@ -114,6 +115,7 @@ Inherits all props from React Native's [SectionList](https://facebook.github.io/
 | title              | string                                | true     | -             |
 | image              | instanceOf(Image)                     | false    | null          |
 | selected           | bool                                  | false    | false         |
+| titleProps         | object                                | false    | {}            |
 
 ### BpkSectionListHeader
 


### PR DESCRIPTION
`titleProps` takes an object of properties that will be passed to the underlying BpkText instance allowing for styling of the text component.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
