### PR TITLE
[NO-JIRA] Make text input value optional

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- react-native-bpk-component-text-input:
+  - property `value` is now optional to match react native text input behaviour.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -67,13 +67,13 @@ PODS:
     - React-cxxreact (= 0.60.4)
     - React-jsi (= 0.60.4)
   - React-jsinspector (0.60.4)
-  - react-native-bpk-component-calendar (4.0.16):
+  - react-native-bpk-component-calendar (4.0.17):
     - Backpack (~> 23.0)
     - React
-  - react-native-bpk-component-dialog (4.0.15):
+  - react-native-bpk-component-dialog (4.0.16):
     - Backpack (~> 23.0)
     - React
-  - react-native-bpk-component-rating (0.0.8):
+  - react-native-bpk-component-rating (0.0.9):
     - Backpack (~> 23.0)
     - React
   - react-native-maps (0.26.1):
@@ -223,9 +223,9 @@ SPEC CHECKSUMS:
   React-jsi: 21d3153b1153fbf6510a92b6b11e33e725cb7432
   React-jsiexecutor: 7549641e48bafae7bfee3f3ea19bf4901639c5de
   React-jsinspector: 73f24a02fa684ed6a2b828ba116874a2191ded88
-  react-native-bpk-component-calendar: 712fd8bb369fbf03209f4dccd4bd90220faff0f8
-  react-native-bpk-component-dialog: f56f34ca249d6ce6098053a01eda05a9bebd18f3
-  react-native-bpk-component-rating: 73008cafe7ce74aebf6cac6ec76d72f583859499
+  react-native-bpk-component-calendar: bf5341afd56001b05c6777e39c8e5a536641e602
+  react-native-bpk-component-dialog: d3b0fbca231634164ce0ae60d29901507a57cdd0
+  react-native-bpk-component-rating: 470544dd179449137b6f65b31deab616390059ae
   react-native-maps: 6e499eee4eabf422ba8b6f94e993cc768bf35153
   React-RCTActionSheet: 9f71d7ae3e8fb10e08d162cbf14c621349dbfab3
   React-RCTAnimation: 981d8c95b0e30918a9832ccac32af83562a27fae

