### PR TITLE
[BPK-3309] Fix text input font theming

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,14 @@
 
 - react-native-bpk-component-star-rating:
   - Added dark mode support.
+  
+**Fixed:**
+
+- react-native-bpk-theming
+  - `getThemeAttributes` now always returns optional props if they are present in the theme.
+
+- react-native-bpk-component-text-input
+  - `textFontFamily` theme prop is now optional.
 
 ## How to write a good changelog entry
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -108,13 +108,13 @@ const androidSnapshotsWithIosTokens = fileChanges.filter(filePath => {
 
   const fileContent = fs.readFileSync(filePath).toString();
 
-  return fileContent.includes(`"fontFamily": ${iosProps.FONT_FAMILY.VALUE},`);
+  return fileContent.includes(`"fontFamily": ${iosProps.FONT_FAMILY.value},`);
 });
 
 if (androidSnapshotsWithIosTokens.length > 0) {
   // eslint-disable-next-line max-len
   fail(
-    `iOS tokens have been found in the following Android snapshots:\n  - ${androidSnapshotsWithIosTokens.join(
+    `iOS "fontFamily" tokens have been found in the following Android snapshots:\n  - ${androidSnapshotsWithIosTokens.join(
       '\n  - ',
     )}`,
   );

--- a/packages/react-native-bpk-component-text-input/README.md
+++ b/packages/react-native-bpk-component-text-input/README.md
@@ -120,5 +120,10 @@ More details about how to use and define a mask can be found here: https://githu
 
 ## Theme Props
 
-* `textFontFamily`
+### Required
+
 * `textInputFocusedColor`
+
+### Optional
+
+* `textFontFamily`

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
@@ -196,7 +196,7 @@ const commonTests = () => {
 
       it('should support font theming', () => {
         const theme = {
-          textFontFamily: 'roboto',
+          textFontFamily: 'relative',
         };
         const testRenderer = TestRenderer.create(
           <BpkThemeProvider theme={theme}>

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
@@ -193,6 +193,18 @@ const commonTests = () => {
         );
         expect(testRenderer.toJSON()).toMatchSnapshot();
       });
+
+      it('should support font theming', () => {
+        const theme = {
+          textFontFamily: 'roboto',
+        };
+        const testRenderer = TestRenderer.create(
+          <BpkThemeProvider theme={theme}>
+            <WithColorScheme label="Name" value="" />
+          </BpkThemeProvider>,
+        );
+        expect(testRenderer.toJSON()).toMatchSnapshot();
+      });
     });
   });
 };

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -42,7 +42,11 @@ import {
   getPlaceholderColor,
   getStyles,
 } from './styles';
-import { REQUIRED_THEME_ATTRIBUTES, themePropType } from './theming';
+import {
+  REQUIRED_THEME_ATTRIBUTES,
+  OPTIONAL_THEME_ATTRIBUTES,
+  themePropType,
+} from './theming';
 
 export type Props = {
   label: string,
@@ -212,6 +216,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
     const themeAttributes = getThemeAttributes(
       REQUIRED_THEME_ATTRIBUTES,
       theme,
+      OPTIONAL_THEME_ATTRIBUTES,
     );
 
     const focusedColor = themeAttributes

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -241,7 +241,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
 
     const inputTextStyle = [styles.input];
 
-    if (themeAttributes) {
+    if (themeAttributes && themeAttributes.textFontFamily) {
       inputTextStyle.push({ fontFamily: themeAttributes.textFontFamily });
       animatedLabelStyle.push({ fontFamily: themeAttributes.textFontFamily });
     }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -1292,7 +1292,7 @@ exports[`RTL BpkTextInput dark mode should support font theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "roboto",
+          "fontFamily": "relative",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1337,7 +1337,7 @@ exports[`RTL BpkTextInput dark mode should support font theming 1`] = `
               "textAlign": "right",
             },
             Object {
-              "fontFamily": "roboto",
+              "fontFamily": "relative",
             },
           ]
         }
@@ -2717,7 +2717,7 @@ exports[`RTL BpkTextInput light mode should support font theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "roboto",
+          "fontFamily": "relative",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2762,7 +2762,7 @@ exports[`RTL BpkTextInput light mode should support font theming 1`] = `
               "textAlign": "right",
             },
             Object {
-              "fontFamily": "roboto",
+              "fontFamily": "relative",
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -1273,7 +1273,7 @@ exports[`RTL BpkTextInput dark mode should render correctly with value 1`] = `
 </View>
 `;
 
-exports[`RTL BpkTextInput dark mode should support theming 1`] = `
+exports[`RTL BpkTextInput dark mode should support font theming 1`] = `
 <View
   style={null}
 >
@@ -1292,7 +1292,7 @@ exports[`RTL BpkTextInput dark mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "System",
+          "fontFamily": "roboto",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1335,6 +1335,85 @@ exports[`RTL BpkTextInput dark mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "right",
+            },
+            Object {
+              "fontFamily": "roboto",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RTL BpkTextInput dark mode should support theming 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(178, 178, 191, 1)",
+          "fontFamily": undefined,
+          "fontSize": 16,
+          "fontWeight": "400",
+          "lineHeight": 19,
+          "position": "absolute",
+          "top": 20,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(68, 69, 96, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(178, 178, 191)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(255, 255, 255)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "right",
+            },
+            Object {
+              "fontFamily": undefined,
             },
           ]
         }
@@ -2619,7 +2698,7 @@ exports[`RTL BpkTextInput light mode should render correctly with value 1`] = `
 </View>
 `;
 
-exports[`RTL BpkTextInput light mode should support theming 1`] = `
+exports[`RTL BpkTextInput light mode should support font theming 1`] = `
 <View
   style={null}
 >
@@ -2638,7 +2717,7 @@ exports[`RTL BpkTextInput light mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "System",
+          "fontFamily": "roboto",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2681,6 +2760,85 @@ exports[`RTL BpkTextInput light mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "right",
+            },
+            Object {
+              "fontFamily": "roboto",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RTL BpkTextInput light mode should support theming 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(178, 178, 191, 1)",
+          "fontFamily": undefined,
+          "fontSize": 16,
+          "fontWeight": "400",
+          "lineHeight": 19,
+          "position": "absolute",
+          "top": 20,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(221, 221, 229, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(205, 205, 215)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(17, 18, 54)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "right",
+            },
+            Object {
+              "fontFamily": undefined,
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -1368,7 +1368,7 @@ exports[`RTL BpkTextInput dark mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": undefined,
+          "fontFamily": "System",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1411,9 +1411,6 @@ exports[`RTL BpkTextInput dark mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "right",
-            },
-            Object {
-              "fontFamily": undefined,
             },
           ]
         }
@@ -2793,7 +2790,7 @@ exports[`RTL BpkTextInput light mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": undefined,
+          "fontFamily": "System",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2836,9 +2833,6 @@ exports[`RTL BpkTextInput light mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "right",
-            },
-            Object {
-              "fontFamily": undefined,
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -1368,7 +1368,7 @@ exports[`Android BpkTextInput dark mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": undefined,
+          "fontFamily": "sans-serif",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1411,9 +1411,6 @@ exports[`Android BpkTextInput dark mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
-            },
-            Object {
-              "fontFamily": undefined,
             },
           ]
         }
@@ -2793,7 +2790,7 @@ exports[`Android BpkTextInput light mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": undefined,
+          "fontFamily": "sans-serif",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2836,9 +2833,6 @@ exports[`Android BpkTextInput light mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
-            },
-            Object {
-              "fontFamily": undefined,
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -1273,7 +1273,7 @@ exports[`Android BpkTextInput dark mode should render correctly with value 1`] =
 </View>
 `;
 
-exports[`Android BpkTextInput dark mode should support theming 1`] = `
+exports[`Android BpkTextInput dark mode should support font theming 1`] = `
 <View
   style={null}
 >
@@ -1292,7 +1292,7 @@ exports[`Android BpkTextInput dark mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "sans-serif",
+          "fontFamily": "roboto",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1335,6 +1335,85 @@ exports[`Android BpkTextInput dark mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
+            },
+            Object {
+              "fontFamily": "roboto",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkTextInput dark mode should support theming 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 16,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(178, 178, 191, 1)",
+          "fontFamily": undefined,
+          "fontSize": 16,
+          "fontWeight": "400",
+          "lineHeight": 19,
+          "position": "absolute",
+          "top": 19,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(68, 69, 96, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(178, 178, 191)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(255, 255, 255)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+            Object {
+              "fontFamily": undefined,
             },
           ]
         }
@@ -2619,7 +2698,7 @@ exports[`Android BpkTextInput light mode should render correctly with value 1`] 
 </View>
 `;
 
-exports[`Android BpkTextInput light mode should support theming 1`] = `
+exports[`Android BpkTextInput light mode should support font theming 1`] = `
 <View
   style={null}
 >
@@ -2638,7 +2717,7 @@ exports[`Android BpkTextInput light mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "sans-serif",
+          "fontFamily": "roboto",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2681,6 +2760,85 @@ exports[`Android BpkTextInput light mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
+            },
+            Object {
+              "fontFamily": "roboto",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkTextInput light mode should support theming 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 16,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(178, 178, 191, 1)",
+          "fontFamily": undefined,
+          "fontSize": 16,
+          "fontWeight": "400",
+          "lineHeight": 19,
+          "position": "absolute",
+          "top": 19,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(221, 221, 229, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(205, 205, 215)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(17, 18, 54)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+            Object {
+              "fontFamily": undefined,
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -1292,7 +1292,7 @@ exports[`Android BpkTextInput dark mode should support font theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "roboto",
+          "fontFamily": "relative",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1337,7 +1337,7 @@ exports[`Android BpkTextInput dark mode should support font theming 1`] = `
               "textAlign": "left",
             },
             Object {
-              "fontFamily": "roboto",
+              "fontFamily": "relative",
             },
           ]
         }
@@ -2717,7 +2717,7 @@ exports[`Android BpkTextInput light mode should support font theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "roboto",
+          "fontFamily": "relative",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2762,7 +2762,7 @@ exports[`Android BpkTextInput light mode should support font theming 1`] = `
               "textAlign": "left",
             },
             Object {
-              "fontFamily": "roboto",
+              "fontFamily": "relative",
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -1368,7 +1368,7 @@ exports[`iOS BpkTextInput dark mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": undefined,
+          "fontFamily": "System",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1411,9 +1411,6 @@ exports[`iOS BpkTextInput dark mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
-            },
-            Object {
-              "fontFamily": undefined,
             },
           ]
         }
@@ -2793,7 +2790,7 @@ exports[`iOS BpkTextInput light mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": undefined,
+          "fontFamily": "System",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2836,9 +2833,6 @@ exports[`iOS BpkTextInput light mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
-            },
-            Object {
-              "fontFamily": undefined,
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -1292,7 +1292,7 @@ exports[`iOS BpkTextInput dark mode should support font theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "roboto",
+          "fontFamily": "relative",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1337,7 +1337,7 @@ exports[`iOS BpkTextInput dark mode should support font theming 1`] = `
               "textAlign": "left",
             },
             Object {
-              "fontFamily": "roboto",
+              "fontFamily": "relative",
             },
           ]
         }
@@ -2717,7 +2717,7 @@ exports[`iOS BpkTextInput light mode should support font theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "roboto",
+          "fontFamily": "relative",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2762,7 +2762,7 @@ exports[`iOS BpkTextInput light mode should support font theming 1`] = `
               "textAlign": "left",
             },
             Object {
-              "fontFamily": "roboto",
+              "fontFamily": "relative",
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -1273,7 +1273,7 @@ exports[`iOS BpkTextInput dark mode should render correctly with value 1`] = `
 </View>
 `;
 
-exports[`iOS BpkTextInput dark mode should support theming 1`] = `
+exports[`iOS BpkTextInput dark mode should support font theming 1`] = `
 <View
   style={null}
 >
@@ -1292,7 +1292,7 @@ exports[`iOS BpkTextInput dark mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "System",
+          "fontFamily": "roboto",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -1335,6 +1335,85 @@ exports[`iOS BpkTextInput dark mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
+            },
+            Object {
+              "fontFamily": "roboto",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`iOS BpkTextInput dark mode should support theming 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(178, 178, 191, 1)",
+          "fontFamily": undefined,
+          "fontSize": 16,
+          "fontWeight": "400",
+          "lineHeight": 19,
+          "position": "absolute",
+          "top": 20,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(68, 69, 96, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(178, 178, 191)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(255, 255, 255)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+            Object {
+              "fontFamily": undefined,
             },
           ]
         }
@@ -2619,7 +2698,7 @@ exports[`iOS BpkTextInput light mode should render correctly with value 1`] = `
 </View>
 `;
 
-exports[`iOS BpkTextInput light mode should support theming 1`] = `
+exports[`iOS BpkTextInput light mode should support font theming 1`] = `
 <View
   style={null}
 >
@@ -2638,7 +2717,7 @@ exports[`iOS BpkTextInput light mode should support theming 1`] = `
       style={
         Object {
           "color": "rgba(178, 178, 191, 1)",
-          "fontFamily": "System",
+          "fontFamily": "roboto",
           "fontSize": 16,
           "fontWeight": "400",
           "lineHeight": 19,
@@ -2681,6 +2760,85 @@ exports[`iOS BpkTextInput light mode should support theming 1`] = `
               "paddingHorizontal": 0,
               "paddingVertical": 4,
               "textAlign": "left",
+            },
+            Object {
+              "fontFamily": "roboto",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`iOS BpkTextInput light mode should support theming 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(178, 178, 191, 1)",
+          "fontFamily": undefined,
+          "fontSize": 16,
+          "fontWeight": "400",
+          "lineHeight": 19,
+          "position": "absolute",
+          "top": 20,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(221, 221, 229, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(205, 205, 215)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(17, 18, 54)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+            Object {
+              "fontFamily": undefined,
             },
           ]
         }

--- a/packages/react-native-bpk-component-text-input/src/theming.js
+++ b/packages/react-native-bpk-component-text-input/src/theming.js
@@ -20,8 +20,12 @@
 
 import { makeThemePropType } from 'react-native-bpk-theming';
 
-const REQUIRED_THEME_ATTRIBUTES = ['textFontFamily', 'textInputFocusedColor'];
+const REQUIRED_THEME_ATTRIBUTES = ['textInputFocusedColor'];
+const OPTIONAL_THEME_ATTRIBUTES = ['textFontFamily'];
 
-const themePropType = makeThemePropType(REQUIRED_THEME_ATTRIBUTES);
+const themePropType = makeThemePropType(
+  REQUIRED_THEME_ATTRIBUTES,
+  OPTIONAL_THEME_ATTRIBUTES,
+);
 
-export { REQUIRED_THEME_ATTRIBUTES, themePropType };
+export { REQUIRED_THEME_ATTRIBUTES, OPTIONAL_THEME_ATTRIBUTES, themePropType };


### PR DESCRIPTION
**NOTE** I also fixed the danger rule that validates if an iOS `fontFamily` token is being used in Android snapshots. 

Previously it was using the wrong prop `FONT_FAMILY.VALUE` instead of `FONT_FAMILY.value`. So it was actually checking for `fontFamily` equals to `undefined`. 

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
