### PR TITLE
Disabling font scaling in profile when system font size is increased

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -53,4 +53,4 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
 
 - react-native-bpk-component-text:
-  - Disabled font scaling for react native in react-native-bpk-component-text.
+  - Disabled font scaling for REACT NATIVE in react-native-bpk-component-text.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -53,4 +53,4 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
 
 - react-native-bpk-component-text:
-  - Disabled font scaling for react native bpkText.
+  - Disabled font scaling for react native in react-native-bpk-component-text.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,9 @@
 
 **Added:**
 
+- react-native-bpk-component-text:
+  - Disabled font scaling for react native bpkText.
+
 - react-native-bpk-component-button-link:
   - Added dark mode support.
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,12 @@
 
 > Place your changes below this line.
 
+
+**Fixed**
+
+- react-native-bpk-component-text:
+  - Disabled font scaling for REACT NATIVE in react-native-bpk-component-text.
+
 **Added:**
 
 - react-native-bpk-component-button-link:
@@ -52,5 +58,3 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
 - react-native-bpk-component-horcrux:
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
 
-- react-native-bpk-component-text:
-  - Disabled font scaling for REACT NATIVE in react-native-bpk-component-text.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,9 +4,6 @@
 
 **Added:**
 
-- react-native-bpk-component-text:
-  - Disabled font scaling for react native bpkText.
-
 - react-native-bpk-component-button-link:
   - Added dark mode support.
 
@@ -54,3 +51,6 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
 
 - react-native-bpk-component-horcrux:
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+- react-native-bpk-component-text:
+  - Disabled font scaling for react native bpkText.

