### PR TITLE
[BPK-3736] Align switch DM colours to native platforms

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,9 @@
 
 > Place your changes below this line.
 
+**Added:**
+ - react-native-bpk-component-switch:
+   - The track colour is now lighter in dark mode to match the design on iOS.
 
 ## How to write a good changelog entry
 

--- a/lib/bpk-component-switch/src/BpkSwitch.js
+++ b/lib/bpk-component-switch/src/BpkSwitch.js
@@ -22,7 +22,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Platform, Switch } from 'react-native';
 import {
-  colorSkyBlue,
+  primaryColor,
   colorBlackTint01,
   colorBlackTint02,
   colorBlackTint05,
@@ -41,9 +41,9 @@ import { useBpkDynamicValue } from '../../bpk-appearance';
 const REQUIRED_THEME_ATTRIBUTES = ['switchPrimaryColor'];
 
 const useColors = (themeAttributes: ?Object, value: ?boolean): Object => {
-  const primaryColor = themeAttributes
-    ? themeAttributes.switchPrimaryColor
-    : colorSkyBlue;
+  const themedPrimaryColor = useBpkDynamicValue(
+    themeAttributes ? themeAttributes.switchPrimaryColor : primaryColor,
+  );
 
   const androidUnselectedThumbColor = useBpkDynamicValue({
     light: colorSkyGrayTint07,
@@ -58,18 +58,18 @@ const useColors = (themeAttributes: ?Object, value: ?boolean): Object => {
         dark: colorBlackTint01,
       }),
       trackColor: {
-        true: primaryColor,
+        true: themedPrimaryColor,
       },
     },
     android: {
-      thumbColor: value ? primaryColor : androidUnselectedThumbColor,
+      thumbColor: value ? themedPrimaryColor : androidUnselectedThumbColor,
       trackColor: {
         false: useBpkDynamicValue({
           light: colorSkyGrayTint06,
           dark: colorBlackTint02,
         }),
         true: setOpacity(
-          primaryColor,
+          themedPrimaryColor,
           useBpkDynamicValue({
             light: 0.32, // Taken from here https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/color/MaterialColors.java#L42
             dark: 0.5,

--- a/lib/bpk-component-switch/src/__snapshots__/BpkSwitch-test.android.js.snap
+++ b/lib/bpk-component-switch/src/__snapshots__/BpkSwitch-test.android.js.snap
@@ -8,10 +8,10 @@ exports[`Android BpkSwitch dark mode should disable theming if the required attr
   onChange={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  thumbTintColor="rgb(7, 112, 227)"
+  thumbTintColor="rgb(109, 159, 235)"
   trackColorForFalse="rgb(44, 44, 46)"
-  trackColorForTrue="rgba(7, 112, 227, 0.5)"
-  trackTintColor="rgba(7, 112, 227, 0.5)"
+  trackColorForTrue="rgba(109, 159, 235, 0.5)"
+  trackTintColor="rgba(109, 159, 235, 0.5)"
 />
 `;
 
@@ -25,7 +25,7 @@ exports[`Android BpkSwitch dark mode should render correctly 1`] = `
   onStartShouldSetResponder={[Function]}
   thumbTintColor="rgb(99, 99, 102)"
   trackColorForFalse="rgb(44, 44, 46)"
-  trackColorForTrue="rgba(7, 112, 227, 0.5)"
+  trackColorForTrue="rgba(109, 159, 235, 0.5)"
   trackTintColor="rgb(44, 44, 46)"
 />
 `;
@@ -38,10 +38,10 @@ exports[`Android BpkSwitch dark mode should support the "value" prop 1`] = `
   onChange={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  thumbTintColor="rgb(7, 112, 227)"
+  thumbTintColor="rgb(109, 159, 235)"
   trackColorForFalse="rgb(44, 44, 46)"
-  trackColorForTrue="rgba(7, 112, 227, 0.5)"
-  trackTintColor="rgba(7, 112, 227, 0.5)"
+  trackColorForTrue="rgba(109, 159, 235, 0.5)"
+  trackTintColor="rgba(109, 159, 235, 0.5)"
 />
 `;
 

--- a/lib/bpk-component-switch/src/__snapshots__/BpkSwitch-test.ios.js.snap
+++ b/lib/bpk-component-switch/src/__snapshots__/BpkSwitch-test.ios.js.snap
@@ -6,7 +6,7 @@ exports[`iOS BpkSwitch dark mode should disable theming if the required attribut
   onChange={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  onTintColor="rgb(7, 112, 227)"
+  onTintColor="rgb(109, 159, 235)"
   style={
     Array [
       Object {
@@ -29,7 +29,7 @@ exports[`iOS BpkSwitch dark mode should render correctly 1`] = `
   onChange={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  onTintColor="rgb(7, 112, 227)"
+  onTintColor="rgb(109, 159, 235)"
   style={
     Array [
       Object {
@@ -52,7 +52,7 @@ exports[`iOS BpkSwitch dark mode should support the "value" prop 1`] = `
   onChange={[Function]}
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
-  onTintColor="rgb(7, 112, 227)"
+  onTintColor="rgb(109, 159, 235)"
   style={
     Array [
       Object {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/30267516/76100523-a8e48a00-5fc4-11ea-98c8-0c68389b0727.png)

After:
![image](https://user-images.githubusercontent.com/30267516/76100529-ab46e400-5fc4-11ea-82c1-6a02908fdd33.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
