### PR TITLE
[BPK-3082] Set BpkText maxfontsizemultiplier

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- react-native-bpk-component-text:
+  - Set `maxFontSizeMultiplier` to ensure RN screens still function at large zoom levels. Note that in the future this limitation will be removed, and screens will be expected to respond accordingly.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
+++ b/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
@@ -24,6 +24,7 @@ exports[`Android BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -51,6 +52,7 @@ exports[`Android BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -94,6 +96,7 @@ exports[`Android BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -121,6 +124,7 @@ exports[`Android BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -164,6 +168,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -180,6 +185,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -207,6 +213,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -223,6 +230,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -267,6 +275,7 @@ exports[`Android BpkAnimateHeight should render correctly with user styling padd
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -294,6 +303,7 @@ exports[`Android BpkAnimateHeight should render correctly with user styling padd
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
+++ b/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
@@ -24,6 +24,7 @@ exports[`iOS BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -51,6 +52,7 @@ exports[`iOS BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -94,6 +96,7 @@ exports[`iOS BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -121,6 +124,7 @@ exports[`iOS BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -164,6 +168,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -180,6 +185,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -207,6 +213,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -223,6 +230,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -267,6 +275,7 @@ exports[`iOS BpkAnimateHeight should render correctly with user styling padding 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -294,6 +303,7 @@ exports[`iOS BpkAnimateHeight should render correctly with user styling padding 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-badge/src/__snapshots__/BpkBadge-test.android.js.snap
+++ b/packages/react-native-bpk-component-badge/src/__snapshots__/BpkBadge-test.android.js.snap
@@ -37,6 +37,7 @@ exports[`Android BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -95,6 +96,7 @@ exports[`Android BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -153,6 +155,7 @@ exports[`Android BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -213,6 +216,7 @@ exports[`Android BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -271,6 +275,7 @@ exports[`Android BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -336,6 +341,7 @@ exports[`Android BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -401,6 +407,7 @@ exports[`Android BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -459,6 +466,7 @@ exports[`Android BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -517,6 +525,7 @@ exports[`Android BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -577,6 +586,7 @@ exports[`Android BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -635,6 +645,7 @@ exports[`Android BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -700,6 +711,7 @@ exports[`Android BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -757,6 +769,7 @@ exports[`Android BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -807,6 +820,7 @@ exports[`Android BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -857,6 +871,7 @@ exports[`Android BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -909,6 +924,7 @@ exports[`Android BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -959,6 +975,7 @@ exports[`Android BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1016,6 +1033,7 @@ exports[`Android BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1107,6 +1125,7 @@ exports[`Android BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1194,6 +1213,7 @@ exports[`Android BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1283,6 +1303,7 @@ exports[`Android BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1372,6 +1393,7 @@ exports[`Android BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1459,6 +1481,7 @@ exports[`Android BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1555,6 +1578,7 @@ exports[`Android BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1647,6 +1671,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1711,6 +1736,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1796,6 +1822,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1860,6 +1887,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1947,6 +1975,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2015,6 +2044,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2102,6 +2132,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2166,6 +2197,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2251,6 +2283,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2315,6 +2348,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2409,6 +2443,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2477,6 +2512,7 @@ exports[`Android BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2569,6 +2605,7 @@ exports[`Android BpkBadge should render correctly with multiple icons and no mes
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2691,6 +2728,7 @@ exports[`Android BpkBadge should render correctly with multiple icons and no mes
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2815,6 +2853,7 @@ exports[`Android BpkBadge should render correctly with multiple icons and no mes
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2941,6 +2980,7 @@ exports[`Android BpkBadge should render correctly with multiple icons and no mes
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3063,6 +3103,7 @@ exports[`Android BpkBadge should render correctly with multiple icons and no mes
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3194,6 +3235,7 @@ exports[`Android BpkBadge should render correctly with multiple icons and no mes
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3296,6 +3338,7 @@ exports[`Android BpkBadge should render correctly with user provided style 1`] =
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3349,6 +3392,7 @@ exports[`Android BpkBadge should render correctly with user provided style 1`] =
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3402,6 +3446,7 @@ exports[`Android BpkBadge should render correctly with user provided style 1`] =
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3457,6 +3502,7 @@ exports[`Android BpkBadge should render correctly with user provided style 1`] =
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3510,6 +3556,7 @@ exports[`Android BpkBadge should render correctly with user provided style 1`] =
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3570,6 +3617,7 @@ exports[`Android BpkBadge should render correctly with user provided style 1`] =
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3630,6 +3678,7 @@ exports[`Android BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3689,6 +3738,7 @@ exports[`Android BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3748,6 +3798,7 @@ exports[`Android BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3806,6 +3857,7 @@ exports[`Android BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3859,6 +3911,7 @@ exports[`Android BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3919,6 +3972,7 @@ exports[`Android BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-badge/src/__snapshots__/BpkBadge-test.ios.js.snap
+++ b/packages/react-native-bpk-component-badge/src/__snapshots__/BpkBadge-test.ios.js.snap
@@ -37,6 +37,7 @@ exports[`iOS BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -95,6 +96,7 @@ exports[`iOS BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -153,6 +155,7 @@ exports[`iOS BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -213,6 +216,7 @@ exports[`iOS BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -271,6 +275,7 @@ exports[`iOS BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -336,6 +341,7 @@ exports[`iOS BpkBadge should render correctly docked to the end 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -401,6 +407,7 @@ exports[`iOS BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -459,6 +466,7 @@ exports[`iOS BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -517,6 +525,7 @@ exports[`iOS BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -577,6 +586,7 @@ exports[`iOS BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -635,6 +645,7 @@ exports[`iOS BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -700,6 +711,7 @@ exports[`iOS BpkBadge should render correctly docked to the start 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -757,6 +769,7 @@ exports[`iOS BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -807,6 +820,7 @@ exports[`iOS BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -857,6 +871,7 @@ exports[`iOS BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -909,6 +924,7 @@ exports[`iOS BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -959,6 +975,7 @@ exports[`iOS BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1016,6 +1033,7 @@ exports[`iOS BpkBadge should render correctly in normal mode 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1107,6 +1125,7 @@ exports[`iOS BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1194,6 +1213,7 @@ exports[`iOS BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1283,6 +1303,7 @@ exports[`iOS BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1372,6 +1393,7 @@ exports[`iOS BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1459,6 +1481,7 @@ exports[`iOS BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1555,6 +1578,7 @@ exports[`iOS BpkBadge should render correctly with icon 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1647,6 +1671,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1711,6 +1736,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1796,6 +1822,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1860,6 +1887,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1947,6 +1975,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2015,6 +2044,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2102,6 +2132,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2166,6 +2197,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2251,6 +2283,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2315,6 +2348,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2409,6 +2443,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2477,6 +2512,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons 1`] = `
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2569,6 +2605,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons and no message
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2691,6 +2728,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons and no message
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2815,6 +2853,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons and no message
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2941,6 +2980,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons and no message
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3063,6 +3103,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons and no message
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3194,6 +3235,7 @@ exports[`iOS BpkBadge should render correctly with multiple icons and no message
     </Text>
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3296,6 +3338,7 @@ exports[`iOS BpkBadge should render correctly with user provided style 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3349,6 +3392,7 @@ exports[`iOS BpkBadge should render correctly with user provided style 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3402,6 +3446,7 @@ exports[`iOS BpkBadge should render correctly with user provided style 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3457,6 +3502,7 @@ exports[`iOS BpkBadge should render correctly with user provided style 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3510,6 +3556,7 @@ exports[`iOS BpkBadge should render correctly with user provided style 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3570,6 +3617,7 @@ exports[`iOS BpkBadge should render correctly with user provided style 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3630,6 +3678,7 @@ exports[`iOS BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3689,6 +3738,7 @@ exports[`iOS BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3748,6 +3798,7 @@ exports[`iOS BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3806,6 +3857,7 @@ exports[`iOS BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3859,6 +3911,7 @@ exports[`iOS BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -3919,6 +3972,7 @@ exports[`iOS BpkBadge should support theming 1`] = `
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.android.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.android.js.snap
@@ -25,6 +25,7 @@ exports[`Android AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -49,6 +50,7 @@ exports[`Android AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -93,6 +95,7 @@ exports[`Android AnimateAndFade should render correctly when show is false 1`] =
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -117,6 +120,7 @@ exports[`Android AnimateAndFade should render correctly when show is false 1`] =
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -161,6 +165,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnEnter 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -185,6 +190,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnEnter 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -229,6 +235,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnLeave 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -253,6 +260,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnLeave 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.ios.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.ios.js.snap
@@ -25,6 +25,7 @@ exports[`iOS AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -49,6 +50,7 @@ exports[`iOS AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -93,6 +95,7 @@ exports[`iOS AnimateAndFade should render correctly when show is false 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -117,6 +120,7 @@ exports[`iOS AnimateAndFade should render correctly when show is false 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -161,6 +165,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnEnter 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -185,6 +190,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnEnter 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -229,6 +235,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnLeave 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -253,6 +260,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnLeave 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -75,6 +75,7 @@ exports[`Android BpkBannerAlert should accept userland styling 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -153,6 +154,7 @@ exports[`Android BpkBannerAlert should accept userland styling 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -251,6 +253,7 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -329,6 +332,7 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -427,6 +431,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -505,6 +510,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -603,6 +609,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -681,6 +688,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -798,6 +806,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -864,6 +873,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -894,6 +904,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -989,6 +1000,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1055,6 +1067,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1085,6 +1098,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1181,6 +1195,7 @@ exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1233,6 +1248,7 @@ exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
             }
           >
             <Text
+              maxFontSizeMultiplier={3.2}
               numberOfLines={1}
               style={
                 Array [
@@ -1318,6 +1334,7 @@ exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1370,6 +1387,7 @@ exports[`Android BpkBannerAlert should render correctly with dismissable 1`] = `
             }
           >
             <Text
+              maxFontSizeMultiplier={3.2}
               numberOfLines={1}
               style={
                 Array [
@@ -1494,6 +1512,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1560,6 +1579,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1590,6 +1610,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1685,6 +1706,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1751,6 +1773,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1781,6 +1804,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1877,6 +1901,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to error
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1955,6 +1980,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to error
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2053,6 +2079,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to neutr
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2131,6 +2158,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to neutr
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2229,6 +2257,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to succe
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2307,6 +2336,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to succe
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2405,6 +2435,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to warn 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2483,6 +2514,7 @@ exports[`Android BpkBannerAlert should render correctly with type equal to warn 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -77,6 +77,7 @@ exports[`iOS BpkBannerAlert should accept userland styling 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -157,6 +158,7 @@ exports[`iOS BpkBannerAlert should accept userland styling 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -257,6 +259,7 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -337,6 +340,7 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -437,6 +441,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -517,6 +522,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -617,6 +623,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -697,6 +704,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -808,6 +816,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -890,6 +899,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -920,6 +930,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1009,6 +1020,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1091,6 +1103,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1121,6 +1134,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1222,6 +1236,7 @@ exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1361,6 +1376,7 @@ exports[`iOS BpkBannerAlert should render correctly with dismissable 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1528,6 +1544,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1610,6 +1627,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1640,6 +1658,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1729,6 +1748,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1811,6 +1831,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1841,6 +1862,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1939,6 +1961,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to error 1`]
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2019,6 +2042,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to error 1`]
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2119,6 +2143,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to neutral 1
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2199,6 +2224,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to neutral 1
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2299,6 +2325,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to success 1
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2379,6 +2406,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to success 1
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2479,6 +2507,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to warn 1`] 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -2559,6 +2588,7 @@ exports[`iOS BpkBannerAlert should render correctly with type equal to warn 1`] 
           
         </Text>
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {

--- a/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.android.js.snap
+++ b/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.android.js.snap
@@ -45,6 +45,7 @@ exports[`Android BpkButtonLink should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -120,6 +121,7 @@ exports[`Android BpkButtonLink should render correctly with iconAlignment="leadi
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -220,6 +222,7 @@ exports[`Android BpkButtonLink should render correctly with iconAlignment="trail
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -317,6 +320,7 @@ exports[`Android BpkButtonLink should render correctly with text props provided 
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -389,6 +393,7 @@ exports[`Android BpkButtonLink should render correctly with theme prop 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -464,6 +469,7 @@ exports[`Android BpkButtonLink should support elements as icons 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -488,6 +494,7 @@ exports[`Android BpkButtonLink should support elements as icons 1`] = `
       LOREM IPSUM
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -554,6 +561,7 @@ exports[`Android BpkButtonLink should support overwriting styles 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -630,6 +638,7 @@ exports[`Android BpkButtonLink should support the "disabled" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -705,6 +714,7 @@ exports[`Android BpkButtonLink should support the "icon" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -801,6 +811,7 @@ exports[`Android should support "borderlessBackground" equal to false 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -873,6 +884,7 @@ exports[`Android should support "uppercase" equal to false 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [

--- a/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.ios.js.snap
+++ b/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.ios.js.snap
@@ -34,6 +34,7 @@ exports[`iOS BpkButtonLink should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -98,6 +99,7 @@ exports[`iOS BpkButtonLink should render correctly with iconAlignment="leading" 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -187,6 +189,7 @@ exports[`iOS BpkButtonLink should render correctly with iconAlignment="trailing"
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -273,6 +276,7 @@ exports[`iOS BpkButtonLink should render correctly with text props provided 1`] 
   >
     <Text
       allowFontScaling={false}
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -334,6 +338,7 @@ exports[`iOS BpkButtonLink should render correctly with theme prop 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -398,6 +403,7 @@ exports[`iOS BpkButtonLink should support elements as icons 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -422,6 +428,7 @@ exports[`iOS BpkButtonLink should support elements as icons 1`] = `
       Lorem ipsum
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -476,6 +483,7 @@ exports[`iOS BpkButtonLink should support overwriting styles 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -541,6 +549,7 @@ exports[`iOS BpkButtonLink should support the "disabled" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -605,6 +614,7 @@ exports[`iOS BpkButtonLink should support the "icon" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -693,6 +703,7 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [
@@ -778,6 +789,7 @@ exports[`iOS should support the "large" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
         Array [

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -54,6 +54,7 @@ exports[`Android API levels Android API<21 should render without ripple 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -138,6 +139,7 @@ exports[`Android API levels Android API>=21 should render with ripple 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -222,6 +224,7 @@ exports[`Android BpkButton should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -329,6 +332,7 @@ exports[`Android BpkButton should render correctly with iconAlignment="leading" 
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -443,6 +447,7 @@ exports[`Android BpkButton should render correctly with iconAlignment="trailing"
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -529,6 +534,7 @@ exports[`Android BpkButton should render correctly with type="destructive" 1`] =
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -619,6 +625,7 @@ exports[`Android BpkButton should render correctly with type="destructive" and d
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -703,6 +710,7 @@ exports[`Android BpkButton should render correctly with type="featured" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -794,6 +802,7 @@ exports[`Android BpkButton should render correctly with type="featured" and disa
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -878,6 +887,7 @@ exports[`Android BpkButton should render correctly with type="primary" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -969,6 +979,7 @@ exports[`Android BpkButton should render correctly with type="primary" and disab
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1055,6 +1066,7 @@ exports[`Android BpkButton should render correctly with type="secondary" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1145,6 +1157,7 @@ exports[`Android BpkButton should render correctly with type="secondary" and dis
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1232,6 +1245,7 @@ exports[`Android BpkButton should support elements as icons 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1355,6 +1369,7 @@ exports[`Android BpkButton should support having an icon as well as a title 1`] 
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1442,6 +1457,7 @@ exports[`Android BpkButton should support overwriting styles 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1533,6 +1549,7 @@ exports[`Android BpkButton should support the "disabled" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1647,6 +1664,7 @@ exports[`Android BpkButton should support the "icon" property 1`] = `
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1828,6 +1846,7 @@ exports[`Android BpkButton should support the "secondary" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2007,6 +2026,7 @@ exports[`Android BpkButtonThemed should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -43,6 +43,7 @@ exports[`iOS BpkButton should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -152,6 +153,7 @@ exports[`iOS BpkButton should render correctly with iconAlignment="leading" 1`] 
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -268,6 +270,7 @@ exports[`iOS BpkButton should render correctly with iconAlignment="trailing" 1`]
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -351,6 +354,7 @@ exports[`iOS BpkButton should render correctly with type="destructive" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -442,6 +446,7 @@ exports[`iOS BpkButton should render correctly with type="destructive" and disab
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -532,6 +537,7 @@ exports[`iOS BpkButton should render correctly with type="featured" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -622,6 +628,7 @@ exports[`iOS BpkButton should render correctly with type="featured" and disabled
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -708,6 +715,7 @@ exports[`iOS BpkButton should render correctly with type="primary" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -798,6 +806,7 @@ exports[`iOS BpkButton should render correctly with type="primary" and disabled 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -881,6 +890,7 @@ exports[`iOS BpkButton should render correctly with type="secondary" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -972,6 +982,7 @@ exports[`iOS BpkButton should render correctly with type="secondary" and disable
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1065,6 +1076,7 @@ exports[`iOS BpkButton should support elements as icons 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1195,6 +1207,7 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1285,6 +1298,7 @@ exports[`iOS BpkButton should support overwriting styles 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1375,6 +1389,7 @@ exports[`iOS BpkButton should support the "disabled" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1491,6 +1506,7 @@ exports[`iOS BpkButton should support the "icon" property 1`] = `
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1676,6 +1692,7 @@ exports[`iOS BpkButton should support the "secondary" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1868,6 +1885,7 @@ exports[`iOS BpkButtonThemed should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -1984,6 +2002,7 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
       
     </Text>
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2172,6 +2191,7 @@ exports[`iOS should support the "large" and secondary property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -2265,6 +2285,7 @@ exports[`iOS should support the "large" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
@@ -41,6 +41,7 @@ exports[`Android BpkCard should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -104,6 +105,7 @@ exports[`Android BpkCard should render correctly when "cornerStyle=large" 1`] = 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -165,6 +167,7 @@ exports[`Android BpkCard should render correctly with arbitrary props 1`] = `
     testID="arbitrary value"
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -228,6 +231,7 @@ exports[`Android BpkCard should render correctly with custom inner style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -291,6 +295,7 @@ exports[`Android BpkCard should render correctly with custom style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -354,6 +359,7 @@ exports[`Android BpkCard should render correctly with the "focused" state 1`] = 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -408,6 +414,7 @@ exports[`Android BpkCard should render correctly without padding 1`] = `
     style={Array []}
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
@@ -42,6 +42,7 @@ exports[`iOS BpkCard should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -125,6 +126,7 @@ exports[`iOS BpkCard should render correctly when "cornerStyle=large" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -206,6 +208,7 @@ exports[`iOS BpkCard should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -289,6 +292,7 @@ exports[`iOS BpkCard should render correctly with custom inner style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -372,6 +376,7 @@ exports[`iOS BpkCard should render correctly with custom style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -461,6 +466,7 @@ exports[`iOS BpkCard should render correctly with the "focused" state 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -538,6 +544,7 @@ exports[`iOS BpkCard should render correctly without padding 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.android.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.android.js.snap
@@ -55,6 +55,7 @@ exports[`Android withDivider should render correctly 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -97,6 +98,7 @@ exports[`Android withDivider should render correctly 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -175,6 +177,7 @@ exports[`Android withDivider should render correctly with "cornerStyle=large" 1`
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -217,6 +220,7 @@ exports[`Android withDivider should render correctly with "cornerStyle=large" 1`
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -293,6 +297,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -335,6 +340,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -413,6 +419,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -455,6 +462,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -530,6 +538,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -575,6 +584,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -647,6 +657,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -686,6 +697,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {

--- a/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.ios.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.ios.js.snap
@@ -56,6 +56,7 @@ exports[`iOS withDivider should render correctly 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -98,6 +99,7 @@ exports[`iOS withDivider should render correctly 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -196,6 +198,7 @@ exports[`iOS withDivider should render correctly with "cornerStyle=large" 1`] = 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -238,6 +241,7 @@ exports[`iOS withDivider should render correctly with "cornerStyle=large" 1`] = 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -334,6 +338,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -376,6 +381,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -474,6 +480,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -516,6 +523,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -611,6 +619,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -656,6 +665,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -748,6 +758,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -787,6 +798,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {

--- a/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.android.js.snap
@@ -11,6 +11,7 @@ exports[`Android BpkCarouselItem should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.ios.js.snap
@@ -11,6 +11,7 @@ exports[`IOS BpkCarouselItem should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.android.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.android.js.snap
@@ -48,6 +48,7 @@ exports[`Android BpkChip should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -124,6 +125,7 @@ exports[`Android BpkChip should render correctly with "disabled" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -203,6 +205,7 @@ exports[`Android BpkChip should render correctly with "selected" 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -280,6 +283,7 @@ exports[`Android BpkChip should render correctly with arbitrary props 1`] = `
     testID="123"
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -357,6 +361,7 @@ exports[`Android BpkChip should render correctly with custom style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -440,6 +445,7 @@ exports[`Android BpkChip should render outline correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -522,6 +528,7 @@ exports[`Android BpkChip should support theming when selected 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.ios.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.ios.js.snap
@@ -39,6 +39,7 @@ exports[`iOS BpkChip should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -124,6 +125,7 @@ exports[`iOS BpkChip should render correctly with "disabled" 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -216,6 +218,7 @@ exports[`iOS BpkChip should render correctly with "selected" 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -302,6 +305,7 @@ exports[`iOS BpkChip should render correctly with arbitrary props 1`] = `
   testID="123"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -388,6 +392,7 @@ exports[`iOS BpkChip should render correctly with custom style 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -480,6 +485,7 @@ exports[`iOS BpkChip should render outline correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -575,6 +581,7 @@ exports[`iOS BpkChip should support theming when selected 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.android.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.android.js.snap
@@ -48,6 +48,7 @@ exports[`Android BpkDismissibleChip should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -149,6 +150,7 @@ exports[`Android BpkDismissibleChip should render correctly with "disabled" 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -254,6 +256,7 @@ exports[`Android BpkDismissibleChip should render correctly with arbitrary props
     testID="123"
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -359,6 +362,7 @@ exports[`Android BpkDismissibleChip should render correctly with custom style 1`
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -467,6 +471,7 @@ exports[`Android BpkDismissibleChip should render outline correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.ios.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.ios.js.snap
@@ -39,6 +39,7 @@ exports[`iOS BpkDismissibleChip should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -149,6 +150,7 @@ exports[`iOS BpkDismissibleChip should render correctly with "disabled" 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -263,6 +265,7 @@ exports[`iOS BpkDismissibleChip should render correctly with arbitrary props 1`]
   testID="123"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -377,6 +380,7 @@ exports[`iOS BpkDismissibleChip should render correctly with custom style 1`] = 
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -494,6 +498,7 @@ exports[`iOS BpkDismissibleChip should render outline correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.android.js.snap
@@ -42,6 +42,7 @@ exports[`Android BpkFlatListItem should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -147,6 +148,7 @@ exports[`Android BpkFlatListItem should support the "image" property 1`] = `
       }
     />
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -242,6 +244,7 @@ exports[`Android BpkFlatListItem should support the "selected" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -364,6 +367,7 @@ exports[`Android should support theming when selected 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
@@ -38,6 +38,7 @@ exports[`iOS BpkFlatListItem should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -150,6 +151,7 @@ exports[`iOS BpkFlatListItem should support the "image" property 1`] = `
       }
     />
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -252,6 +254,7 @@ exports[`iOS BpkFlatListItem should support the "selected" property 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -377,6 +380,7 @@ exports[`iOS should support theming when selected 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
@@ -32,6 +32,7 @@ exports[`Android BpkHorizontalNavItem should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -88,6 +89,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with "selected" pr
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -150,6 +152,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with "small" prop 
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -206,6 +209,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with "spaceAround"
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -262,6 +266,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with arbitrary pro
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -321,6 +326,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with custom "style
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -377,6 +383,7 @@ exports[`Android BpkHorizontalNavItem should support theming 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
@@ -27,6 +27,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -95,6 +96,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "selected" prop 1
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -169,6 +171,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "small" prop 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -237,6 +240,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "spaceAround" pro
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -305,6 +309,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with arbitrary props 1
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -376,6 +381,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with custom "style" pr
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -444,6 +450,7 @@ exports[`iOS BpkHorizontalNavItem should support theming 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-iphone-x-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-iphone-x-test.ios.js.snap
@@ -81,6 +81,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly 1`] = `
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -132,6 +133,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly 1`] = `
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -225,6 +227,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly with trailing 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -276,6 +279,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly with trailing 
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -327,6 +331,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly with trailing 
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.android.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.android.js.snap
@@ -99,6 +99,7 @@ exports[`android BpkNavigationBar should render correctly 1`] = `
       <Text
         allowFontScaling={false}
         ellipsizeMode="tail"
+        maxFontSizeMultiplier={3.2}
         numberOfLines={1}
         style={
           Array [
@@ -230,6 +231,7 @@ exports[`android BpkNavigationBar should render correctly with a subtitle view 1
       <Text
         allowFontScaling={false}
         ellipsizeMode="tail"
+        maxFontSizeMultiplier={3.2}
         numberOfLines={1}
         style={
           Array [
@@ -504,6 +506,7 @@ exports[`android BpkNavigationBar should render correctly with an icon in the ti
       <Text
         allowFontScaling={false}
         ellipsizeMode="tail"
+        maxFontSizeMultiplier={3.2}
         numberOfLines={1}
         style={
           Array [
@@ -637,6 +640,7 @@ exports[`android BpkNavigationBar should render correctly with custom style 1`] 
       <Text
         allowFontScaling={false}
         ellipsizeMode="tail"
+        maxFontSizeMultiplier={3.2}
         numberOfLines={1}
         style={
           Array [
@@ -768,6 +772,7 @@ exports[`android BpkNavigationBar should render correctly with custom theme 1`] 
       <Text
         allowFontScaling={false}
         ellipsizeMode="tail"
+        maxFontSizeMultiplier={3.2}
         numberOfLines={1}
         style={
           Array [
@@ -896,6 +901,7 @@ exports[`android BpkNavigationBar should render correctly with trailing button 1
       <Text
         allowFontScaling={false}
         ellipsizeMode="tail"
+        maxFontSizeMultiplier={3.2}
         numberOfLines={1}
         style={
           Array [

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.ios.js.snap
@@ -78,6 +78,7 @@ exports[`ios BpkNavigationBar should render correctly 1`] = `
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -129,6 +130,7 @@ exports[`ios BpkNavigationBar should render correctly 1`] = `
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -240,6 +242,7 @@ exports[`ios BpkNavigationBar should render correctly with a subtitle view 1`] =
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -291,6 +294,7 @@ exports[`ios BpkNavigationBar should render correctly with a subtitle view 1`] =
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -410,6 +414,7 @@ exports[`ios BpkNavigationBar should render correctly with a title view 1`] = `
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -539,6 +544,7 @@ exports[`ios BpkNavigationBar should render correctly with an icon in the title 
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -616,6 +622,7 @@ exports[`ios BpkNavigationBar should render correctly with an icon in the title 
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -729,6 +736,7 @@ exports[`ios BpkNavigationBar should render correctly with custom style 1`] = `
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -780,6 +788,7 @@ exports[`ios BpkNavigationBar should render correctly with custom style 1`] = `
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -870,6 +879,7 @@ exports[`ios BpkNavigationBar should render correctly with trailing button 1`] =
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -921,6 +931,7 @@ exports[`ios BpkNavigationBar should render correctly with trailing button 1`] =
         <Text
           allowFontScaling={false}
           ellipsizeMode="tail"
+          maxFontSizeMultiplier={3.2}
           numberOfLines={1}
           style={
             Array [
@@ -972,6 +983,7 @@ exports[`ios BpkNavigationBar should render correctly with trailing button 1`] =
       }
     >
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarBackButtonIOS-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarBackButtonIOS-test.ios.js.snap
@@ -90,6 +90,7 @@ exports[`iOS BpkNavigationBarBackButtonIOS should render correctly with title 1`
     }
   />
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarTextButtonIOS-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarTextButtonIOS-test.ios.js.snap
@@ -26,6 +26,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -79,6 +80,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly disabled 1`] 
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -128,6 +130,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly emphasize 1`]
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -179,6 +182,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly leading confi
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -228,6 +232,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly with type="pr
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -281,6 +286,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly with type="pr
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -334,6 +340,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "disabledTintColor" ov
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -383,6 +390,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "primaryTintColor" ove
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -432,6 +440,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "tintColor" over "prim
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -481,6 +490,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "tintColor" over "type
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.android.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.android.js.snap
@@ -41,6 +41,7 @@ exports[`android TitleView should render correctly with leading icon 1`] = `
   <Text
     allowFontScaling={false}
     ellipsizeMode="tail"
+    maxFontSizeMultiplier={3.2}
     numberOfLines={1}
     style={
       Array [
@@ -85,6 +86,7 @@ exports[`android TitleView should render correctly with only a title 1`] = `
   <Text
     allowFontScaling={false}
     ellipsizeMode="tail"
+    maxFontSizeMultiplier={3.2}
     numberOfLines={1}
     style={
       Array [
@@ -127,6 +129,7 @@ exports[`android TitleView should render correctly with trailing icon 1`] = `
   <Text
     allowFontScaling={false}
     ellipsizeMode="tail"
+    maxFontSizeMultiplier={3.2}
     numberOfLines={1}
     style={
       Array [

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/TitleView-test.ios.js.snap
@@ -41,6 +41,7 @@ exports[`ios TitleView should render correctly with leading icon 1`] = `
   <Text
     allowFontScaling={false}
     ellipsizeMode="tail"
+    maxFontSizeMultiplier={3.2}
     numberOfLines={1}
     style={
       Array [
@@ -85,6 +86,7 @@ exports[`ios TitleView should render correctly with only a title 1`] = `
   <Text
     allowFontScaling={false}
     ellipsizeMode="tail"
+    maxFontSizeMultiplier={3.2}
     numberOfLines={1}
     style={
       Array [
@@ -127,6 +129,7 @@ exports[`ios TitleView should render correctly with trailing icon 1`] = `
   <Text
     allowFontScaling={false}
     ellipsizeMode="tail"
+    maxFontSizeMultiplier={3.2}
     numberOfLines={1}
     style={
       Array [

--- a/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
+++ b/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
@@ -110,6 +110,7 @@ exports[`Android BpkNudger should render correctly 1`] = `
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -345,6 +346,7 @@ exports[`Android BpkNudger should render correctly when value is a not an intege
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -576,6 +578,7 @@ exports[`Android BpkNudger should render correctly when value is greater than ma
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -815,6 +818,7 @@ exports[`Android BpkNudger should render correctly when value is less than min 1
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
+++ b/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
@@ -117,6 +117,7 @@ exports[`iOS BpkNudger should render correctly 1`] = `
     />
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -366,6 +367,7 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
     />
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -611,6 +613,7 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
     />
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -864,6 +867,7 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
     />
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.android.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.android.js.snap
@@ -17,6 +17,7 @@ exports[`Android BpkPanel should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -53,6 +54,7 @@ exports[`Android BpkPanel should render correctly with arbitrary props 1`] = `
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -91,6 +93,7 @@ exports[`Android BpkPanel should render correctly with custom style 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -123,6 +126,7 @@ exports[`Android BpkPanel should render correctly without padding 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.ios.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.ios.js.snap
@@ -17,6 +17,7 @@ exports[`iOS BpkPanel should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -53,6 +54,7 @@ exports[`iOS BpkPanel should render correctly with arbitrary props 1`] = `
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -91,6 +93,7 @@ exports[`iOS BpkPanel should render correctly with custom style 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -123,6 +126,7 @@ exports[`iOS BpkPanel should render correctly without padding 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.android.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.android.js.snap
@@ -34,6 +34,7 @@ exports[`Android withDivider should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -74,6 +75,7 @@ exports[`Android withDivider should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -128,6 +130,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -168,6 +171,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -224,6 +228,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -264,6 +269,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -317,6 +323,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -360,6 +367,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -407,6 +415,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -444,6 +453,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.ios.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.ios.js.snap
@@ -34,6 +34,7 @@ exports[`iOS withDivider should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -74,6 +75,7 @@ exports[`iOS withDivider should render correctly 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -128,6 +130,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -168,6 +171,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -224,6 +228,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -264,6 +269,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -317,6 +323,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -360,6 +367,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -407,6 +415,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -444,6 +453,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
@@ -109,6 +109,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -244,6 +245,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -379,6 +381,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -555,6 +558,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -696,6 +700,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -831,6 +836,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
@@ -113,6 +113,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         }
       >
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -197,6 +198,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -278,6 +280,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         }
       >
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -362,6 +365,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -443,6 +447,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         }
       >
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -527,6 +532,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -711,6 +717,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         }
       >
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -795,6 +802,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -882,6 +890,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         }
       >
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -966,6 +975,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {
@@ -1047,6 +1057,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         }
       >
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -1131,6 +1142,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
             }
           />
           <Text
+            maxFontSizeMultiplier={3.2}
             style={
               Array [
                 Object {

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
@@ -80,6 +80,7 @@ exports[`Android BpkPhoneNumberInput should render correctly 1`] = `
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {
@@ -251,6 +252,7 @@ exports[`Android BpkPhoneNumberInput should render correctly with \`editable\` f
         }
       />
       <Text
+        maxFontSizeMultiplier={3.2}
         style={
           Array [
             Object {

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
@@ -79,6 +79,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly 1`] = `
           }
         />
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {
@@ -266,6 +267,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly with \`editable\` false
           }
         />
         <Text
+          maxFontSizeMultiplier={3.2}
           style={
             Array [
               Object {

--- a/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
+++ b/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
@@ -127,6 +127,7 @@ exports[`Android BpkPicker should render correctly 1`] = `
             }
           >
             <Text
+              maxFontSizeMultiplier={3.2}
               style={
                 Array [
                   Object {
@@ -176,6 +177,7 @@ exports[`Android BpkPicker should render correctly 1`] = `
             }
           >
             <Text
+              maxFontSizeMultiplier={3.2}
               style={
                 Array [
                   Object {
@@ -331,6 +333,7 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
             }
           >
             <Text
+              maxFontSizeMultiplier={3.2}
               style={
                 Array [
                   Object {
@@ -382,6 +385,7 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
             }
           >
             <Text
+              maxFontSizeMultiplier={3.2}
               style={
                 Array [
                   Object {

--- a/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.ios.js.snap
+++ b/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.ios.js.snap
@@ -89,6 +89,7 @@ exports[`iOS BpkPicker should render correctly 1`] = `
         >
           <Text
             allowFontScaling={false}
+            maxFontSizeMultiplier={3.2}
             numberOfLines={1}
             style={
               Array [
@@ -237,6 +238,7 @@ exports[`iOS BpkPicker should render correctly with a selected value 1`] = `
         >
           <Text
             allowFontScaling={false}
+            maxFontSizeMultiplier={3.2}
             numberOfLines={1}
             style={
               Array [

--- a/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
@@ -29,6 +29,7 @@ exports[`Android BpkPickerItem should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -77,6 +78,7 @@ exports[`Android BpkPickerItem should render correctly with an onPress function 
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -129,6 +131,7 @@ exports[`Android BpkPickerItem should render correctly with the selected prop 1`
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.android.js.snap
+++ b/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.android.js.snap
@@ -15,6 +15,7 @@ exports[`Android BpkSectionListHeader should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.ios.js.snap
+++ b/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.ios.js.snap
@@ -11,6 +11,7 @@ exports[`iOS BpkSectionListHeader should render correctly 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.android.js.snap
+++ b/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.android.js.snap
@@ -375,6 +375,7 @@ exports[`Android BpkSelect should render correctly with "valid" false and a vali
     </Text>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -516,6 +517,7 @@ exports[`Android BpkSelect should render correctly with a text label 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -655,6 +657,7 @@ exports[`Android BpkSelect should render correctly with custom styles 1`] = `
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -739,6 +742,7 @@ exports[`Android BpkSelect should render correctly with the disabled prop 1`] = 
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.ios.js.snap
+++ b/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.ios.js.snap
@@ -435,6 +435,7 @@ exports[`iOS BpkSelect should render correctly with "valid" false and a validati
     />
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -583,6 +584,7 @@ exports[`iOS BpkSelect should render correctly with a text label 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -750,6 +752,7 @@ exports[`iOS BpkSelect should render correctly with custom styles 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {
@@ -846,6 +849,7 @@ exports[`iOS BpkSelect should render correctly with the disabled prop 1`] = `
     }
   >
     <Text
+      maxFontSizeMultiplier={3.2}
       style={
         Array [
           Object {

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -437,6 +437,7 @@ exports[`RTL BpkTextInput should render correctly with description 1`] = `
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -556,6 +557,7 @@ exports[`RTL BpkTextInput should render correctly with description, valid=false 
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -1161,6 +1163,7 @@ exports[`RTL BpkTextInput should render correctly with valid false and a validat
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -437,6 +437,7 @@ exports[`Android BpkTextInput should render correctly with description 1`] = `
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -556,6 +557,7 @@ exports[`Android BpkTextInput should render correctly with description, valid=fa
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -1161,6 +1163,7 @@ exports[`Android BpkTextInput should render correctly with valid false and a val
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -437,6 +437,7 @@ exports[`iOS BpkTextInput should render correctly with description 1`] = `
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -556,6 +557,7 @@ exports[`iOS BpkTextInput should render correctly with description, valid=false 
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -1161,6 +1163,7 @@ exports[`iOS BpkTextInput should render correctly with valid false and a validat
     </View>
   </View>
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -212,7 +212,7 @@ const BpkText = (props: Props) => {
 
   return (
     // eslint-disable-next-line backpack/use-components
-    <Text style={style} {...rest}>
+    <Text style={style} maxFontSizeMultiplier={3.2} {...rest}>
       {children}
     </Text>
   );

--- a/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.android.js.snap
+++ b/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.android.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Android BpkText should ignore weight prop if deprecated \`emphasize\` prop is being used 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -23,6 +24,7 @@ exports[`Android BpkText should ignore weight prop if deprecated \`emphasize\` p
 
 exports[`Android BpkText should render correctly 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -42,6 +44,7 @@ exports[`Android BpkText should render correctly 1`] = `
 
 exports[`Android BpkText should render correctly with deprecated \`emphasize\` prop 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -63,6 +66,7 @@ exports[`Android BpkText should render correctly with deprecated \`emphasize\` p
 
 exports[`Android BpkText should render correctly with textStyle="base and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -84,6 +88,7 @@ exports[`Android BpkText should render correctly with textStyle="base and weight
 
 exports[`Android BpkText should render correctly with textStyle="base" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -103,6 +108,7 @@ exports[`Android BpkText should render correctly with textStyle="base" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="caps and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -124,6 +130,7 @@ exports[`Android BpkText should render correctly with textStyle="caps and weight
 
 exports[`Android BpkText should render correctly with textStyle="caps" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -143,6 +150,7 @@ exports[`Android BpkText should render correctly with textStyle="caps" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="lg and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -164,6 +172,7 @@ exports[`Android BpkText should render correctly with textStyle="lg and weight="
 
 exports[`Android BpkText should render correctly with textStyle="lg" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -183,6 +192,7 @@ exports[`Android BpkText should render correctly with textStyle="lg" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="sm and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -204,6 +214,7 @@ exports[`Android BpkText should render correctly with textStyle="sm and weight="
 
 exports[`Android BpkText should render correctly with textStyle="sm" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -223,6 +234,7 @@ exports[`Android BpkText should render correctly with textStyle="sm" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xl and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -244,6 +256,7 @@ exports[`Android BpkText should render correctly with textStyle="xl and weight="
 
 exports[`Android BpkText should render correctly with textStyle="xl and weight="heavy" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -265,6 +278,7 @@ exports[`Android BpkText should render correctly with textStyle="xl and weight="
 
 exports[`Android BpkText should render correctly with textStyle="xl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -284,6 +298,7 @@ exports[`Android BpkText should render correctly with textStyle="xl" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xs and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -305,6 +320,7 @@ exports[`Android BpkText should render correctly with textStyle="xs and weight="
 
 exports[`Android BpkText should render correctly with textStyle="xs" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -324,6 +340,7 @@ exports[`Android BpkText should render correctly with textStyle="xs" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xxl and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -345,6 +362,7 @@ exports[`Android BpkText should render correctly with textStyle="xxl and weight=
 
 exports[`Android BpkText should render correctly with textStyle="xxl and weight="heavy" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -366,6 +384,7 @@ exports[`Android BpkText should render correctly with textStyle="xxl and weight=
 
 exports[`Android BpkText should render correctly with textStyle="xxl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -385,6 +404,7 @@ exports[`Android BpkText should render correctly with textStyle="xxl" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xxxl and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -406,6 +426,7 @@ exports[`Android BpkText should render correctly with textStyle="xxxl and weight
 
 exports[`Android BpkText should render correctly with textStyle="xxxl and weight="heavy" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -427,6 +448,7 @@ exports[`Android BpkText should render correctly with textStyle="xxxl and weight
 
 exports[`Android BpkText should render correctly with textStyle="xxxl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -446,6 +468,7 @@ exports[`Android BpkText should render correctly with textStyle="xxxl" 1`] = `
 
 exports[`Android BpkText should support overwriting styles 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -468,6 +491,7 @@ exports[`Android BpkText should support overwriting styles 1`] = `
 
 exports[`Android should render correctly with custom font for weight emphasized 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -492,6 +516,7 @@ exports[`Android should render correctly with custom font for weight emphasized 
 
 exports[`Android should render correctly with custom font for weight heavy 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -516,6 +541,7 @@ exports[`Android should render correctly with custom font for weight heavy 1`] =
 
 exports[`Android should render correctly with custom font for weight regular 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {

--- a/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
@@ -2,6 +2,7 @@
 
 exports[`iOS BpkText should ignore weight prop if deprecated \`emphasize\` prop is being used 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -23,6 +24,7 @@ exports[`iOS BpkText should ignore weight prop if deprecated \`emphasize\` prop 
 
 exports[`iOS BpkText should render correctly 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -42,6 +44,7 @@ exports[`iOS BpkText should render correctly 1`] = `
 
 exports[`iOS BpkText should render correctly with deprecated \`emphasize\` prop 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -63,6 +66,7 @@ exports[`iOS BpkText should render correctly with deprecated \`emphasize\` prop 
 
 exports[`iOS BpkText should render correctly with textStyle="base and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -84,6 +88,7 @@ exports[`iOS BpkText should render correctly with textStyle="base and weight="em
 
 exports[`iOS BpkText should render correctly with textStyle="base" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -103,6 +108,7 @@ exports[`iOS BpkText should render correctly with textStyle="base" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="caps and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -124,6 +130,7 @@ exports[`iOS BpkText should render correctly with textStyle="caps and weight="em
 
 exports[`iOS BpkText should render correctly with textStyle="caps" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -143,6 +150,7 @@ exports[`iOS BpkText should render correctly with textStyle="caps" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="lg and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -164,6 +172,7 @@ exports[`iOS BpkText should render correctly with textStyle="lg and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="lg" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -183,6 +192,7 @@ exports[`iOS BpkText should render correctly with textStyle="lg" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="sm and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -204,6 +214,7 @@ exports[`iOS BpkText should render correctly with textStyle="sm and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="sm" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -223,6 +234,7 @@ exports[`iOS BpkText should render correctly with textStyle="sm" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xl and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -244,6 +256,7 @@ exports[`iOS BpkText should render correctly with textStyle="xl and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="xl and weight="heavy" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -265,6 +278,7 @@ exports[`iOS BpkText should render correctly with textStyle="xl and weight="heav
 
 exports[`iOS BpkText should render correctly with textStyle="xl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -284,6 +298,7 @@ exports[`iOS BpkText should render correctly with textStyle="xl" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xs and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -305,6 +320,7 @@ exports[`iOS BpkText should render correctly with textStyle="xs and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="xs" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -324,6 +340,7 @@ exports[`iOS BpkText should render correctly with textStyle="xs" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xxl and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -345,6 +362,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxl and weight="emp
 
 exports[`iOS BpkText should render correctly with textStyle="xxl and weight="heavy" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -366,6 +384,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxl and weight="hea
 
 exports[`iOS BpkText should render correctly with textStyle="xxl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -385,6 +404,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxl" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="emphasized" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -406,6 +426,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="em
 
 exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="heavy" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -427,6 +448,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="he
 
 exports[`iOS BpkText should render correctly with textStyle="xxxl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -446,6 +468,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxxl" 1`] = `
 
 exports[`iOS BpkText should support overwriting styles 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -468,6 +491,7 @@ exports[`iOS BpkText should support overwriting styles 1`] = `
 
 exports[`iOS should not apply \`emphasize\` for textStyle="xxl" 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {
@@ -489,6 +513,7 @@ exports[`iOS should not apply \`emphasize\` for textStyle="xxl" 1`] = `
 
 exports[`iOS should render correctly with theming 1`] = `
 <Text
+  maxFontSizeMultiplier={3.2}
   style={
     Array [
       Object {

--- a/packages/react-native-bpk-component-touchable-overlay/src/__snapshots__/BpkTouchableOverlay-test.js.snap
+++ b/packages/react-native-bpk-component-touchable-overlay/src/__snapshots__/BpkTouchableOverlay-test.js.snap
@@ -14,6 +14,7 @@ exports[`BpkTouchableOverlay should render correctly 1`] = `
   style={null}
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -63,6 +64,7 @@ exports[`BpkTouchableOverlay should render correctly with arbitrary props 1`] = 
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -112,6 +114,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -164,6 +167,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -216,6 +220,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -268,6 +273,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -320,6 +326,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -372,6 +379,7 @@ exports[`BpkTouchableOverlay should render correctly with custom overlay styles 
   testID="arbitrary value"
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {
@@ -427,6 +435,7 @@ exports[`BpkTouchableOverlay should render correctly with custom style prop 1`] 
   }
 >
   <Text
+    maxFontSizeMultiplier={3.2}
     style={
       Array [
         Object {


### PR DESCRIPTION
Current:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/30267516/67261652-86305980-f499-11e9-93e1-981d40108773.png">

Limits it enough, but not too much:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/30267516/67261380-503ea580-f498-11e9-8a37-895fce84e01c.png">

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