--- a/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
+++ b/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.android.js.snap
@@ -24,6 +24,7 @@ exports[`Android BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -52,6 +53,7 @@ exports[`Android BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -96,6 +98,7 @@ exports[`Android BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -124,6 +127,7 @@ exports[`Android BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -168,6 +172,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -185,6 +190,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -213,6 +219,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -230,6 +237,7 @@ exports[`Android BpkAnimateHeight should render correctly with n children 1`] = 
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -275,6 +283,7 @@ exports[`Android BpkAnimateHeight should render correctly with user styling padd
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -303,6 +312,7 @@ exports[`Android BpkAnimateHeight should render correctly with user styling padd
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
+++ b/packages/react-native-bpk-component-animate-height/src/__snapshots__/BpkAnimateHeight-test.ios.js.snap
@@ -24,6 +24,7 @@ exports[`iOS BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -52,6 +53,7 @@ exports[`iOS BpkAnimateHeight should render correctly collapsed 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -96,6 +98,7 @@ exports[`iOS BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -124,6 +127,7 @@ exports[`iOS BpkAnimateHeight should render correctly expanded 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -168,6 +172,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -185,6 +190,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -213,6 +219,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -230,6 +237,7 @@ exports[`iOS BpkAnimateHeight should render correctly with n children 1`] = `
       Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -275,6 +283,7 @@ exports[`iOS BpkAnimateHeight should render correctly with user styling padding 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -303,6 +312,7 @@ exports[`iOS BpkAnimateHeight should render correctly with user styling padding 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.android.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.android.js.snap
@@ -25,6 +25,7 @@ exports[`Android AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -50,6 +51,7 @@ exports[`Android AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -95,6 +97,7 @@ exports[`Android AnimateAndFade should render correctly when show is false 1`] =
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -120,6 +123,7 @@ exports[`Android AnimateAndFade should render correctly when show is false 1`] =
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -165,6 +169,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnEnter 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -190,6 +195,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnEnter 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -235,6 +241,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnLeave 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -260,6 +267,7 @@ exports[`Android AnimateAndFade should render correctly with animateOnLeave 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.ios.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/AnimateAndFade-test.ios.js.snap
@@ -25,6 +25,7 @@ exports[`iOS AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -50,6 +51,7 @@ exports[`iOS AnimateAndFade should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -95,6 +97,7 @@ exports[`iOS AnimateAndFade should render correctly when show is false 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -120,6 +123,7 @@ exports[`iOS AnimateAndFade should render correctly when show is false 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -165,6 +169,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnEnter 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -190,6 +195,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnEnter 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -235,6 +241,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnLeave 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -260,6 +267,7 @@ exports[`iOS AnimateAndFade should render correctly with animateOnLeave 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -75,6 +75,7 @@ exports[`Android BpkBannerAlert dark mode should accept userland styling 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -154,6 +155,7 @@ exports[`Android BpkBannerAlert dark mode should accept userland styling 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -253,6 +255,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with dismissab
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -306,6 +309,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with dismissab
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               numberOfLines={1}
               style={
@@ -392,6 +396,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with dismissab
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -445,6 +450,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with dismissab
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               numberOfLines={1}
               style={
@@ -551,6 +557,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -630,6 +637,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -729,6 +737,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -808,6 +817,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -907,6 +917,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -986,6 +997,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1085,6 +1097,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1164,6 +1177,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with type equa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1264,6 +1278,7 @@ exports[`Android BpkBannerAlert light mode should accept userland styling 1`] = 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1343,6 +1358,7 @@ exports[`Android BpkBannerAlert light mode should accept userland styling 1`] = 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1442,6 +1458,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with dismissa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1495,6 +1512,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with dismissa
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               numberOfLines={1}
               style={
@@ -1581,6 +1599,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with dismissa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1634,6 +1653,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with dismissa
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               numberOfLines={1}
               style={
@@ -1740,6 +1760,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1819,6 +1840,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1918,6 +1940,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1997,6 +2020,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2096,6 +2120,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2175,6 +2200,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2274,6 +2300,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2353,6 +2380,7 @@ exports[`Android BpkBannerAlert light mode should render correctly with type equ
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2452,6 +2480,7 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2531,6 +2560,7 @@ exports[`Android BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2630,6 +2660,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2709,6 +2740,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnEnter 1`] 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2808,6 +2840,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2887,6 +2920,7 @@ exports[`Android BpkBannerAlert should render correctly with animateOnLeave 1`] 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3005,6 +3039,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3072,6 +3107,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3103,6 +3139,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3199,6 +3236,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3266,6 +3304,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3297,6 +3336,7 @@ exports[`Android BpkBannerAlert should render correctly with children provided (
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3413,6 +3453,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3480,6 +3521,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3511,6 +3553,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3607,6 +3650,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3674,6 +3718,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3705,6 +3750,7 @@ exports[`Android BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [

--- a/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/packages/react-native-bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -77,6 +77,7 @@ exports[`iOS BpkBannerAlert dark mode should accept userland styling 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -158,6 +159,7 @@ exports[`iOS BpkBannerAlert dark mode should accept userland styling 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -262,6 +264,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with dismissable 1
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -402,6 +405,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with dismissable 1
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -559,6 +563,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -640,6 +645,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -741,6 +747,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -822,6 +829,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -923,6 +931,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1004,6 +1013,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1105,6 +1115,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1186,6 +1197,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with type equal to
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1288,6 +1300,7 @@ exports[`iOS BpkBannerAlert light mode should accept userland styling 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1369,6 +1382,7 @@ exports[`iOS BpkBannerAlert light mode should accept userland styling 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1473,6 +1487,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with dismissable 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1613,6 +1628,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with dismissable 
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1770,6 +1786,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1851,6 +1868,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1952,6 +1970,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2033,6 +2052,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2134,6 +2154,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2215,6 +2236,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2316,6 +2338,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2397,6 +2420,7 @@ exports[`iOS BpkBannerAlert light mode should render correctly with type equal t
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2498,6 +2522,7 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2579,6 +2604,7 @@ exports[`iOS BpkBannerAlert should render correctly when not shown 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2680,6 +2706,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2761,6 +2788,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnEnter 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2862,6 +2890,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -2943,6 +2972,7 @@ exports[`iOS BpkBannerAlert should render correctly with animateOnLeave 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3055,6 +3085,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3138,6 +3169,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3169,6 +3201,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3259,6 +3292,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3342,6 +3376,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3373,6 +3408,7 @@ exports[`iOS BpkBannerAlert should render correctly with children provided (expa
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3483,6 +3519,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3566,6 +3603,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3597,6 +3635,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3687,6 +3726,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           
         </Text>
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -3770,6 +3810,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -3801,6 +3842,7 @@ exports[`iOS BpkBannerAlert should render correctly with expanded 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [

--- a/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.android.js.snap
+++ b/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.android.js.snap
@@ -45,6 +45,7 @@ exports[`Android BpkButtonLink dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -120,6 +121,7 @@ exports[`Android BpkButtonLink dark mode should support overwriting styles 1`] =
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -197,6 +199,7 @@ exports[`Android BpkButtonLink dark mode should support the "disabled" property 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -273,6 +276,7 @@ exports[`Android BpkButtonLink dark mode should support the "icon" property 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -370,6 +374,7 @@ exports[`Android BpkButtonLink light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -445,6 +450,7 @@ exports[`Android BpkButtonLink light mode should support overwriting styles 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -522,6 +528,7 @@ exports[`Android BpkButtonLink light mode should support the "disabled" property
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -598,6 +605,7 @@ exports[`Android BpkButtonLink light mode should support the "icon" property 1`]
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -698,6 +706,7 @@ exports[`Android BpkButtonLink should render correctly with iconAlignment="leadi
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -799,6 +808,7 @@ exports[`Android BpkButtonLink should render correctly with iconAlignment="trail
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -970,6 +980,7 @@ exports[`Android BpkButtonLink should render correctly with theme prop 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -1046,6 +1057,7 @@ exports[`Android BpkButtonLink should support elements as icons 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -1071,6 +1083,7 @@ exports[`Android BpkButtonLink should support elements as icons 1`] = `
       LOREM IPSUM
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1136,6 +1149,7 @@ exports[`Android should support "borderlessBackground" equal to false 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -1209,6 +1223,7 @@ exports[`Android should support "uppercase" equal to false 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={

--- a/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.ios.js.snap
+++ b/packages/react-native-bpk-component-button-link/src/__snapshots__/BpkButtonLink-test.ios.js.snap
@@ -34,6 +34,7 @@ exports[`iOS BpkButtonLink dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -97,6 +98,7 @@ exports[`iOS BpkButtonLink dark mode should support overwriting styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -163,6 +165,7 @@ exports[`iOS BpkButtonLink dark mode should support the "disabled" property 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -228,6 +231,7 @@ exports[`iOS BpkButtonLink dark mode should support the "icon" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -314,6 +318,7 @@ exports[`iOS BpkButtonLink light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -377,6 +382,7 @@ exports[`iOS BpkButtonLink light mode should support overwriting styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -443,6 +449,7 @@ exports[`iOS BpkButtonLink light mode should support the "disabled" property 1`]
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -508,6 +515,7 @@ exports[`iOS BpkButtonLink light mode should support the "icon" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -597,6 +605,7 @@ exports[`iOS BpkButtonLink should render correctly with iconAlignment="leading" 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -687,6 +696,7 @@ exports[`iOS BpkButtonLink should render correctly with iconAlignment="trailing"
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -836,6 +846,7 @@ exports[`iOS BpkButtonLink should render correctly with theme prop 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -901,6 +912,7 @@ exports[`iOS BpkButtonLink should support elements as icons 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -926,6 +938,7 @@ exports[`iOS BpkButtonLink should support elements as icons 1`] = `
       Lorem ipsum
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -983,6 +996,7 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={
@@ -1069,6 +1083,7 @@ exports[`iOS should support the "large" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       numberOfLines={1}
       style={

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.android.js.snap
@@ -54,6 +54,7 @@ exports[`Android API levels Android API<21 should render without ripple 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -139,6 +140,7 @@ exports[`Android API levels Android API>=21 should render with ripple 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -224,6 +226,7 @@ exports[`Android BpkButton dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -311,6 +314,7 @@ exports[`Android BpkButton dark mode should render correctly with type="destruct
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -402,6 +406,7 @@ exports[`Android BpkButton dark mode should render correctly with type="destruct
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -487,6 +492,7 @@ exports[`Android BpkButton dark mode should render correctly with type="featured
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -579,6 +585,7 @@ exports[`Android BpkButton dark mode should render correctly with type="featured
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -664,6 +671,7 @@ exports[`Android BpkButton dark mode should render correctly with type="primary"
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -756,6 +764,7 @@ exports[`Android BpkButton dark mode should render correctly with type="primary"
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -843,6 +852,7 @@ exports[`Android BpkButton dark mode should render correctly with type="secondar
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -934,6 +944,7 @@ exports[`Android BpkButton dark mode should render correctly with type="secondar
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1022,6 +1033,7 @@ exports[`Android BpkButton dark mode should support overwriting styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1114,6 +1126,7 @@ exports[`Android BpkButton dark mode should support the "disabled" property 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1199,6 +1212,7 @@ exports[`Android BpkButton light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1286,6 +1300,7 @@ exports[`Android BpkButton light mode should render correctly with type="destruc
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1377,6 +1392,7 @@ exports[`Android BpkButton light mode should render correctly with type="destruc
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1462,6 +1478,7 @@ exports[`Android BpkButton light mode should render correctly with type="feature
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1554,6 +1571,7 @@ exports[`Android BpkButton light mode should render correctly with type="feature
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1639,6 +1657,7 @@ exports[`Android BpkButton light mode should render correctly with type="primary
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1731,6 +1750,7 @@ exports[`Android BpkButton light mode should render correctly with type="primary
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1818,6 +1838,7 @@ exports[`Android BpkButton light mode should render correctly with type="seconda
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1909,6 +1930,7 @@ exports[`Android BpkButton light mode should render correctly with type="seconda
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1997,6 +2019,7 @@ exports[`Android BpkButton light mode should support overwriting styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2089,6 +2112,7 @@ exports[`Android BpkButton light mode should support the "disabled" property 1`]
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2197,6 +2221,7 @@ exports[`Android BpkButton should render correctly with iconAlignment="leading" 
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2312,6 +2337,7 @@ exports[`Android BpkButton should render correctly with iconAlignment="trailing"
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2400,6 +2426,7 @@ exports[`Android BpkButton should support elements as icons 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2524,6 +2551,7 @@ exports[`Android BpkButton should support having an icon as well as a title 1`] 
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2639,6 +2667,7 @@ exports[`Android BpkButton should support the "icon" property 1`] = `
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2914,6 +2943,7 @@ exports[`Android BpkButtonThemed should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
+++ b/packages/react-native-bpk-component-button/src/__snapshots__/BpkButton-test.ios.js.snap
@@ -43,6 +43,7 @@ exports[`iOS BpkButton dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -127,6 +128,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="destructive"
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -219,6 +221,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="destructive"
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -310,6 +313,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="featured" 1`
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -401,6 +405,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="featured" an
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -488,6 +493,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="primary" 1`]
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -579,6 +585,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="primary" and
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -663,6 +670,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="secondary" 1
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -755,6 +763,7 @@ exports[`iOS BpkButton dark mode should render correctly with type="secondary" a
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -850,6 +859,7 @@ exports[`iOS BpkButton dark mode should support overwriting styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -941,6 +951,7 @@ exports[`iOS BpkButton dark mode should support the "disabled" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1028,6 +1039,7 @@ exports[`iOS BpkButton light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1112,6 +1124,7 @@ exports[`iOS BpkButton light mode should render correctly with type="destructive
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1204,6 +1217,7 @@ exports[`iOS BpkButton light mode should render correctly with type="destructive
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1295,6 +1309,7 @@ exports[`iOS BpkButton light mode should render correctly with type="featured" 1
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1386,6 +1401,7 @@ exports[`iOS BpkButton light mode should render correctly with type="featured" a
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1473,6 +1489,7 @@ exports[`iOS BpkButton light mode should render correctly with type="primary" 1`
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1564,6 +1581,7 @@ exports[`iOS BpkButton light mode should render correctly with type="primary" an
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1648,6 +1666,7 @@ exports[`iOS BpkButton light mode should render correctly with type="secondary" 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1740,6 +1759,7 @@ exports[`iOS BpkButton light mode should render correctly with type="secondary" 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1835,6 +1855,7 @@ exports[`iOS BpkButton light mode should support overwriting styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -1926,6 +1947,7 @@ exports[`iOS BpkButton light mode should support the "disabled" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2036,6 +2058,7 @@ exports[`iOS BpkButton should render correctly with iconAlignment="leading" 1`] 
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2153,6 +2176,7 @@ exports[`iOS BpkButton should render correctly with iconAlignment="trailing" 1`]
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2243,6 +2267,7 @@ exports[`iOS BpkButton should support elements as icons 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2374,6 +2399,7 @@ exports[`iOS BpkButton should support having an icon as well as a title 1`] = `
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2491,6 +2517,7 @@ exports[`iOS BpkButton should support the "icon" property 1`] = `
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2782,6 +2809,7 @@ exports[`iOS BpkButtonThemed should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -2899,6 +2927,7 @@ exports[`iOS should support the "icon" and "large" property 1`] = `
       
     </Text>
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -3088,6 +3117,7 @@ exports[`iOS should support the "large" and secondary property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -3182,6 +3212,7 @@ exports[`iOS should support the "large" property 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.android.js.snap
@@ -41,6 +41,7 @@ exports[`Android BpkCard dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -105,6 +106,7 @@ exports[`Android BpkCard dark mode should render correctly with the "focused" st
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -166,6 +168,7 @@ exports[`Android BpkCard light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -230,6 +233,7 @@ exports[`Android BpkCard light mode should render correctly with the "focused" s
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -294,6 +298,7 @@ exports[`Android BpkCard should render correctly when "cornerStyle=large" 1`] = 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -356,6 +361,7 @@ exports[`Android BpkCard should render correctly with arbitrary props 1`] = `
     testID="arbitrary value"
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -420,6 +426,7 @@ exports[`Android BpkCard should render correctly with custom inner style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -484,6 +491,7 @@ exports[`Android BpkCard should render correctly with custom style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -539,6 +547,7 @@ exports[`Android BpkCard should render correctly without padding 1`] = `
     style={Array []}
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/BpkCard-test.ios.js.snap
@@ -35,6 +35,7 @@ exports[`iOS BpkCard dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -112,6 +113,7 @@ exports[`iOS BpkCard dark mode should render correctly with the "focused" state 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -193,6 +195,7 @@ exports[`iOS BpkCard light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -283,6 +286,7 @@ exports[`iOS BpkCard light mode should render correctly with the "focused" state
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -367,6 +371,7 @@ exports[`iOS BpkCard should render correctly when "cornerStyle=large" 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -449,6 +454,7 @@ exports[`iOS BpkCard should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -533,6 +539,7 @@ exports[`iOS BpkCard should render correctly with custom inner style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -617,6 +624,7 @@ exports[`iOS BpkCard should render correctly with custom style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -695,6 +703,7 @@ exports[`iOS BpkCard should render correctly without padding 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.android.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.android.js.snap
@@ -55,6 +55,7 @@ exports[`Android withDivider should render correctly 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -98,6 +99,7 @@ exports[`Android withDivider should render correctly 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -177,6 +179,7 @@ exports[`Android withDivider should render correctly with "cornerStyle=large" 1`
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -220,6 +223,7 @@ exports[`Android withDivider should render correctly with "cornerStyle=large" 1`
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -297,6 +301,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -340,6 +345,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -419,6 +425,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -462,6 +469,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -538,6 +546,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -584,6 +593,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -657,6 +667,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -697,6 +708,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [

--- a/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.ios.js.snap
+++ b/packages/react-native-bpk-component-card/src/__snapshots__/withDivider-test.ios.js.snap
@@ -56,6 +56,7 @@ exports[`iOS withDivider should render correctly 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -99,6 +100,7 @@ exports[`iOS withDivider should render correctly 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -198,6 +200,7 @@ exports[`iOS withDivider should render correctly with "cornerStyle=large" 1`] = 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -241,6 +244,7 @@ exports[`iOS withDivider should render correctly with "cornerStyle=large" 1`] = 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -338,6 +342,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -381,6 +386,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -480,6 +486,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -523,6 +530,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -619,6 +627,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -665,6 +674,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -758,6 +768,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -798,6 +809,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [

--- a/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.android.js.snap
@@ -11,6 +11,7 @@ exports[`Android BpkCarouselItem should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-carousel/src/__snapshots__/BpkCarouselItem-test.ios.js.snap
@@ -11,6 +11,7 @@ exports[`IOS BpkCarouselItem should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.android.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.android.js.snap
@@ -48,6 +48,7 @@ exports[`Android BpkChip dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -125,6 +126,7 @@ exports[`Android BpkChip dark mode should render correctly with "disabled" 1`] =
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -205,6 +207,7 @@ exports[`Android BpkChip dark mode should render correctly with "selected" 1`] =
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -292,6 +295,7 @@ exports[`Android BpkChip dark mode should render outline correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -369,6 +373,7 @@ exports[`Android BpkChip light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -446,6 +451,7 @@ exports[`Android BpkChip light mode should render correctly with "disabled" 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -526,6 +532,7 @@ exports[`Android BpkChip light mode should render correctly with "selected" 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -613,6 +620,7 @@ exports[`Android BpkChip light mode should render outline correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -691,6 +699,7 @@ exports[`Android BpkChip should render correctly with arbitrary props 1`] = `
     testID="123"
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -769,6 +778,7 @@ exports[`Android BpkChip should render correctly with custom style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -849,6 +859,7 @@ exports[`Android BpkChip should support theming when selected 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.ios.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkChip-test.ios.js.snap
@@ -39,6 +39,7 @@ exports[`iOS BpkChip dark mode should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -125,6 +126,7 @@ exports[`iOS BpkChip dark mode should render correctly with "disabled" 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -218,6 +220,7 @@ exports[`iOS BpkChip dark mode should render correctly with "selected" 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -314,6 +317,7 @@ exports[`iOS BpkChip dark mode should render outline correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -400,6 +404,7 @@ exports[`iOS BpkChip light mode should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -486,6 +491,7 @@ exports[`iOS BpkChip light mode should render correctly with "disabled" 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -579,6 +585,7 @@ exports[`iOS BpkChip light mode should render correctly with "selected" 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -675,6 +682,7 @@ exports[`iOS BpkChip light mode should render outline correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -762,6 +770,7 @@ exports[`iOS BpkChip should render correctly with arbitrary props 1`] = `
   testID="123"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -849,6 +858,7 @@ exports[`iOS BpkChip should render correctly with custom style 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -942,6 +952,7 @@ exports[`iOS BpkChip should support theming when selected 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.android.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.android.js.snap
@@ -48,6 +48,7 @@ exports[`Android BpkDismissibleChip dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -150,6 +151,7 @@ exports[`Android BpkDismissibleChip dark mode should render correctly with "disa
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -265,6 +267,7 @@ exports[`Android BpkDismissibleChip dark mode should render outline correctly 1`
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -370,6 +373,7 @@ exports[`Android BpkDismissibleChip light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -472,6 +476,7 @@ exports[`Android BpkDismissibleChip light mode should render correctly with "dis
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -587,6 +592,7 @@ exports[`Android BpkDismissibleChip light mode should render outline correctly 1
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -693,6 +699,7 @@ exports[`Android BpkDismissibleChip should render correctly with arbitrary props
     testID="123"
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -799,6 +806,7 @@ exports[`Android BpkDismissibleChip should render correctly with custom style 1`
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.ios.js.snap
+++ b/packages/react-native-bpk-component-chip/src/__snapshots__/BpkDismissibleChip-test.ios.js.snap
@@ -39,6 +39,7 @@ exports[`iOS BpkDismissibleChip dark mode should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -150,6 +151,7 @@ exports[`iOS BpkDismissibleChip dark mode should render correctly with "disabled
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -274,6 +276,7 @@ exports[`iOS BpkDismissibleChip dark mode should render outline correctly 1`] = 
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -388,6 +391,7 @@ exports[`iOS BpkDismissibleChip light mode should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -499,6 +503,7 @@ exports[`iOS BpkDismissibleChip light mode should render correctly with "disable
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -623,6 +628,7 @@ exports[`iOS BpkDismissibleChip light mode should render outline correctly 1`] =
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -738,6 +744,7 @@ exports[`iOS BpkDismissibleChip should render correctly with arbitrary props 1`]
   testID="123"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -853,6 +860,7 @@ exports[`iOS BpkDismissibleChip should render correctly with custom style 1`] = 
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.android.js.snap
@@ -42,6 +42,7 @@ exports[`Android BpkFlatListItem dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -138,6 +139,7 @@ exports[`Android BpkFlatListItem dark mode should support the "selected" propert
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -243,6 +245,7 @@ exports[`Android BpkFlatListItem light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -339,6 +342,7 @@ exports[`Android BpkFlatListItem light mode should support the "selected" proper
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -454,6 +458,7 @@ exports[`Android BpkFlatListItem should support the "image" property 1`] = `
       }
     />
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -568,6 +573,7 @@ exports[`Android should support theming when selected 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-flat-list/src/__snapshots__/BpkFlatListItem-test.ios.js.snap
@@ -38,6 +38,7 @@ exports[`iOS BpkFlatListItem dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -141,6 +142,7 @@ exports[`iOS BpkFlatListItem dark mode should support the "selected" property 1`
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -250,6 +252,7 @@ exports[`iOS BpkFlatListItem light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -353,6 +356,7 @@ exports[`iOS BpkFlatListItem light mode should support the "selected" property 1
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -472,6 +476,7 @@ exports[`iOS BpkFlatListItem should support the "image" property 1`] = `
       }
     />
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -592,6 +597,7 @@ exports[`iOS should support theming when selected 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
@@ -32,6 +32,7 @@ exports[`Android BpkHorizontalNavItem dark mode should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -92,6 +93,7 @@ exports[`Android BpkHorizontalNavItem dark mode should render correctly with "di
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -151,6 +153,7 @@ exports[`Android BpkHorizontalNavItem dark mode should render correctly with "se
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -210,6 +213,7 @@ exports[`Android BpkHorizontalNavItem light mode should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -270,6 +274,7 @@ exports[`Android BpkHorizontalNavItem light mode should render correctly with "d
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -329,6 +334,7 @@ exports[`Android BpkHorizontalNavItem light mode should render correctly with "s
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -391,6 +397,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with "small" prop 
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -447,6 +454,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with "spaceAround"
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -503,6 +511,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with arbitrary pro
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -562,6 +571,7 @@ exports[`Android BpkHorizontalNavItem should render correctly with custom "style
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -618,6 +628,7 @@ exports[`Android BpkHorizontalNavItem should support theming 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
+++ b/packages/react-native-bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
@@ -27,6 +27,7 @@ exports[`iOS BpkHorizontalNavItem dark mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -99,6 +100,7 @@ exports[`iOS BpkHorizontalNavItem dark mode should render correctly with "disabl
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -170,6 +172,7 @@ exports[`iOS BpkHorizontalNavItem dark mode should render correctly with "select
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -241,6 +244,7 @@ exports[`iOS BpkHorizontalNavItem light mode should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -313,6 +317,7 @@ exports[`iOS BpkHorizontalNavItem light mode should render correctly with "disab
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -384,6 +389,7 @@ exports[`iOS BpkHorizontalNavItem light mode should render correctly with "selec
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -458,6 +464,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "small" prop 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -526,6 +533,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with "spaceAround" pro
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -594,6 +602,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with arbitrary props 1
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -665,6 +674,7 @@ exports[`iOS BpkHorizontalNavItem should render correctly with custom "style" pr
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -733,6 +743,7 @@ exports[`iOS BpkHorizontalNavItem should support theming 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-iphone-x-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-iphone-x-test.ios.js.snap
@@ -81,6 +81,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly 1`] = `
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -227,6 +228,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly with trailing 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -331,6 +333,7 @@ exports[`ios - iPhone X  BpkNavigationBar should render correctly with trailing 
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBar-test.ios.js.snap
@@ -78,6 +78,7 @@ exports[`ios BpkNavigationBar should render correctly 1`] = `
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -242,6 +243,7 @@ exports[`ios BpkNavigationBar should render correctly with a subtitle view 1`] =
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -414,6 +416,7 @@ exports[`ios BpkNavigationBar should render correctly with a title view 1`] = `
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -544,6 +547,7 @@ exports[`ios BpkNavigationBar should render correctly with an icon in the title 
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -736,6 +740,7 @@ exports[`ios BpkNavigationBar should render correctly with custom style 1`] = `
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -879,6 +884,7 @@ exports[`ios BpkNavigationBar should render correctly with trailing button 1`] =
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -983,6 +989,7 @@ exports[`ios BpkNavigationBar should render correctly with trailing button 1`] =
       }
     >
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarBackButtonIOS-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarBackButtonIOS-test.ios.js.snap
@@ -90,6 +90,7 @@ exports[`iOS BpkNavigationBarBackButtonIOS should render correctly with title 1`
     }
   />
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarTextButtonIOS-test.ios.js.snap
+++ b/packages/react-native-bpk-component-navigation-bar/src/__snapshots__/BpkNavigationBarTextButtonIOS-test.ios.js.snap
@@ -26,6 +26,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -80,6 +81,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly disabled 1`] 
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -130,6 +132,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly emphasize 1`]
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -182,6 +185,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly leading confi
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -232,6 +236,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly with type="pr
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -286,6 +291,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should render correctly with type="pr
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -340,6 +346,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "disabledTintColor" ov
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -390,6 +397,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "primaryTintColor" ove
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -440,6 +448,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "tintColor" over "prim
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -490,6 +499,7 @@ exports[`iOS BpkNavigationBarTextButtonIOS should respect "tintColor" over "type
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
+++ b/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.android.js.snap
@@ -110,6 +110,7 @@ exports[`Android BpkNudger should render correctly 1`] = `
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -346,6 +347,7 @@ exports[`Android BpkNudger should render correctly when value is a not an intege
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -578,6 +580,7 @@ exports[`Android BpkNudger should render correctly when value is greater than ma
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -818,6 +821,7 @@ exports[`Android BpkNudger should render correctly when value is less than min 1
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
+++ b/packages/react-native-bpk-component-nudger/src/__snapshots__/BpkNudger-test.ios.js.snap
@@ -117,6 +117,7 @@ exports[`iOS BpkNudger should render correctly 1`] = `
     />
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -367,6 +368,7 @@ exports[`iOS BpkNudger should render correctly when value is a not an integer 1`
     />
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -613,6 +615,7 @@ exports[`iOS BpkNudger should render correctly when value is greater than max 1`
     />
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -867,6 +870,7 @@ exports[`iOS BpkNudger should render correctly when value is less than min 1`] =
     />
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.android.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.android.js.snap
@@ -17,6 +17,7 @@ exports[`Android BpkPanel should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -54,6 +55,7 @@ exports[`Android BpkPanel should render correctly with arbitrary props 1`] = `
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -93,6 +95,7 @@ exports[`Android BpkPanel should render correctly with custom style 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -126,6 +129,7 @@ exports[`Android BpkPanel should render correctly without padding 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.ios.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/BpkPanel-test.ios.js.snap
@@ -17,6 +17,7 @@ exports[`iOS BpkPanel should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -54,6 +55,7 @@ exports[`iOS BpkPanel should render correctly with arbitrary props 1`] = `
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -93,6 +95,7 @@ exports[`iOS BpkPanel should render correctly with custom style 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -126,6 +129,7 @@ exports[`iOS BpkPanel should render correctly without padding 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.android.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.android.js.snap
@@ -34,6 +34,7 @@ exports[`Android withDivider should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -75,6 +76,7 @@ exports[`Android withDivider should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -130,6 +132,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -171,6 +174,7 @@ exports[`Android withDivider should render correctly with arbitrary props 1`] = 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -228,6 +232,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -269,6 +274,7 @@ exports[`Android withDivider should render correctly with custom main style 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -323,6 +329,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -367,6 +374,7 @@ exports[`Android withDivider should render correctly with custom stub style 1`] 
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -415,6 +423,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -453,6 +462,7 @@ exports[`Android withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.ios.js.snap
+++ b/packages/react-native-bpk-component-panel/src/__snapshots__/withDivider-test.ios.js.snap
@@ -34,6 +34,7 @@ exports[`iOS withDivider should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -75,6 +76,7 @@ exports[`iOS withDivider should render correctly 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -130,6 +132,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -171,6 +174,7 @@ exports[`iOS withDivider should render correctly with arbitrary props 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -228,6 +232,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -269,6 +274,7 @@ exports[`iOS withDivider should render correctly with custom main style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -323,6 +329,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -367,6 +374,7 @@ exports[`iOS withDivider should render correctly with custom stub style 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -415,6 +423,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -453,6 +462,7 @@ exports[`iOS withDivider should render correctly without padding 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.android.js.snap
@@ -109,6 +109,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -245,6 +246,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -381,6 +383,7 @@ exports[`Android BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -558,6 +561,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -700,6 +704,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -836,6 +841,7 @@ exports[`Android BpkDialingCodeList should render correctly with "selectedId" se
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkDialingCodeList-test.ios.js.snap
@@ -113,6 +113,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         }
       >
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -198,6 +199,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -280,6 +282,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         }
       >
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -365,6 +368,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -447,6 +451,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
         }
       >
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -532,6 +537,7 @@ exports[`iOS BpkDialingCodeList should render correctly 1`] = `
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -717,6 +723,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         }
       >
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -802,6 +809,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -890,6 +898,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         }
       >
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -975,6 +984,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [
@@ -1057,6 +1067,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
         }
       >
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -1142,6 +1153,7 @@ exports[`iOS BpkDialingCodeList should render correctly with "selectedId" set 1`
             }
           />
           <Text
+            allowFontScaling={false}
             maxFontSizeMultiplier={3.2}
             style={
               Array [

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.android.js.snap
@@ -80,6 +80,7 @@ exports[`Android BpkPhoneNumberInput should render correctly 1`] = `
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [
@@ -252,6 +253,7 @@ exports[`Android BpkPhoneNumberInput should render correctly with \`editable\` f
         }
       />
       <Text
+        allowFontScaling={false}
         maxFontSizeMultiplier={3.2}
         style={
           Array [

--- a/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-phone-input/src/__snapshots__/BpkPhoneNumberInput-test.ios.js.snap
@@ -79,6 +79,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly 1`] = `
           }
         />
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [
@@ -267,6 +268,7 @@ exports[`iOS BpkPhoneNumberInput should render correctly with \`editable\` false
           }
         />
         <Text
+          allowFontScaling={false}
           maxFontSizeMultiplier={3.2}
           style={
             Array [

--- a/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
+++ b/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
@@ -127,6 +127,7 @@ exports[`Android BpkPicker should render correctly 1`] = `
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               style={
                 Array [
@@ -177,6 +178,7 @@ exports[`Android BpkPicker should render correctly 1`] = `
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               style={
                 Array [
@@ -333,6 +335,7 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               style={
                 Array [
@@ -385,6 +388,7 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
             }
           >
             <Text
+              allowFontScaling={false}
               maxFontSizeMultiplier={3.2}
               style={
                 Array [

--- a/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
+++ b/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPickerItem-test.android.js.snap
@@ -29,6 +29,7 @@ exports[`Android BpkPickerItem should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -78,6 +79,7 @@ exports[`Android BpkPickerItem should render correctly with an onPress function 
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -131,6 +133,7 @@ exports[`Android BpkPickerItem should render correctly with the selected prop 1`
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.android.js.snap
+++ b/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.android.js.snap
@@ -15,6 +15,7 @@ exports[`Android BpkSectionListHeader should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.ios.js.snap
+++ b/packages/react-native-bpk-component-section-list/src/__snapshots__/BpkSectionListHeader-test.ios.js.snap
@@ -11,6 +11,7 @@ exports[`iOS BpkSectionListHeader should render correctly 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.android.js.snap
+++ b/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.android.js.snap
@@ -375,6 +375,7 @@ exports[`Android BpkSelect should render correctly with "valid" false and a vali
     </Text>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -517,6 +518,7 @@ exports[`Android BpkSelect should render correctly with a text label 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -657,6 +659,7 @@ exports[`Android BpkSelect should render correctly with custom styles 1`] = `
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -742,6 +745,7 @@ exports[`Android BpkSelect should render correctly with the disabled prop 1`] = 
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.ios.js.snap
+++ b/packages/react-native-bpk-component-select/src/__snapshots__/BpkSelect-test.ios.js.snap
@@ -435,6 +435,7 @@ exports[`iOS BpkSelect should render correctly with "valid" false and a validati
     />
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -584,6 +585,7 @@ exports[`iOS BpkSelect should render correctly with a text label 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -752,6 +754,7 @@ exports[`iOS BpkSelect should render correctly with custom styles 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [
@@ -849,6 +852,7 @@ exports[`iOS BpkSelect should render correctly with the disabled prop 1`] = `
     }
   >
     <Text
+      allowFontScaling={false}
       maxFontSizeMultiplier={3.2}
       style={
         Array [

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -437,6 +437,7 @@ exports[`RTL BpkTextInput should render correctly with description 1`] = `
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -557,6 +558,7 @@ exports[`RTL BpkTextInput should render correctly with description, valid=false 
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -1163,6 +1165,7 @@ exports[`RTL BpkTextInput should render correctly with valid false and a validat
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -437,6 +437,7 @@ exports[`Android BpkTextInput should render correctly with description 1`] = `
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -557,6 +558,7 @@ exports[`Android BpkTextInput should render correctly with description, valid=fa
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -1163,6 +1165,7 @@ exports[`Android BpkTextInput should render correctly with valid false and a val
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -437,6 +437,7 @@ exports[`iOS BpkTextInput should render correctly with description 1`] = `
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -557,6 +558,7 @@ exports[`iOS BpkTextInput should render correctly with description, valid=false 
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -1163,6 +1165,7 @@ exports[`iOS BpkTextInput should render correctly with valid false and a validat
     </View>
   </View>
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [

--- a/packages/react-native-bpk-component-text/package.json
+++ b/packages/react-native-bpk-component-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bpk-component-text",
-  "version": "4.2.2",
+  "version": "4.2.1",
   "main": "index.js",
   "description": "Backpack React Native text component.",
   "repository": {

--- a/packages/react-native-bpk-component-text/package.json
+++ b/packages/react-native-bpk-component-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-bpk-component-text",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "main": "index.js",
   "description": "Backpack React Native text component.",
   "repository": {

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -219,11 +219,11 @@ const BpkText = (props: Props) => {
   return (
     // eslint-disable-next-line backpack/use-components
     <Text 
-      allowFontScaing={false} 
-      style={style} 
-      maxFontSizeMultiplier={3.2} 
-      {...rest}>
-        {children}
+    allowFontScaing={false} 
+    style={style} 
+    maxFontSizeMultiplier={3.2} 
+    {...rest}>
+      {children}
     </Text>
   );
 };

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -218,8 +218,12 @@ const BpkText = (props: Props) => {
 
   return (
     // eslint-disable-next-line backpack/use-components
-    <Text allowFontScaing={false} style={style} maxFontSizeMultiplier={3.2} {...rest}>
-      {children}
+    <Text 
+      allowFontScaing={false} 
+      style={style} 
+      maxFontSizeMultiplier={3.2} 
+      {...rest}>
+        {children}
     </Text>
   );
 };

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -219,7 +219,7 @@ const BpkText = (props: Props) => {
   return (
     // eslint-disable-next-line backpack/use-components
     <Text
-      allowFontScaing={false}
+      allowFontScaling={false}
       style={style}
       maxFontSizeMultiplier={3.2}
       {...rest}

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -218,7 +218,7 @@ const BpkText = (props: Props) => {
 
   return (
     // eslint-disable-next-line backpack/use-components
-    <Text style={style} maxFontSizeMultiplier={3.2} {...rest}>
+    <Text allowFontScaing={false} style={style} maxFontSizeMultiplier={3.2} {...rest}>
       {children}
     </Text>
   );

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -218,10 +218,10 @@ const BpkText = (props: Props) => {
 
   return (
     // eslint-disable-next-line backpack/use-components
-    <Text 
-      allowFontScaing={false} 
-      style={style} 
-      maxFontSizeMultiplier={3.2} 
+    <Text
+      allowFontScaing={false}
+      style={style}
+      maxFontSizeMultiplier={3.2}
       {...rest}
     >
       {children}

--- a/packages/react-native-bpk-component-text/src/BpkText.js
+++ b/packages/react-native-bpk-component-text/src/BpkText.js
@@ -219,10 +219,11 @@ const BpkText = (props: Props) => {
   return (
     // eslint-disable-next-line backpack/use-components
     <Text 
-    allowFontScaing={false} 
-    style={style} 
-    maxFontSizeMultiplier={3.2} 
-    {...rest}>
+      allowFontScaing={false} 
+      style={style} 
+      maxFontSizeMultiplier={3.2} 
+      {...rest}
+    >
       {children}
     </Text>
   );

--- a/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.android.js.snap
+++ b/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.android.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Android BpkText dark mode should render correctly 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -22,6 +23,7 @@ exports[`Android BpkText dark mode should render correctly 1`] = `
 
 exports[`Android BpkText dark mode should support overwriting styles 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -45,6 +47,7 @@ exports[`Android BpkText dark mode should support overwriting styles 1`] = `
 
 exports[`Android BpkText light mode should render correctly 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -65,6 +68,7 @@ exports[`Android BpkText light mode should render correctly 1`] = `
 
 exports[`Android BpkText light mode should support overwriting styles 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -88,6 +92,7 @@ exports[`Android BpkText light mode should support overwriting styles 1`] = `
 
 exports[`Android BpkText should ignore weight prop if deprecated \`emphasize\` prop is being used 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -110,6 +115,7 @@ exports[`Android BpkText should ignore weight prop if deprecated \`emphasize\` p
 
 exports[`Android BpkText should render correctly with deprecated \`emphasize\` prop 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -132,6 +138,7 @@ exports[`Android BpkText should render correctly with deprecated \`emphasize\` p
 
 exports[`Android BpkText should render correctly with textStyle="base and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -154,6 +161,7 @@ exports[`Android BpkText should render correctly with textStyle="base and weight
 
 exports[`Android BpkText should render correctly with textStyle="base" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -174,6 +182,7 @@ exports[`Android BpkText should render correctly with textStyle="base" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="caps and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -196,6 +205,7 @@ exports[`Android BpkText should render correctly with textStyle="caps and weight
 
 exports[`Android BpkText should render correctly with textStyle="caps" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -216,6 +226,7 @@ exports[`Android BpkText should render correctly with textStyle="caps" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="lg and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -238,6 +249,7 @@ exports[`Android BpkText should render correctly with textStyle="lg and weight="
 
 exports[`Android BpkText should render correctly with textStyle="lg" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -258,6 +270,7 @@ exports[`Android BpkText should render correctly with textStyle="lg" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="sm and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -280,6 +293,7 @@ exports[`Android BpkText should render correctly with textStyle="sm and weight="
 
 exports[`Android BpkText should render correctly with textStyle="sm" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -300,6 +314,7 @@ exports[`Android BpkText should render correctly with textStyle="sm" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xl and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -322,6 +337,7 @@ exports[`Android BpkText should render correctly with textStyle="xl and weight="
 
 exports[`Android BpkText should render correctly with textStyle="xl and weight="heavy" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -344,6 +360,7 @@ exports[`Android BpkText should render correctly with textStyle="xl and weight="
 
 exports[`Android BpkText should render correctly with textStyle="xl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -364,6 +381,7 @@ exports[`Android BpkText should render correctly with textStyle="xl" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xs and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -386,6 +404,7 @@ exports[`Android BpkText should render correctly with textStyle="xs and weight="
 
 exports[`Android BpkText should render correctly with textStyle="xs" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -406,6 +425,7 @@ exports[`Android BpkText should render correctly with textStyle="xs" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xxl and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -428,6 +448,7 @@ exports[`Android BpkText should render correctly with textStyle="xxl and weight=
 
 exports[`Android BpkText should render correctly with textStyle="xxl and weight="heavy" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -450,6 +471,7 @@ exports[`Android BpkText should render correctly with textStyle="xxl and weight=
 
 exports[`Android BpkText should render correctly with textStyle="xxl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -470,6 +492,7 @@ exports[`Android BpkText should render correctly with textStyle="xxl" 1`] = `
 
 exports[`Android BpkText should render correctly with textStyle="xxxl and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -492,6 +515,7 @@ exports[`Android BpkText should render correctly with textStyle="xxxl and weight
 
 exports[`Android BpkText should render correctly with textStyle="xxxl and weight="heavy" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -514,6 +538,7 @@ exports[`Android BpkText should render correctly with textStyle="xxxl and weight
 
 exports[`Android BpkText should render correctly with textStyle="xxxl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -534,6 +559,7 @@ exports[`Android BpkText should render correctly with textStyle="xxxl" 1`] = `
 
 exports[`Android should render correctly with custom font for weight emphasized 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -559,6 +585,7 @@ exports[`Android should render correctly with custom font for weight emphasized 
 
 exports[`Android should render correctly with custom font for weight heavy 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -584,6 +611,7 @@ exports[`Android should render correctly with custom font for weight heavy 1`] =
 
 exports[`Android should render correctly with custom font for weight regular 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [

--- a/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text/src/__snapshots__/BpkText-test.ios.js.snap
@@ -2,6 +2,7 @@
 
 exports[`iOS BpkText dark mode should render correctly 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -22,6 +23,7 @@ exports[`iOS BpkText dark mode should render correctly 1`] = `
 
 exports[`iOS BpkText dark mode should support overwriting styles 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -45,6 +47,7 @@ exports[`iOS BpkText dark mode should support overwriting styles 1`] = `
 
 exports[`iOS BpkText light mode should render correctly 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -65,6 +68,7 @@ exports[`iOS BpkText light mode should render correctly 1`] = `
 
 exports[`iOS BpkText light mode should support overwriting styles 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -88,6 +92,7 @@ exports[`iOS BpkText light mode should support overwriting styles 1`] = `
 
 exports[`iOS BpkText should ignore weight prop if deprecated \`emphasize\` prop is being used 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -110,6 +115,7 @@ exports[`iOS BpkText should ignore weight prop if deprecated \`emphasize\` prop 
 
 exports[`iOS BpkText should render correctly with deprecated \`emphasize\` prop 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -132,6 +138,7 @@ exports[`iOS BpkText should render correctly with deprecated \`emphasize\` prop 
 
 exports[`iOS BpkText should render correctly with textStyle="base and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -154,6 +161,7 @@ exports[`iOS BpkText should render correctly with textStyle="base and weight="em
 
 exports[`iOS BpkText should render correctly with textStyle="base" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -174,6 +182,7 @@ exports[`iOS BpkText should render correctly with textStyle="base" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="caps and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -196,6 +205,7 @@ exports[`iOS BpkText should render correctly with textStyle="caps and weight="em
 
 exports[`iOS BpkText should render correctly with textStyle="caps" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -216,6 +226,7 @@ exports[`iOS BpkText should render correctly with textStyle="caps" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="lg and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -238,6 +249,7 @@ exports[`iOS BpkText should render correctly with textStyle="lg and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="lg" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -258,6 +270,7 @@ exports[`iOS BpkText should render correctly with textStyle="lg" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="sm and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -280,6 +293,7 @@ exports[`iOS BpkText should render correctly with textStyle="sm and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="sm" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -300,6 +314,7 @@ exports[`iOS BpkText should render correctly with textStyle="sm" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xl and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -322,6 +337,7 @@ exports[`iOS BpkText should render correctly with textStyle="xl and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="xl and weight="heavy" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -344,6 +360,7 @@ exports[`iOS BpkText should render correctly with textStyle="xl and weight="heav
 
 exports[`iOS BpkText should render correctly with textStyle="xl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -364,6 +381,7 @@ exports[`iOS BpkText should render correctly with textStyle="xl" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xs and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -386,6 +404,7 @@ exports[`iOS BpkText should render correctly with textStyle="xs and weight="emph
 
 exports[`iOS BpkText should render correctly with textStyle="xs" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -406,6 +425,7 @@ exports[`iOS BpkText should render correctly with textStyle="xs" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xxl and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -428,6 +448,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxl and weight="emp
 
 exports[`iOS BpkText should render correctly with textStyle="xxl and weight="heavy" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -450,6 +471,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxl and weight="hea
 
 exports[`iOS BpkText should render correctly with textStyle="xxl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -470,6 +492,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxl" 1`] = `
 
 exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="emphasized" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -492,6 +515,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="em
 
 exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="heavy" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -514,6 +538,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxxl and weight="he
 
 exports[`iOS BpkText should render correctly with textStyle="xxxl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -534,6 +559,7 @@ exports[`iOS BpkText should render correctly with textStyle="xxxl" 1`] = `
 
 exports[`iOS should not apply \`emphasize\` for textStyle="xxl" 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [
@@ -556,6 +582,7 @@ exports[`iOS should not apply \`emphasize\` for textStyle="xxl" 1`] = `
 
 exports[`iOS should render correctly with theming 1`] = `
 <Text
+  allowFontScaling={false}
   maxFontSizeMultiplier={3.2}
   style={
     Array [

--- a/packages/react-native-bpk-component-touchable-overlay/src/__snapshots__/BpkTouchableOverlay-test.js.snap
+++ b/packages/react-native-bpk-component-touchable-overlay/src/__snapshots__/BpkTouchableOverlay-test.js.snap
@@ -14,6 +14,7 @@ exports[`BpkTouchableOverlay dark mode should render correctly 1`] = `
   style={null}
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -67,6 +68,7 @@ exports[`BpkTouchableOverlay dark mode should render correctly with custom style
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -116,6 +118,7 @@ exports[`BpkTouchableOverlay light mode should render correctly 1`] = `
   style={null}
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -169,6 +172,7 @@ exports[`BpkTouchableOverlay light mode should render correctly with custom styl
   }
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -219,6 +223,7 @@ exports[`BpkTouchableOverlay should render correctly with arbitrary props 1`] = 
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -269,6 +274,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -322,6 +328,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -375,6 +382,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -428,6 +436,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -481,6 +490,7 @@ exports[`BpkTouchableOverlay should render correctly with border radius props se
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [
@@ -534,6 +544,7 @@ exports[`BpkTouchableOverlay should render correctly with custom overlay styles 
   testID="arbitrary value"
 >
   <Text
+    allowFontScaling={false}
     maxFontSizeMultiplier={3.2}
     style={
       Array [


### PR DESCRIPTION
Updating the BpkText comment so the resizing does of text does not occur when the phones text is increased through accessibility settings. This is currently the behaviour in native screens and this behaviour should be present in react native screens, and therefore over al screens. 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
