### PR TITLE
[NO JIRA]: Fixed nav stories to remove hack

### DIFF
--- a/packages/react-native-bpk-component-navigation-bar/stories.js
+++ b/packages/react-native-bpk-component-navigation-bar/stories.js
@@ -19,7 +19,7 @@
 /* @flow */
 
 import React from 'react';
-import { I18nManager, Platform, StyleSheet } from 'react-native';
+import { I18nManager, Platform } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import BpkThemeProvider from 'react-native-bpk-theming';
@@ -29,8 +29,6 @@ import BpkImage from 'react-native-bpk-component-image';
 
 import themeAttributes from '../../storybook/themeAttributes';
 
-import isIphoneX from './src/isIphoneX';
-
 import BpkNavigationBar, {
   BpkNavigationBarButtonAndroid,
   BpkNavigationBarBackButtonIOS,
@@ -39,20 +37,6 @@ import BpkNavigationBar, {
 } from './index';
 
 const exampleLogo = require('./logo.png');
-
-/*
-HACK
-On iOS, Storybook's UI covers the status bar which affects the appearance
-of the navigation bar. This pulls it upwards to counteract it.
-*/
-const IOS_STATUS_BAR_HEIGHT = isIphoneX ? 44 : 20;
-const styles = StyleSheet.create({
-  navigationBar: Platform.select({
-    ios: {
-      marginTop: -IOS_STATUS_BAR_HEIGHT,
-    },
-  }),
-});
 
 const backIcon = () =>
   I18nManager.isRTL ? 'native-android--forward' : 'native-android--back';
@@ -135,18 +119,13 @@ const textButton = Platform.select({
 
 storiesOf('react-native-bpk-component-navigation-bar', module)
   .add('docs:default', () => (
-    <BpkNavigationBar
-      leadingButton={backButton()}
-      title="Backpack"
-      style={styles.navigationBar}
-    />
+    <BpkNavigationBar leadingButton={backButton()} title="Backpack" />
   ))
   .add('docs:modal', () => (
     <BpkNavigationBar
       leadingButton={cancelButton()}
       trailingButton={doneButton()}
       title="Backpack"
-      style={styles.navigationBar}
     />
   ))
   .add('docs:primary-text-buttons', () => (
@@ -154,7 +133,6 @@ storiesOf('react-native-bpk-component-navigation-bar', module)
       leadingButton={textButton()}
       trailingButton={textButton()}
       title="Backpack"
-      style={styles.navigationBar}
     />
   ))
   .add('docs:subtitle-view', () => (
@@ -166,14 +144,12 @@ storiesOf('react-native-bpk-component-navigation-bar', module)
           <BpkText>Hello</BpkText>
         </BpkCard>
       }
-      style={styles.navigationBar}
     />
   ))
   .add('docs:icon-in-title', () => (
     <BpkNavigationBar
       leadingButton={backButton()}
       title={{ value: 'Checkout', icon: 'lock', iconPosition: 'leading' }}
-      style={styles.navigationBar}
     />
   ))
   .add('Themed', () => (
@@ -181,7 +157,6 @@ storiesOf('react-native-bpk-component-navigation-bar', module)
       <BpkNavigationBar
         leadingButton={backButton()}
         title={<BpkImage alt="logo" source={exampleLogo} />}
-        style={styles.navigationBar}
       />
     </BpkThemeProvider>
   ))
@@ -189,7 +164,6 @@ storiesOf('react-native-bpk-component-navigation-bar', module)
     <BpkNavigationBar
       leadingButton={backButton()}
       title="This is a very long title with a lot of content"
-      style={styles.navigationBar}
     />
   ))
   .add('Disabled button', () => (
@@ -197,13 +171,8 @@ storiesOf('react-native-bpk-component-navigation-bar', module)
       leadingButton={cancelButton()}
       trailingButton={doneButton(true)}
       title="Backpack"
-      style={styles.navigationBar}
     />
   ))
   .add('iOS icon button', () => (
-    <BpkNavigationBar
-      trailingButton={addButton()}
-      title="Backpack"
-      style={styles.navigationBar}
-    />
+    <BpkNavigationBar trailingButton={addButton()} title="Backpack" />
   ));


### PR DESCRIPTION
This PR removed the iOS hack that was previously introduced to fix a storybook issue with the UI and the header.

It seems in a newer version this issue is now fixed, therefore this PR removes the previous hack to now realign it.

Before:
![Screenshot 2019-10-02 at 15 08 50](https://user-images.githubusercontent.com/8831547/66051932-a4083f80-e527-11e9-8bb6-00012827d02a.png)

After:
![Screenshot 2019-10-02 at 15 09 05](https://user-images.githubusercontent.com/8831547/66051885-8dfa7f00-e527-11e9-91ea-7ee984a45ba2.png)
