### PR TITLE
[BPK-3283] Fix prop type warnings for theming

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Changed:**
+
+- react-native-bpk-theming:
+  - Components that can be themed will now only throw a prop type error when a theme is partially applied. Previously, a prop type error would appear if a component was placed inside a `BpkThemeProvider` but no relevant theming props were given to it. This change enables the use of themed components alongside non-themed ones without seeing warnings.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Backpack (24.0.0):
+  - Backpack (24.0.1):
     - FloatingPanel (= 1.6.6)
     - FSCalendar (~> 2.8)
     - MBProgressHUD (~> 0.9.1)
@@ -67,13 +67,13 @@ PODS:
     - React-cxxreact (= 0.60.4)
     - React-jsi (= 0.60.4)
   - React-jsinspector (0.60.4)
-  - react-native-bpk-component-calendar (4.0.17):
+  - react-native-bpk-component-calendar (4.0.18):
     - Backpack (~> 24.0)
     - React
-  - react-native-bpk-component-dialog (4.0.16):
+  - react-native-bpk-component-dialog (4.0.17):
     - Backpack (~> 24.0)
     - React
-  - react-native-bpk-component-rating (0.0.9):
+  - react-native-bpk-component-rating (0.0.10):
     - Backpack (~> 24.0)
     - React
   - react-native-maps (0.26.1):
@@ -206,7 +206,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Backpack: 8a6bd13a29e315a4a09428a11c571fe3fd284bdb
+  Backpack: a5a3c5a92fc5bbca0d13d60fcbb99c59ba95f017
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: 0d985ec461359c82bc254f26d11008bdae50d17a
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
@@ -223,9 +223,9 @@ SPEC CHECKSUMS:
   React-jsi: 21d3153b1153fbf6510a92b6b11e33e725cb7432
   React-jsiexecutor: 7549641e48bafae7bfee3f3ea19bf4901639c5de
   React-jsinspector: 73f24a02fa684ed6a2b828ba116874a2191ded88
-  react-native-bpk-component-calendar: 55c6eef408545ab4b5b0adb6544acb7b8e0cb77a
-  react-native-bpk-component-dialog: d8d55fbf83f74c397f995d49ee060c00e68fd8dc
-  react-native-bpk-component-rating: ce0853430a67e579c1919ddca4a4e5de2d05d043
+  react-native-bpk-component-calendar: 0dc4ad8ddb390833d84798d5ff201240a62da901
+  react-native-bpk-component-dialog: cc99ca4b61e541e2b841e487da2f6d4a98898d8e
+  react-native-bpk-component-rating: 00e684acb99a1dec4a1362d5a22aef282abc1e5d
   react-native-maps: 6e499eee4eabf422ba8b6f94e993cc768bf35153
   React-RCTActionSheet: 9f71d7ae3e8fb10e08d162cbf14c621349dbfab3
   React-RCTAnimation: 981d8c95b0e30918a9832ccac32af83562a27fae

--- a/package-lock.json
+++ b/package-lock.json
@@ -9218,7 +9218,7 @@
     },
     "detect-libc": {
       "version": "1.0.3",
-      "resolved": "",
+      "resolved": false,
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true,
       "optional": true
@@ -11554,7 +11554,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -11572,7 +11572,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11599,7 +11599,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -20615,7 +20615,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true

--- a/packages/react-native-bpk-component-progress/README.md
+++ b/packages/react-native-bpk-component-progress/README.md
@@ -28,8 +28,8 @@ export default class App extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <BpkProgress min={0} max={100} value={10} />
-        <BpkProgress min={0} max={100} value={10} type="Bar" />
+        <BpkProgress min={0} max={100} value={10} accessibilityLabel="0 of 100" />
+        <BpkProgress min={0} max={100} value={10} accessibilityLabel="0 of 100" type="Bar" />
       </View>
     );
   }
