### PR TITLE
[NO-JIRA] Guard BpkStyleSheet against undefined styles

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,10 @@
 
 > Place your changes below this line.
 
-**Changed:**
+**Fixed:**
+
+- react-native-bpk-appearance:
+  - fixed `BpkDynamicStyleSheet.create` to handle `undefined` or `null` styles.
 
 - react-native-bpk-theming:
   - Components that can be themed will now only throw a prop type error when a theme is partially applied. Previously, a prop type error would appear if a component was placed inside a `BpkThemeProvider` but no relevant theming props were given to it. This change enables the use of themed components alongside non-themed ones without seeing warnings.

--- a/packages/react-native-bpk-appearance/src/BpkDynamicStyleSheet-test.js
+++ b/packages/react-native-bpk-appearance/src/BpkDynamicStyleSheet-test.js
@@ -257,4 +257,16 @@ describe('BpkDynamicStyleSheet', () => {
       );
     });
   });
+
+  it('should not fail with undefined or null styles', () => {
+    const nullStyle = BpkDynamicStyleSheet.create({
+      one: undefined,
+      two: null,
+    });
+    expect(nullStyle.light.one).toBe(undefined);
+    expect(nullStyle.light.two).toBe(null);
+
+    expect(nullStyle.dark.one).toBe(undefined);
+    expect(nullStyle.dark.two).toBe(null);
+  });
 });

--- a/packages/react-native-bpk-appearance/src/BpkDynamicStyleSheet.js
+++ b/packages/react-native-bpk-appearance/src/BpkDynamicStyleSheet.js
@@ -88,6 +88,10 @@ function extractStyleForVariation<+S: BpkStyleSheetNamedStyles>(
 ) {
   return Object.keys(style).reduce((mapped, topLevelKey) => {
     const styleDef = style[topLevelKey];
+    if (styleDef == null) {
+      mapped[topLevelKey] = styleDef; // eslint-disable-line no-param-reassign
+      return mapped;
+    }
     // $FlowFixMe
     const unpacked = unpackValue(styleDef, variation);
     mapped[topLevelKey] = extractDynamicValues(unpacked, variation); // eslint-disable-line no-param-reassign


### PR DESCRIPTION
This can happen when using `Platform.select` and providing the style for only one platform.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
