### PR TITLE
[NO-JIRA] Fix withAppearance types

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- react-native-bpk-appearance:
+  - Fix `withBpkAppearance` type definition.
+
 **Added:**
 
 - react-native-bpk-component-panel:

--- a/packages/react-native-bpk-appearance/README.md
+++ b/packages/react-native-bpk-appearance/README.md
@@ -179,7 +179,7 @@ const defaultProps = {
   user: { guest: true }
 };
 
-class UserProfile extends Component<{ ...Props, ...WithBpkAppearanceInjectedProps}> {
+class UserProfile extends Component<Props & WithBpkAppearanceInjectedProps> {
   render() {
     const { bpkAppearance, user } = this.props;
     const currentStyle = unpackBpkDynamicValue(style, bpkAppearance);
@@ -356,7 +356,7 @@ NOTE: If you are using a functional component use one of the provided hooks inst
 import React, { type Config } from 'react';
 import { type WithBpkAppearanceInjectedProps, withBpkAppearance } from 'react-native-bpk-appearance';
 
-class MyComponent extends Component<{ ...Props, ...WithBpkAppearanceInjectedProps }> {
+class MyComponent extends Component<Props & WithBpkAppearanceInjectedProps> {
  render() {
    const { bpkAppearance, ...rest } = this.props;
    ....

--- a/packages/react-native-bpk-appearance/src/withBpkAppearance.js
+++ b/packages/react-native-bpk-appearance/src/withBpkAppearance.js
@@ -38,7 +38,7 @@ const getDisplayName = Component =>
  * import React, { type Config } from 'react';
  * import { type WithBpkAppearanceInjectedProps, withBpkAppearance } from 'react-native-bpk-appearance';
  *
- * class MyComponent extends Component<{ ...Props, ...WithBpkAppearanceInjectedProps }> {
+ * class MyComponent extends Component<Props & WithBpkAppearanceInjectedProps> {
  *  render() {
  *    const { bpkAppearance, ...rest } = this.props;
  *    ....
@@ -51,7 +51,7 @@ const getDisplayName = Component =>
  * @returns {Component} the wrapped component with an extra `bpkAppearance` prop.
  */
 const withBpkAppearance = <Config>(
-  Component: AbstractComponent<{ ...Config, ...InjectedProps }>,
+  Component: AbstractComponent<{| ...$Exact<Config>, ...InjectedProps |}>,
 ): AbstractComponent<Config> => {
   // eslint-disable-next-line prettier/prettier
   const WithBpkAppearance = React.forwardRef((props, ref) => {

--- a/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
+++ b/packages/react-native-bpk-component-flat-list/src/BpkFlatListItem.ios.js
@@ -79,10 +79,9 @@ const dynamicStyles = BpkDynamicStyleSheet.create({
   },
 });
 
-class BpkFlatListItem extends React.PureComponent<{
-  ...FlatListItemProps,
-  ...WithBpkAppearanceInjectedProps,
-}> {
+class BpkFlatListItem extends React.PureComponent<
+  FlatListItemProps & WithBpkAppearanceInjectedProps,
+> {
   static propTypes = LIST_ITEM_PROP_TYPES;
 
   static defaultProps = LIST_ITEM_DEFAULT_PROPS;

--- a/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/packages/react-native-bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -18,12 +18,7 @@
 
 /* @flow */
 
-import {
-  I18nManager,
-  ScrollView,
-  View,
-  ViewPropTypes,
-} from 'react-native';
+import { I18nManager, ScrollView, View, ViewPropTypes } from 'react-native';
 import React, { type Node, type ElementProps, type Config } from 'react';
 import PropTypes from 'prop-types';
 import { lineColor, borderSizeSm } from 'bpk-tokens/tokens/base.react.native';
@@ -85,10 +80,10 @@ type State = {
 const defaultProps = {
   spaceAround: false,
   style: null,
-}
+};
 
 class BpkHorizontalNav extends React.Component<
-  { ...Props, ...WithBpkAppearanceInjectedProps },
+  Props & WithBpkAppearanceInjectedProps,
   State,
 > {
   static propTypes = {
@@ -202,4 +197,5 @@ class BpkHorizontalNav extends React.Component<
   }
 }
 
-export default withBpkAppearance<Config<Props, typeof defaultProps>>(BpkHorizontalNav); // eslint-disable-line prettier/prettier
+type PropsConfig = Config<Props, typeof defaultProps>;
+export default withBpkAppearance<PropsConfig>(BpkHorizontalNav); // eslint-disable-line prettier/prettier

--- a/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.ios.js
+++ b/packages/react-native-bpk-component-navigation-bar/src/BpkNavigationBar.ios.js
@@ -127,7 +127,7 @@ export type Props = {
   style: ViewStyleProp,
 };
 
-type EnhancedProps = { ...Props, ...WithBpkAppearanceInjectedProps };
+type EnhancedProps = Props & WithBpkAppearanceInjectedProps;
 
 class BpkNavigationBar extends Component<EnhancedProps, {}> {
   theme: ?IOSTheme;


### PR DESCRIPTION
Because we use inexact types for props (so we can have ...rest) the current type definition was not able to ensure the type of a specific key after combining both types. So a prop that was initially defined as `string` would become `void | string` after using this HOC.

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