@@ -46,7 +46,7 @@ export default class App extends Component {
 | value              | number                                | true     | -             |
 | fillStyle          | object                                | false    | -             |
 | style              | object                                | false    | -             |
-| theme              | See [Theme Props](#theme-props) below | false    | -             | 
+| theme              | See [Theme Props](#theme-props) below | false    | -             |
 | type               | oneOf('default', 'bar')               | false    | default       |
 
 

--- a/packages/react-native-bpk-theming/src/util-test.js
+++ b/packages/react-native-bpk-theming/src/util-test.js
@@ -35,6 +35,10 @@ const VALID_THEME = {
   themeAttributeC: true,
   nonRequiredAttribute: 'green',
 };
+// When zero required attributes are passed in, the theme is still valid.
+const VALID_EMPTY_THEME = {
+  nonRequiredAttribute: 'green',
+};
 const INVALID_THEME = {
   themeAttributeA: 'red',
   themeAttributeC: true,
@@ -44,6 +48,10 @@ const INVALID_THEME = {
 describe('isValidTheme', () => {
   it('should validated themes that are valid', () => {
     expect(isValidTheme(REQUIRED_ATTRIBUTES, VALID_THEME)).toBeTruthy();
+  });
+
+  it('should validated themes when none of the required props are passed in', () => {
+    expect(isValidTheme(REQUIRED_ATTRIBUTES, VALID_EMPTY_THEME)).toBeTruthy();
   });
 
   it('should fail to validate invalid themes', () => {
@@ -115,18 +123,14 @@ describe('makeThemePropType', () => {
       ).toBeFalsy();
     });
 
-    it('should fail when random props are provided', () => {
+    it('should not fail when random props are provided', () => {
       expect(
         propType(
           { style: { color: colorPanjin }, theme: { ramdom: '1' } },
           'theme',
           'TestComponent',
         ),
-      ).toEqual(
-        new Error(
-          'Invalid prop `theme` supplied to `TestComponent`. When supplying `theme` all the required theming attributes(`themeAttributeA, themeAttributeB, themeAttributeC`) must be supplied.',
-        ),
-      );
+      ).toBeFalsy();
     });
   });
 });

--- a/packages/react-native-bpk-theming/src/util.js
+++ b/packages/react-native-bpk-theming/src/util.js
@@ -37,19 +37,38 @@ const grays = {
   colorSkyGray,
 };
 
-export const isValidTheme = (
+const getNumberOfRequiredAttributesSupplied = (
   requiredAttributes: Array<string>,
   theme: Object,
-): boolean =>
-  requiredAttributes.reduce(
-    (valid, attribute) =>
+): number =>
+  requiredAttributes.reduce((accumulator, attribute) => {
+    if (
       has(theme, attribute) &&
       (isBoolean(theme[attribute]) ||
         isNumber(theme[attribute]) ||
-        !isEmpty(theme[attribute])) &&
-      valid,
-    true,
+        !isEmpty(theme[attribute]))
+    ) {
+      return accumulator + 1;
+    }
+    return accumulator;
+  }, 0);
+
+export const isValidTheme = (
+  requiredAttributes: Array<string>,
+  theme: Object,
+): boolean => {
+  const numberOfRequiredAttributesSupplied = getNumberOfRequiredAttributesSupplied(
+    requiredAttributes,
+    theme,
   );
+  if (numberOfRequiredAttributesSupplied === 0) {
+    return true;
+  }
+  if (numberOfRequiredAttributesSupplied === requiredAttributes.length) {
+    return true;
+  }
+  return false;
+};
 
 const filterOutOptionalProps = (
   requiredAttributes: Array<string>,
@@ -119,7 +138,10 @@ export const getThemeAttributes = (
     return null;
   }
 
-  const hasAllRequiredAttributes = isValidTheme(requiredAttributes, theme);
+  // We don't use `isValidTheme` here because we don't want to match themes that have zero required theme attributes.
+  const hasAllRequiredAttributes =
+    getNumberOfRequiredAttributesSupplied(requiredAttributes, theme) ===
+    requiredAttributes.length;
   const hasOptionalAttributes =
     optionalAttributes && optionalAttributes.length > 0;
 

--- a/packages/react-native-bpk-theming/stories.js
+++ b/packages/react-native-bpk-theming/stories.js
@@ -26,7 +26,6 @@ import {
   colorWhite,
   colorPanjin,
   colorSkyBlue,
-  colorSkyBlueTint01,
   colorErfoud,
   fontFamily,
 } from 'bpk-tokens/tokens/base.react.native';
@@ -45,15 +44,6 @@ type Theme = {
   buttonSecondaryTextColor: string,
   buttonSecondaryBackgroundColor: string,
   buttonSecondaryBorderColor: string,
-  primaryColor: string,
-  colorGray50: string,
-  colorSkyGrayTint06: string,
-  colorSkyGrayTint05: string,
-  colorSkyGrayTint04: string,
-  colorSkyGrayTint03: string,
-  colorSkyGrayTint02: string,
-  colorSkyGrayTint01: string,
-  colorSkyGray: string,
   textFontFamily: string,
 };
 
@@ -68,15 +58,6 @@ const generateThemeAttributes = (
   buttonSecondaryTextColor: gradientEndColor,
   buttonSecondaryBackgroundColor: colorWhite,
   buttonSecondaryBorderColor: gradientEndColor,
-  primaryColor: gradientStartColor,
-  colorGray50: '#F1F2F8',
-  colorSkyGrayTint06: '#DDDDE5',
-  colorSkyGrayTint05: '#CDCDD7',
-  colorSkyGrayTint04: '#B2B2BF',
-  colorSkyGrayTint03: '#8F90A0',
-  colorSkyGrayTint02: '#68697F',
-  colorSkyGrayTint01: '#444560',
-  colorSkyGray: '#111236',
   textFontFamily: textFontFamily || fontFamily,
 });
 
@@ -96,109 +77,6 @@ type State = {
   theme: Theme,
 };
 
-const SolidColorBlockPrimary = () => (
-  <BpkThemeAttributes>
-    {({ primaryColor }) => (
-      <View
-        style={[styles.solidColorBlock, { backgroundColor: primaryColor }]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-
-const SolidColorBlockGray50 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint07 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint07 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray100 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint06 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint06 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray200 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint05 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint05 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray300 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint04 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint04 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray400 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint03 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint03 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray500 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint02 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint02 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray700 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGrayTint01 }) => (
-      <View
-        style={[
-          styles.solidColorBlock,
-          { backgroundColor: colorSkyGrayTint01 },
-        ]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
-const SolidColorBlockGray900 = () => (
-  <BpkThemeAttributes>
-    {({ colorSkyGray }) => (
-      <View
-        style={[styles.solidColorBlock, { backgroundColor: colorSkyGray }]}
-      />
-    )}
-  </BpkThemeAttributes>
-);
 const BlockOfText = () => (
   <BpkThemeAttributes>
     {({ textFontFamily }) => (
@@ -219,7 +97,7 @@ class BpkThemePicker extends Component<{}, State> {
     this.themes = {
       blue: generateThemeAttributes(
         colorSkyBlue,
-        Platform.OS === 'ios' ? colorSkyBlueTint01 : colorSkyBlue,
+        colorSkyBlue,
         Platform.OS === 'android' ? 'serif-monospace' : 'Courier',
       ),
       yellow: generateThemeAttributes(colorErfoud, colorErfoud),
@@ -266,15 +144,6 @@ class BpkThemePicker extends Component<{}, State> {
               onPress={action('secondary themed button pressed')}
               style={styles.bottomMargin}
             />
-            <SolidColorBlockPrimary />
-            <SolidColorBlockGray50 />
-            <SolidColorBlockGray100 />
-            <SolidColorBlockGray200 />
-            <SolidColorBlockGray300 />
-            <SolidColorBlockGray400 />
-            <SolidColorBlockGray500 />
-            <SolidColorBlockGray700 />
-            <SolidColorBlockGray900 />
             <BlockOfText />
           </View>
         </BpkThemeProvider>


### PR DESCRIPTION
Previously, if you made no attempt to theme a component but placed it inside a `BpkThemeProvider` you would see warnings that you hadn't supplied all the required attributes.

For example:

```
<BpkThemeProvider 
    theme={ /* correct theme props for button but nothing for progress bar */}
>
    <BpkButton />      // Gets themed correctly
    <BpkProgressBar /> // Shows warnings because you didn't pass in its theme props
</BpkThemeProvider>
```

This was fine when theming was only used for partner branding, because we never wanted non-themed components inside a `BpkThemeProvider`. However, consumers are now using theming to just theme _some_ components inside a view hierarchy.

This PR loosens the warning, so that it only fires when _some_ theme attributes _but not all_ for a component are supplied. In other words, when you don't pass in _any_ theme props the component needs, there won't be a warning.

If you still pass in a partial theme - you supply _some_ but not _all_ required attributes, a warning will still appear.

Here's an example - I added a `BpkProgressBar` to our storybook but didn't pass in any of its theme props. It appears fine using the default styling, and no warning was shown.

![Simulator Screen Shot - iPhone 8 - 2019-12-13 at 19 25 36](https://user-images.githubusercontent.com/73652/70829372-72dca300-1de5-11ea-87cb-1e5f8ceea82c.png)

I also did a couple of other small housekeeping things in this PR, which I'll comment on inline.