--- a/packages/react-native-bpk-component-text-input/README.md
+++ b/packages/react-native-bpk-component-text-input/README.md
@@ -103,7 +103,6 @@ export default class App extends Component {
 | Property                    | PropType                                                    | Required | Default Value |
 | --------------------------- | ----------------------------------------------------------- | -------- | ------------- |
 | label                       | string                                                      | true     | -             |
-| value                       | string                                                      | true     | -             |
 | clearButtonMode (iOS only)  | oneOf('never', 'while-editing', 'unless-editing', 'always') | false    | while-editing |
 | description                 | string                                                      | false    | null          |
 | editable                    | bool                                                        | false    | true          |
@@ -113,6 +112,7 @@ export default class App extends Component {
 | validationMessage           | string                                                      | false    | null          |
 | style                       | style                                                       | false    | null          |
 | accessoryView               | node                                                        | false    | null          |
+| value                       | string                                                      | false    | undefined     |
 
 ## Mask
 

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput-test.common.js
@@ -32,7 +32,7 @@ const commonTests = () => {
     describeEachColorScheme(BpkTextInput, WithColorScheme => {
       it('should render correctly', () => {
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" />,
+          <WithColorScheme label="Name" />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -40,7 +40,7 @@ const commonTests = () => {
 
       it('should render correctly with arbitrary props', () => {
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" testId="arbitrary" />,
+          <WithColorScheme label="Name" testId="arbitrary" />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -54,7 +54,7 @@ const commonTests = () => {
         });
 
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" style={styles.custom} />,
+          <WithColorScheme label="Name" style={styles.custom} />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -96,7 +96,7 @@ const commonTests = () => {
 
       it('should render correctly with valid', () => {
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" valid />,
+          <WithColorScheme label="Name" valid />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -104,7 +104,7 @@ const commonTests = () => {
 
       it('should render correctly with valid false', () => {
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" valid={false} />,
+          <WithColorScheme label="Name" valid={false} />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -148,7 +148,7 @@ const commonTests = () => {
 
       it('should ignore when placeholder is provided, as element is not focused', () => {
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" placeholder="Placeholder" />,
+          <WithColorScheme label="Name" placeholder="Placeholder" />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -156,7 +156,7 @@ const commonTests = () => {
 
       it('should render correctly with `accessoryView`', () => {
         const testRenderer = TestRenderer.create(
-          <WithColorScheme label="Name" value="" accessoryView={<View />} />,
+          <WithColorScheme label="Name" accessoryView={<View />} />,
         );
 
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -188,7 +188,7 @@ const commonTests = () => {
         };
         const testRenderer = TestRenderer.create(
           <BpkThemeProvider theme={theme}>
-            <WithColorScheme label="Name" value="" />
+            <WithColorScheme label="Name" />
           </BpkThemeProvider>,
         );
         expect(testRenderer.toJSON()).toMatchSnapshot();
@@ -200,7 +200,7 @@ const commonTests = () => {
         };
         const testRenderer = TestRenderer.create(
           <BpkThemeProvider theme={theme}>
-            <WithColorScheme label="Name" value="" />
+            <WithColorScheme label="Name" />
           </BpkThemeProvider>,
         );
         expect(testRenderer.toJSON()).toMatchSnapshot();

--- a/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
+++ b/packages/react-native-bpk-component-text-input/src/BpkTextInput.js
@@ -50,7 +50,6 @@ import {
 
 export type Props = {
   label: string,
-  value: string,
   clearButtonMode: 'never' | 'while-editing' | 'unless-editing' | 'always',
   editable: boolean,
   description: ?string,
@@ -63,12 +62,12 @@ export type Props = {
   valid: ?boolean,
   validationMessage: ?string,
   accessoryView: ?Node,
+  value: ?string,
   theme: ?Theme,
 };
 
 export const propTypes = {
   label: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-foreign-prop-types
   clearButtonMode: TextInput.propTypes.clearButtonMode,
   description: PropTypes.string,
@@ -82,6 +81,7 @@ export const propTypes = {
   valid: PropTypes.oneOf([true, false, null]),
   validationMessage: PropTypes.string,
   accessoryView: PropTypes.node,
+  value: PropTypes.string,
   theme: themePropType,
 };
 
@@ -98,6 +98,7 @@ export const defaultProps = {
   valid: null,
   validationMessage: null,
   accessoryView: null,
+  value: undefined,
   theme: null,
 };
 
@@ -279,7 +280,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
           <Animated.View style={animatedInputStyle}>
             <TextInput
               editable={editable}
-              value={mask ? this.tinymask.mask(value) : value || ''}
+              value={mask && value ? this.tinymask.mask(value) : value}
               style={inputTextStyle}
               onFocus={this.onFocus}
               onBlur={this.onBlur}

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -66,7 +66,6 @@ exports[`RTL BpkTextInput dark mode should ignore when placeholder is provided, 
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -139,7 +138,6 @@ exports[`RTL BpkTextInput dark mode should render correctly 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -214,7 +212,6 @@ exports[`RTL BpkTextInput dark mode should render correctly with \`accessoryView
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -288,7 +285,6 @@ exports[`RTL BpkTextInput dark mode should render correctly with arbitrary props
         }
         testId="arbitrary"
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -365,7 +361,6 @@ exports[`RTL BpkTextInput dark mode should render correctly with custom style 1`
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -945,7 +940,6 @@ exports[`RTL BpkTextInput dark mode should render correctly with valid 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -1045,7 +1039,6 @@ exports[`RTL BpkTextInput dark mode should render correctly with valid false 1`]
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -1342,7 +1335,6 @@ exports[`RTL BpkTextInput dark mode should support font theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1415,7 +1407,6 @@ exports[`RTL BpkTextInput dark mode should support theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1488,7 +1479,6 @@ exports[`RTL BpkTextInput light mode should ignore when placeholder is provided,
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1561,7 +1551,6 @@ exports[`RTL BpkTextInput light mode should render correctly 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1636,7 +1625,6 @@ exports[`RTL BpkTextInput light mode should render correctly with \`accessoryVie
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1710,7 +1698,6 @@ exports[`RTL BpkTextInput light mode should render correctly with arbitrary prop
         }
         testId="arbitrary"
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1787,7 +1774,6 @@ exports[`RTL BpkTextInput light mode should render correctly with custom style 1
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -2367,7 +2353,6 @@ exports[`RTL BpkTextInput light mode should render correctly with valid 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -2467,7 +2452,6 @@ exports[`RTL BpkTextInput light mode should render correctly with valid false 1`
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -2764,7 +2748,6 @@ exports[`RTL BpkTextInput light mode should support font theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -2837,7 +2820,6 @@ exports[`RTL BpkTextInput light mode should support theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -66,7 +66,6 @@ exports[`Android BpkTextInput dark mode should ignore when placeholder is provid
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -139,7 +138,6 @@ exports[`Android BpkTextInput dark mode should render correctly 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -214,7 +212,6 @@ exports[`Android BpkTextInput dark mode should render correctly with \`accessory
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -288,7 +285,6 @@ exports[`Android BpkTextInput dark mode should render correctly with arbitrary p
         }
         testId="arbitrary"
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -365,7 +361,6 @@ exports[`Android BpkTextInput dark mode should render correctly with custom styl
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -945,7 +940,6 @@ exports[`Android BpkTextInput dark mode should render correctly with valid 1`] =
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -1045,7 +1039,6 @@ exports[`Android BpkTextInput dark mode should render correctly with valid false
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -1342,7 +1335,6 @@ exports[`Android BpkTextInput dark mode should support font theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1415,7 +1407,6 @@ exports[`Android BpkTextInput dark mode should support theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1488,7 +1479,6 @@ exports[`Android BpkTextInput light mode should ignore when placeholder is provi
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1561,7 +1551,6 @@ exports[`Android BpkTextInput light mode should render correctly 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1636,7 +1625,6 @@ exports[`Android BpkTextInput light mode should render correctly with \`accessor
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1710,7 +1698,6 @@ exports[`Android BpkTextInput light mode should render correctly with arbitrary 
         }
         testId="arbitrary"
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1787,7 +1774,6 @@ exports[`Android BpkTextInput light mode should render correctly with custom sty
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -2367,7 +2353,6 @@ exports[`Android BpkTextInput light mode should render correctly with valid 1`] 
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -2467,7 +2452,6 @@ exports[`Android BpkTextInput light mode should render correctly with valid fals
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -2764,7 +2748,6 @@ exports[`Android BpkTextInput light mode should support font theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -2837,7 +2820,6 @@ exports[`Android BpkTextInput light mode should support theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>

--- a/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/packages/react-native-bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -66,7 +66,6 @@ exports[`iOS BpkTextInput dark mode should ignore when placeholder is provided, 
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -139,7 +138,6 @@ exports[`iOS BpkTextInput dark mode should render correctly 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -214,7 +212,6 @@ exports[`iOS BpkTextInput dark mode should render correctly with \`accessoryView
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -288,7 +285,6 @@ exports[`iOS BpkTextInput dark mode should render correctly with arbitrary props
         }
         testId="arbitrary"
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -365,7 +361,6 @@ exports[`iOS BpkTextInput dark mode should render correctly with custom style 1`
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -945,7 +940,6 @@ exports[`iOS BpkTextInput dark mode should render correctly with valid 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -1045,7 +1039,6 @@ exports[`iOS BpkTextInput dark mode should render correctly with valid false 1`]
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -1342,7 +1335,6 @@ exports[`iOS BpkTextInput dark mode should support font theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1415,7 +1407,6 @@ exports[`iOS BpkTextInput dark mode should support theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1488,7 +1479,6 @@ exports[`iOS BpkTextInput light mode should ignore when placeholder is provided,
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1561,7 +1551,6 @@ exports[`iOS BpkTextInput light mode should render correctly 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1636,7 +1625,6 @@ exports[`iOS BpkTextInput light mode should render correctly with \`accessoryVie
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1710,7 +1698,6 @@ exports[`iOS BpkTextInput light mode should render correctly with arbitrary prop
         }
         testId="arbitrary"
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -1787,7 +1774,6 @@ exports[`iOS BpkTextInput light mode should render correctly with custom style 1
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -2367,7 +2353,6 @@ exports[`iOS BpkTextInput light mode should render correctly with valid 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -2467,7 +2452,6 @@ exports[`iOS BpkTextInput light mode should render correctly with valid false 1`
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
       <Text
         allowFontScaling={false}
@@ -2764,7 +2748,6 @@ exports[`iOS BpkTextInput light mode should support font theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>
@@ -2837,7 +2820,6 @@ exports[`iOS BpkTextInput light mode should support theming 1`] = `
           ]
         }
         underlineColorAndroid="transparent"
-        value=""
       />
     </View>
   </View>

--- a/packages/react-native-bpk-component-text-input/src/styles.js
+++ b/packages/react-native-bpk-component-text-input/src/styles.js
@@ -124,7 +124,7 @@ const animatedStyles = StyleSheet.create({
 });
 
 const getLabelColorValue = (
-  value: string,
+  value: ?string,
   valid: ?boolean,
   editable: boolean,
   hasAccessoryView: boolean,
@@ -158,7 +158,7 @@ const getLabelStyle = (
     editable,
     hasAccessoryView,
   }: {
-    value: string,
+    value: ?string,
     valid: ?boolean,
     editable: boolean,
     hasAccessoryView: boolean,

--- a/packages/react-native-bpk-component-text-input/stories.js
+++ b/packages/react-native-bpk-component-text-input/stories.js
@@ -18,10 +18,11 @@
 
 /* @flow */
 
-import React, { Component } from 'react';
+import React, { Component, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { ScrollView, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
+import { action } from '@storybook/addon-actions';
 import {
   lineColor,
   backgroundSecondaryColor,
@@ -51,11 +52,15 @@ const dynamicStyles = BpkDynamicStyleSheet.create({
 });
 
 class StatefulBpkTextInput extends Component<
-  { initialValue: string, label: string },
-  { value: string },
+  { initialValue: string | typeof undefined, label: string },
+  { value: string | typeof undefined },
 > {
   static propTypes = {
-    initialValue: PropTypes.string.isRequired,
+    initialValue: PropTypes.string,
+  };
+
+  static defaultProps = {
+    initialValue: undefined,
   };
 
   constructor(props) {
@@ -88,18 +93,20 @@ storiesOf('react-native-bpk-component-text-input', module)
     return (
       <ScrollView>
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Input"
-          initialValue=""
           style={styles.input}
           placeholder="3 letter airport code"
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Input with value and description"
           initialValue="Edinburgh"
           description="Enter your destination."
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Input with multiline value"
           initialValue="Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor." // eslint-disable-line max-len
           multiline
@@ -107,12 +114,13 @@ storiesOf('react-native-bpk-component-text-input', module)
           autoGrow
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Valid input"
-          initialValue="Edinburgh"
           valid
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Invalid input"
           initialValue="Edinbvrgh"
           valid={false}
@@ -120,33 +128,35 @@ storiesOf('react-native-bpk-component-text-input', module)
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Non-editable input"
-          initialValue=""
           editable={false}
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Password"
           initialValue="letmein"
           secureTextEntry
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Phone number"
           initialValue="+441234567890"
           keyboardType="phone-pad"
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Input with date mask"
-          initialValue=""
           mask="99/99"
           maxLength={5}
           style={styles.input}
         />
         <StatefulBpkTextInput
+          onChange={action('changed')}
           label="Input with card number mask"
-          initialValue=""
           mask="9999-9999-9999-9999"
           maxLength={19}
           style={styles.input}
@@ -167,7 +177,6 @@ storiesOf('react-native-bpk-component-text-input', module)
         />
         <StatefulBpkTextInput
           label="Phone number"
-          initialValue=""
           keyboardType="phone-pad"
           style={styles.input}
           placeholder="E.g. 1234567890"
@@ -184,6 +193,37 @@ storiesOf('react-native-bpk-component-text-input', module)
       </ScrollView>
     );
   })
+  .add('With forced value', () => {
+    const [value, setValue] = useState('');
+    const onChange = useCallback((e: any) => {
+      const { text } = e.nativeEvent;
+      if (!text || text.length === 0) {
+        setValue('');
+      } else {
+        setValue(text.replace(/./g, '*'));
+      }
+    }, []);
+    const styles = useBpkDynamicStyleSheet(dynamicStyles);
+
+    return (
+      <BpkTextInput
+        label="Hidden input"
+        style={styles.input}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  })
+  .add('Uncontrolled', () => {
+    const styles = useBpkDynamicStyleSheet(dynamicStyles);
+    return (
+      <BpkTextInput
+        label="Uncontrolled"
+        style={[styles.input]}
+        onChange={action('changed')}
+      />
+    );
+  })
   .add('Themed', () => {
     const styles = useBpkDynamicStyleSheet(dynamicStyles);
     return (
@@ -191,7 +231,6 @@ storiesOf('react-native-bpk-component-text-input', module)
         <ScrollView>
           <StatefulBpkTextInput
             label="Input"
-            initialValue=""
             style={styles.input}
             placeholder="3 letter airport code"
           />


### PR DESCRIPTION
This is what the RN component does and now it can be used as an uncontrolled input if needed. https://facebook.github.io/react-native/docs/textinput#value 

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
