### PR TITLE
[NO-JIRA] Fix calendar bridge bitecode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ allprojects {
 }
 
 ext {
-    backpackVersion     = "19.1.0"
+    backpackVersion     = "21.1.1"
     compileSdkVersion   = 29
     targetSdkVersion    = 29
     minSdkVersion       = 21

--- a/packages/react-native-bpk-component-calendar/src/android/build.gradle
+++ b/packages/react-native-bpk-component-calendar/src/android/build.gradle
@@ -36,5 +36,5 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
-  implementation "com.github.skyscanner:backpack-android:19.0.0"
+  implementation "com.github.skyscanner:backpack-android:21.1.1"
 }


### PR DESCRIPTION
This was happening because the signature of `BpkCalendarController` changed and the bridge was compiled against an old version. Even though the change was not breaking the bitecode was no compatible anymore, and because the app uses the pre-compiled version it was breaking during runtime.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
