### PR TITLE
[BPK-3323] Changed picker scrim colour on Android

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,10 +2,14 @@
 
 > Place your changes below this line.
 
+
 **Fixed:**
 
 - react-native-bpk-appearance:
   - Fix `withBpkAppearance` type definition.
+
+- react-native-bpk-component-picker:
+  - Changed the overlay/scrim colour on Android to match the underlying platform instead of using a colour token from Backpack.
 
 **Added:**
 

--- a/packages/react-native-bpk-component-picker/src/BpkPickerMenu.android.js
+++ b/packages/react-native-bpk-component-picker/src/BpkPickerMenu.android.js
@@ -29,7 +29,6 @@ import {
 import { setOpacity } from 'bpk-tokens';
 import {
   borderRadiusSm,
-  colorSkyGray,
   colorWhite,
   lineHeightBase,
   spacingBase,
@@ -44,6 +43,10 @@ import {
 
 const MAX_ROWS_TO_DISPLAY = 6;
 
+// To match the platform standard we mirror Android instead of using a
+// Backpack colour.
+const ANDROID_OVERLAY_COLOR = setOpacity('black', 0.6);
+
 const styles = StyleSheet.create({
   overlay: {
     left: 0,
@@ -51,7 +54,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     width: '100%',
-    backgroundColor: setOpacity(colorSkyGray, 0.8),
+    backgroundColor: ANDROID_OVERLAY_COLOR,
   },
   listWrapper: {
     flexDirection: 'row',

--- a/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
+++ b/packages/react-native-bpk-component-picker/src/__snapshots__/BpkPicker-test.android.js.snap
@@ -20,7 +20,7 @@ exports[`Android BpkPicker should render correctly 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "backgroundColor": "rgba(17, 18, 54, 0.8)",
+        "backgroundColor": "rgba(0, 0, 0, 0.6)",
         "height": "100%",
         "left": 0,
         "position": "absolute",
@@ -224,7 +224,7 @@ exports[`Android BpkPicker should render correctly with a selected value 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       Object {
-        "backgroundColor": "rgba(17, 18, 54, 0.8)",
+        "backgroundColor": "rgba(0, 0, 0, 0.6)",
         "height": "100%",
         "left": 0,
         "position": "absolute",


### PR DESCRIPTION
The below screenshots are evidence that it matches the platform. The first screenshot is from a native Android menu and the second one is from the picker. Note how they match!

![Screen Shot 2019-11-27 at 13 38 41 (3)](https://user-images.githubusercontent.com/73652/69728530-810b9d80-111c-11ea-99c7-226cc413031f.png)
![Screen Shot 2019-11-27 at 13 38 22 (3)](https://user-images.githubusercontent.com/73652/69728531-810b9d80-111c-11ea-9c59-e97ac5bc2840.png)
