### PR TITLE
Reinstate failing badge test

### DIFF
--- a/packages/react-native-bpk-component-badge/src/BpkBadge-test.common.js
+++ b/packages/react-native-bpk-component-badge/src/BpkBadge-test.common.js
@@ -111,6 +111,19 @@ const commonTests = () => {
       expect(tree).toMatchSnapshot();
     });
 
+    it('should throw an error is an extraneous docked values is provided', () => {
+      jest.spyOn(console, 'error').mockImplementation(err => {
+        throw err;
+      });
+
+      expect(() => {
+        // Ignoring this false positive flow error.
+        // The test is asserting that our prop type works for non flow users.
+        // $FlowFixMe
+        renderer.create(generateBadgeStory({ docked: 'unknown' }));
+      }).toThrowError();
+    });
+
     it('should support theming', () => {
       const theme = {
         badgeSuccessBackgroundColor: 'blue',


### PR DESCRIPTION
I removed this test as it was preventing us shipping `withTheme(BpkBadge)`.
We should reinstate it and fix it at some point though, I guess 🤷‍♀ 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
