### PR TITLE
[BPK-3678] Update to mockk and refactor tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,9 +196,9 @@ You can also run the tests in 'watch mode', which means the process will continu
 <details>
 <summary>Run Android emulators manually</summary>
 
-The setup process detailed in *[Prerequisites](#prerequisites)* created two Android emulators. One with API version 27 and another with 21.
+The setup process detailed in *[Prerequisites](#prerequisites)* created two Android emulators. One with API version 28 and another with 21.
 
-To run these manually, run `npm run android:emulator` or `npm run android:emulator:min` to run API versions 27 and 21 respectively.
+To run these manually, run `npm run android:emulator` or `npm run android:emulator:min` to run API versions 28 and 21 respectively.
 
 </details>
 

--- a/lib/android/build.internal.gradle
+++ b/lib/android/build.internal.gradle
@@ -18,9 +18,5 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
   androidTestImplementation 'androidx.test:rules:1.2.0'
 
-  androidTestImplementation 'org.mockito:mockito-core:2.28.1'
-  androidTestImplementation 'org.mockito:mockito-android:2.28.1'
-  androidTestImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
-
-  androidTestImplementation 'org.opentest4j:opentest4j:1.1.0'
+  androidTestImplementation "io.mockk:mockk-android:1.9"
 }

--- a/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/BpkViewStateHolderTest.kt
+++ b/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/BpkViewStateHolderTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2020 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.skyscanner.backpack.reactnative
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BpkViewStateHolderTest {
+
+  private lateinit var subject: BpkViewStateHolder
+
+  @Before
+  fun setup() {
+    subject = BpkViewStateHolder()
+  }
+
+  @Test
+  fun test_mark_dirty() {
+    subject.markDirty()
+    assertTrue(subject.isDirty())
+    assertFalse(subject.isInvalid())
+  }
+
+  @Test
+  fun test_mark_invalid() {
+    subject.markInvalid()
+    assertTrue(subject.isInvalid())
+    assertFalse(subject.isDirty())
+  }
+
+  @Test
+  fun test_trigger_callbacks() {
+    var calls = 0
+    subject.onAfterUpdateTransaction {
+      calls += 1
+    }
+
+    subject.dispatchUpdateTransactionFinished()
+    assertEquals(0, calls)
+
+    subject.markDirty()
+    subject.dispatchUpdateTransactionFinished()
+    subject.dispatchUpdateTransactionFinished()
+    assertEquals(1, calls)
+
+    subject.markInvalid()
+    subject.dispatchUpdateTransactionFinished()
+    subject.dispatchUpdateTransactionFinished()
+    assertEquals(2, calls)
+  }
+}

--- a/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/rating/BpkRatingShadowNodeTest.kt
+++ b/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/rating/BpkRatingShadowNodeTest.kt
@@ -20,7 +20,7 @@ package net.skyscanner.backpack.reactnative.rating
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.facebook.soloader.SoLoader
 import com.facebook.yoga.YogaMeasureMode
-import com.nhaarman.mockitokotlin2.mock
+import io.mockk.mockk
 import net.skyscanner.backpack.rating.BpkRating
 import net.skyscanner.backpack.reactnative.testing.ReactContextTestRule
 import org.hamcrest.Matchers.greaterThan
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class BpkRatingShadowNodeTest {
-
   private lateinit var subject: BpkRatingShadowNode
 
   @get:Rule
@@ -63,7 +62,7 @@ class BpkRatingShadowNodeTest {
 
   @Test
   fun test_measure_with_no_data() {
-    val result = subject.measure(mock(), 0f, YogaMeasureMode.UNDEFINED, 0f, YogaMeasureMode.UNDEFINED)
+    val result = subject.measure(mockk(), 0f, YogaMeasureMode.UNDEFINED, 0f, YogaMeasureMode.UNDEFINED)
     assertEquals(0, result)
   }
 
@@ -75,7 +74,7 @@ class BpkRatingShadowNodeTest {
         BpkRating.Orientation.Vertical,
         BpkRating.Size.Base))
 
-    val result = subject.measure(mock(), 0f, YogaMeasureMode.UNDEFINED, 0f, YogaMeasureMode.UNDEFINED)
+    val result = subject.measure(mockk(), 0f, YogaMeasureMode.UNDEFINED, 0f, YogaMeasureMode.UNDEFINED)
 
     // There is no way to precisely test if the measure is correct here, so we just check if is
     // greater than 0. screenshots tests should cover this.

--- a/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/rating/BpkRatingViewManagerTest.kt
+++ b/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/rating/BpkRatingViewManagerTest.kt
@@ -21,26 +21,28 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException
-import com.facebook.react.bridge.JavaOnlyArray
-import com.facebook.react.bridge.JavaOnlyMap
+import androidx.test.platform.app.InstrumentationRegistry
+import com.facebook.react.bridge.*
 import com.facebook.react.uimanager.ReactStylesDiffMap
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import com.facebook.react.uimanager.ThemedReactContext
+import io.mockk.*
 import net.skyscanner.backpack.R
 import net.skyscanner.backpack.rating.BpkRating
 import net.skyscanner.backpack.reactnative.testing.Matchers.throws
+import net.skyscanner.backpack.reactnative.testing.ReactTestHelper
 import net.skyscanner.backpack.reactnative.testing.ReactViewManagerTestRule
+import net.skyscanner.backpack.util.BpkTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -51,31 +53,34 @@ class BpkRatingViewManagerTest {
   private val manager: BpkRatingViewManager
     get() = managerRule.manager
 
+  private val themedContext: ThemedReactContext
+    get() = managerRule.themedContext
+
   @Test
   fun test_title() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps("title", JavaOnlyArray.of("low", "med", "high")))
 
-    assertNotNull(view.title)
-    assertEquals("low", view.title?.invoke(BpkRating.Score.Low))
-    assertEquals("med", view.title?.invoke(BpkRating.Score.Medium))
-    assertEquals("high", view.title?.invoke(BpkRating.Score.High))
+    assertNotNull(view.state.title)
+    assertEquals("low", view.state.title?.invoke(BpkRating.Score.Low))
+    assertEquals("med", view.state.title?.invoke(BpkRating.Score.Medium))
+    assertEquals("high", view.state.title?.invoke(BpkRating.Score.High))
   }
 
   @Test
   fun test_title_single_value() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps("title", JavaOnlyArray.of("all")))
 
-    assertNotNull(view.title)
-    assertEquals("all", view.title?.invoke(BpkRating.Score.Low))
-    assertEquals("all", view.title?.invoke(BpkRating.Score.Medium))
-    assertEquals("all", view.title?.invoke(BpkRating.Score.High))
+    assertNotNull(view.state.title)
+    assertEquals("all", view.state.title?.invoke(BpkRating.Score.Low))
+    assertEquals("all", view.state.title?.invoke(BpkRating.Score.Medium))
+    assertEquals("all", view.state.title?.invoke(BpkRating.Score.High))
   }
 
   @Test
   fun test_title_invalid_values() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     assertThat({
       manager.updateProperties(view, buildProps("title", JavaOnlyArray.of(null)))
     }, throws(JSApplicationIllegalArgumentException::class))
@@ -86,29 +91,29 @@ class BpkRatingViewManagerTest {
 
   @Test
   fun test_subtitle() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps("subtitle", JavaOnlyArray.of("low", "med", "high")))
 
-    assertNotNull(view.subtitle)
-    assertEquals("low", view.subtitle?.invoke(BpkRating.Score.Low))
-    assertEquals("med", view.subtitle?.invoke(BpkRating.Score.Medium))
-    assertEquals("high", view.subtitle?.invoke(BpkRating.Score.High))
+    assertNotNull(view.state.subtitle)
+    assertEquals("low", view.state.subtitle?.invoke(BpkRating.Score.Low))
+    assertEquals("med", view.state.subtitle?.invoke(BpkRating.Score.Medium))
+    assertEquals("high", view.state.subtitle?.invoke(BpkRating.Score.High))
   }
 
   @Test
   fun test_subtitle_single_value() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps("subtitle", JavaOnlyArray.of("all")))
 
-    assertNotNull(view.subtitle)
-    assertEquals("all", view.subtitle?.invoke(BpkRating.Score.Low))
-    assertEquals("all", view.subtitle?.invoke(BpkRating.Score.Medium))
-    assertEquals("all", view.subtitle?.invoke(BpkRating.Score.High))
+    assertNotNull(view.state.subtitle)
+    assertEquals("all", view.state.subtitle?.invoke(BpkRating.Score.Low))
+    assertEquals("all", view.state.subtitle?.invoke(BpkRating.Score.Medium))
+    assertEquals("all", view.state.subtitle?.invoke(BpkRating.Score.High))
   }
 
   @Test
   fun test_subtitle_invalid_values() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     assertThat({
       manager.updateProperties(view, buildProps("subtitle", JavaOnlyArray.of(null)))
     }, throws(JSApplicationIllegalArgumentException::class))
@@ -119,15 +124,15 @@ class BpkRatingViewManagerTest {
 
   @Test
   fun test_value() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps("value", 1f))
 
-    assertEquals(1f, view.value)
+    assertEquals(1f, view.state.value)
   }
 
   @Test
   fun test_size() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     val options = mapOf(
       "icon" to BpkRating.Size.Icon,
       "xs" to BpkRating.Size.ExtraSmall,
@@ -140,7 +145,7 @@ class BpkRatingViewManagerTest {
       val expectedValue = entry.value
 
       manager.updateProperties(view, buildProps("size", jsValue))
-      assertEquals(expectedValue, view.size)
+      assertEquals(expectedValue, view.state.size)
     }
 
     assertThat({
@@ -150,7 +155,7 @@ class BpkRatingViewManagerTest {
 
   @Test
   fun test_orientation() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     val options = mapOf(
       "horizontal" to BpkRating.Orientation.Horizontal,
       "vertical" to BpkRating.Orientation.Vertical)
@@ -160,7 +165,7 @@ class BpkRatingViewManagerTest {
       val expectedValue = entry.value
 
       manager.updateProperties(view, buildProps("orientation", jsValue))
-      assertEquals(expectedValue, view.orientation)
+      assertEquals(expectedValue, view.state.orientation)
     }
 
     assertThat({
@@ -170,41 +175,41 @@ class BpkRatingViewManagerTest {
 
   @Test
   fun test_icon() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps(
       "size", "icon",
       "icon", JavaOnlyArray.of("bpk_flag", "bpk_food", "bpk_flask")))
 
-    val flag = drawableToBitmap(managerRule.themedContext.getDrawable(R.drawable.bpk_flag))!!
-    val food = drawableToBitmap(managerRule.themedContext.getDrawable(R.drawable.bpk_food))!!
-    val flask = drawableToBitmap(managerRule.themedContext.getDrawable(R.drawable.bpk_flask))!!
+    val flag = drawableToBitmap(themedContext.getDrawable(R.drawable.bpk_flag))!!
+    val food = drawableToBitmap(themedContext.getDrawable(R.drawable.bpk_food))!!
+    val flask = drawableToBitmap(themedContext.getDrawable(R.drawable.bpk_flask))!!
 
-    assertNotNull(view.icon)
+    assertNotNull(view.state.icon)
 
-    assertTrue(flag.sameAs(drawableToBitmap(view.icon?.invoke(BpkRating.Score.Low))))
-    assertTrue(food.sameAs(drawableToBitmap(view.icon?.invoke(BpkRating.Score.Medium))))
-    assertTrue(flask.sameAs(drawableToBitmap(view.icon?.invoke(BpkRating.Score.High))))
+    assertTrue(flag.sameAs(drawableToBitmap(view.state.icon?.invoke(BpkRating.Score.Low))))
+    assertTrue(food.sameAs(drawableToBitmap(view.state.icon?.invoke(BpkRating.Score.Medium))))
+    assertTrue(flask.sameAs(drawableToBitmap(view.state.icon?.invoke(BpkRating.Score.High))))
   }
 
   @Test
   fun test_icon_single_value() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps(
       "size", "icon",
       "icon", JavaOnlyArray.of("bpk_flag")))
 
-    val flag = drawableToBitmap(managerRule.themedContext.getDrawable(R.drawable.bpk_flag))!!
+    val flag = drawableToBitmap(themedContext.getDrawable(R.drawable.bpk_flag))!!
 
-    assertNotNull(view.icon)
+    assertNotNull(view.state.icon)
 
-    assertTrue(flag.sameAs(drawableToBitmap(view.icon?.invoke(BpkRating.Score.Low))))
-    assertTrue(flag.sameAs(drawableToBitmap(view.icon?.invoke(BpkRating.Score.Medium))))
-    assertTrue(flag.sameAs(drawableToBitmap(view.icon?.invoke(BpkRating.Score.High))))
+    assertTrue(flag.sameAs(drawableToBitmap(view.state.icon?.invoke(BpkRating.Score.Low))))
+    assertTrue(flag.sameAs(drawableToBitmap(view.state.icon?.invoke(BpkRating.Score.Medium))))
+    assertTrue(flag.sameAs(drawableToBitmap(view.state.icon?.invoke(BpkRating.Score.High))))
   }
 
   @Test
   fun test_icon_invalid_values() {
-    val view =  manager.createViewInstance(managerRule.themedContext)
+    val view =  manager.createViewInstance(themedContext)
     manager.updateProperties(view, buildProps("size", "icon"))
     assertThat({
       manager.updateProperties(view, buildProps("icon", JavaOnlyArray.of(null)))
@@ -218,9 +223,9 @@ class BpkRatingViewManagerTest {
   }
 
   @Test
-  @Ignore("TODO: This is causing weird errors with mockito")
   fun test_render_once_after_transaction() {
-    val view = spy(manager.createViewInstance(managerRule.themedContext))
+    val stateHolder = mockk<RNBpkRating.Companion.StateHolder>(relaxed = true)
+    val view = RNBpkRating(themedContext, stateHolder)
     manager.updateProperties(view, buildProps(
       "value", 1f,
       "icon", JavaOnlyArray.of("bpk_flag", "bpk_food", "bpk_flask"),
@@ -229,7 +234,8 @@ class BpkRatingViewManagerTest {
       "orientation", "horizontal",
       "size", "xs"
     ))
-    verify(view, times(1)).render()
+
+    verify(exactly = 1) { stateHolder.dispatchUpdateTransactionFinished() }
   }
 
   private fun buildProps(vararg keysAndValues: Any?): ReactStylesDiffMap? {

--- a/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/rating/RNBpkRatingTest.kt
+++ b/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/rating/RNBpkRatingTest.kt
@@ -20,7 +20,7 @@ package net.skyscanner.backpack.reactnative.rating
 import androidx.core.content.ContextCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.facebook.react.uimanager.UIManagerModule
-import com.nhaarman.mockitokotlin2.*
+import io.mockk.verify
 import net.skyscanner.backpack.R
 import net.skyscanner.backpack.rating.BpkRating
 import net.skyscanner.backpack.reactnative.testing.ReactContextTestRule
@@ -48,13 +48,13 @@ class RNBpkRatingTest {
     val iconRes = ContextCompat.getDrawable(contextRule.context, R.drawable.bpk_flag)!!
     val icon = { _:BpkRating.Score -> iconRes }
 
-    rating.title = title
-    rating.subtitle = subTitle
-    rating.value = value
-    rating.icon = icon
+    rating.state.title = title
+    rating.state.subtitle = subTitle
+    rating.state.value = value
+    rating.state.icon = icon
     rating.render()
 
-    verify(uiModule).setViewLocalData(eq(rating.id), any())
+    verify { uiModule.setViewLocalData(eq(rating.id), any()) }
 
     val bpkRating = rating.getChildAt(0)
     assertTrue(bpkRating is BpkRating)
@@ -71,12 +71,10 @@ class RNBpkRatingTest {
   fun test_updating_orientation() {
     val rating = RNBpkRating(contextRule.context)
     rating.render()
-
     val instance = rating.getChildAt(0)
 
-    rating.orientation = BpkRating.Orientation.Vertical
+    rating.state.orientation = BpkRating.Orientation.Vertical
     rating.render()
-
     val newInstance = rating.getChildAt(0)
 
     // BpkRating does not expose the orientation so we check if a new instance is correctly created
@@ -87,12 +85,10 @@ class RNBpkRatingTest {
   fun test_updating_zie() {
     val rating = RNBpkRating(contextRule.context)
     rating.render()
-
     val instance = rating.getChildAt(0)
 
-    rating.size = BpkRating.Size.Base
+    rating.state.size = BpkRating.Size.Base
     rating.render()
-
     val newInstance = rating.getChildAt(0)
 
     // BpkRating does not expose the size so we check if a new instance is correctly created
@@ -112,18 +108,17 @@ class RNBpkRatingTest {
     val flaskRes = ContextCompat.getDrawable(contextRule.context, R.drawable.bpk_flask)!!
     val flask = { _:BpkRating.Score -> flaskRes }
 
-    rating.title = { "Tile1" }
-    rating.subtitle = { "Subtitle1" }
-    rating.value = 2f
-    rating.icon = flag
+    rating.state.title = { "Tile1" }
+    rating.state.subtitle = { "Subtitle1" }
+    rating.state.value = 2f
+    rating.state.icon = flag
     rating.render()
-
-    rating.title = title
-    rating.subtitle = subTitle
-    rating.value = value
-    rating.icon = flask
+    rating.state.title = title
+    rating.state.subtitle = subTitle
+    rating.state.value = value
+    rating.state.icon = flask
+    rating.state.icon = flask
     rating.render()
-
     val bpkRating = rating.getChildAt(0)
     bpkRating as BpkRating
 

--- a/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/testing/ReactTestHelper.kt
+++ b/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/testing/ReactTestHelper.kt
@@ -23,8 +23,8 @@ import com.facebook.react.bridge.queue.ReactQueueConfiguration
 import com.facebook.react.bridge.queue.ReactQueueConfigurationImpl
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec
 import com.facebook.react.uimanager.UIManagerModule
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
+import io.mockk.every
+import io.mockk.mockk
 
 /**
  * Based on https://github.com/facebook/react-native/blob/master/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.java
@@ -40,10 +40,9 @@ object ReactTestHelper {
     val ReactQueueConfiguration: ReactQueueConfiguration = ReactQueueConfigurationImpl.create(
       spec
     ) { e -> throw RuntimeException(e) }
-    val reactInstance: CatalystInstance = mock(CatalystInstance::class.java)
-    `when`(reactInstance.reactQueueConfiguration).thenReturn(ReactQueueConfiguration)
-    `when`(reactInstance.getNativeModule(UIManagerModule::class.java))
-      .thenReturn(mock(UIManagerModule::class.java))
+    val reactInstance: CatalystInstance = mockk(relaxed = true)
+    every { reactInstance.reactQueueConfiguration } returns ReactQueueConfiguration
+    every { reactInstance.getNativeModule(UIManagerModule::class.java) } returns mockk(relaxed = true)
     return reactInstance
   }
 }

--- a/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/testing/ReactViewManagerTestRule.kt
+++ b/lib/android/src/androidTest/java/net/skyscanner/backpack/reactnative/testing/ReactViewManagerTestRule.kt
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.ThemedReactContext
+import io.mockk.clearAllMocks
 import net.skyscanner.backpack.util.BpkTheme
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BpkViewStateHolder.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BpkViewStateHolder.kt
@@ -1,0 +1,83 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2020 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.skyscanner.backpack.reactnative
+
+private const val STATE_CLEAN = 0
+private const val STATE_DIRTY = 1
+private const val STATE_INVALID_INSTANCE = 2
+
+/**
+ * [BpkViewStateHolder] should be used by RN view wrappers to hold the view state
+ * and react to view update transactions.
+ *
+ * Example:
+ * ```Kotlin
+ * class StateHolder: BpkViewStateHolder() {
+ *   var title: String
+ *    set(value) {
+ *      field = value
+ *      markDirty() // view should update in the next render transaction
+ *    }
+ * }
+ *
+ * class View(val stateHolder: BpkViewStateHolder) {
+ *   init {
+ *     stateHolder.onAfterUpdateTransaction(::render)
+ *   }
+ *
+ *   render() {
+ *      // this will only ever be called when the view is dirty and needs to re-render
+ *      nativeView.title = stateHolder.title
+ *      updateNativeView();
+ *   }
+ * }
+ * ```
+ */
+open class BpkViewStateHolder {
+  private var state = STATE_CLEAN
+  private val callbacks = mutableSetOf<() -> Unit>()
+
+  internal fun markDirty() {
+    state = state or STATE_DIRTY
+  }
+
+  internal fun markInvalid() {
+    state = state or STATE_INVALID_INSTANCE
+  }
+
+  fun isDirty() = state and STATE_DIRTY == STATE_DIRTY
+
+  fun isInvalid() = state and STATE_INVALID_INSTANCE == STATE_INVALID_INSTANCE
+
+  private fun shouldUpdate() = state != STATE_CLEAN
+
+  private fun markClean() {
+    state = STATE_CLEAN
+  }
+
+  fun onAfterUpdateTransaction(callback: () -> Unit) {
+    callbacks.add(callback)
+  }
+
+  fun dispatchUpdateTransactionFinished() {
+    if (shouldUpdate()) {
+      callbacks.forEach { it.invoke() }
+      markClean()
+    }
+  }
+}

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BpkViewStateHolder.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BpkViewStateHolder.kt
@@ -17,6 +17,8 @@
  */
 package net.skyscanner.backpack.reactnative
 
+import kotlin.reflect.KProperty
+
 private const val STATE_CLEAN = 0
 private const val STATE_DIRTY = 1
 private const val STATE_INVALID_INSTANCE = 2
@@ -80,4 +82,29 @@ open class BpkViewStateHolder {
       markClean()
     }
   }
+
+  companion object {
+    class StateUpdaterDelegate<in R: BpkViewStateHolder, T>(
+      initialVal: T,
+      val onUpdate: (R) -> Unit
+    ) {
+      private var value: T = initialVal
+      operator fun getValue(thisRef: R, property: KProperty<*>): T {
+        return value
+      }
+
+      operator fun setValue(thisRef: R, property: KProperty<*>, newValue: T) {
+        value = newValue
+        onUpdate(thisRef)
+      }
+    }
+
+    fun <R: BpkViewStateHolder, T>markDirtyOnUpdate(initialVal: T) =
+      StateUpdaterDelegate<R, T>(initialVal) { it.markDirty() }
+
+    fun <R: BpkViewStateHolder, T>markInvalidOnUpdate(initialVal: T) =
+      StateUpdaterDelegate<R, T>(initialVal) { it.markInvalid() }
+  }
 }
+
+

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/BpkRatingLocalData.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/BpkRatingLocalData.kt
@@ -21,7 +21,7 @@ package net.skyscanner.backpack.reactnative.rating
 import android.content.Context
 import net.skyscanner.backpack.rating.BpkRating
 
-internal open class BpkRatingLocalData(
+internal class BpkRatingLocalData(
   private val rating: BpkRating,
   private val orientation: BpkRating.Orientation,
   private val size: BpkRating.Size

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/BpkRatingShadowNode.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/BpkRatingShadowNode.kt
@@ -46,7 +46,7 @@ import com.facebook.yoga.YogaNode
  * 4. [BpkRatingShadowNode.measure] will use the [BpkRatingLocalData] to create a copy of the current
  *   view being rendered and measure itself.
  */
-open class BpkRatingShadowNode internal constructor() : LayoutShadowNode(), YogaMeasureFunction {
+class BpkRatingShadowNode internal constructor() : LayoutShadowNode(), YogaMeasureFunction {
 
   private var localData: BpkRatingLocalData? = null
   private var lastWidth = 0

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/BpkRatingViewManager.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/BpkRatingViewManager.kt
@@ -17,6 +17,7 @@
  */
 package net.skyscanner.backpack.reactnative.rating
 
+import androidx.annotation.VisibleForTesting
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableArray
@@ -50,36 +51,36 @@ class BpkRatingViewManager : BaseViewManager<RNBpkRating, BpkRatingShadowNode>()
 
   @ReactProp(name = "title")
   fun setTitle(view: RNBpkRating, titles: ReadableArray) {
-    view.title = { score ->
+    view.state.title = { score ->
       pickValueForScore(score, titles, "title").asString()
     }
   }
 
   @ReactProp(name = "subtitle")
   fun setSubtitle(view: RNBpkRating, subtitles: ReadableArray) {
-    view.subtitle = { score ->
+    view.state.subtitle = { score ->
       pickValueForScore(score, subtitles, "subtitle").asString()
     }
   }
 
   @ReactProp(name = "value")
   fun setValue(view: RNBpkRating, value: Float) {
-    view.value = value
+    view.state.value = value
   }
 
   @ReactProp(name = "size")
   fun setSize(view: RNBpkRating, size: String) {
-    view.size = size.asRatingSize()
+    view.state.size = size.asRatingSize()
   }
 
   @ReactProp(name = "orientation")
   fun setOrientation(view: RNBpkRating, orientation: String) {
-    view.orientation = orientation.asRatingOrientation()
+    view.state.orientation = orientation.asRatingOrientation()
   }
 
   @ReactProp(name = "icon")
   fun setIcon(view: RNBpkRating, icons: ReadableArray) {
-    view.icon = { score ->
+    view.state.icon = { score ->
       val context = view.context
       val iconName = pickValueForScore(score, icons, "icon").asString()
       val iconId = context.resources.getIdentifier(iconName, "drawable", view.context.packageName)
@@ -89,7 +90,7 @@ class BpkRatingViewManager : BaseViewManager<RNBpkRating, BpkRatingShadowNode>()
 
   override fun onAfterUpdateTransaction(view: RNBpkRating) {
     super.onAfterUpdateTransaction(view)
-    view.render()
+    view.state.dispatchUpdateTransactionFinished()
   }
 
   private fun pickValueForScore(score: BpkRating.Score, values: ReadableArray, propName: String): Dynamic {

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/RNBpkRating.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/RNBpkRating.kt
@@ -87,41 +87,12 @@ class RNBpkRating(
 
   companion object {
     class StateHolder: BpkViewStateHolder() {
-      var title: ((BpkRating.Score) -> String)? = null
-        set(value) {
-          field = value
-          markDirty()
-        }
-
-      var subtitle: ((BpkRating.Score) -> String)? = null
-        set(value) {
-          field = value
-          markDirty()
-        }
-
-      var value: Float = 0f
-        set(value) {
-          field = value
-          markDirty()
-        }
-
-      var icon: ((BpkRating.Score) -> Drawable)? = null
-        set(value) {
-          field = value
-          markDirty()
-        }
-
-      var size: BpkRating.Size = BpkRating.Size.Base
-        set(value) {
-          field = value
-          markInvalid()
-        }
-
-      var orientation: BpkRating.Orientation = BpkRating.Orientation.Horizontal
-        set(value) {
-          field = value
-          markInvalid()
-        }
+      var title: ((BpkRating.Score) -> String)? by markDirtyOnUpdate(null)
+      var subtitle: ((BpkRating.Score) -> String)? by markDirtyOnUpdate(null)
+      var value: Float by markDirtyOnUpdate(0f)
+      var icon: ((BpkRating.Score) -> Drawable)? by markDirtyOnUpdate(null)
+      var size: BpkRating.Size by markInvalidOnUpdate(BpkRating.Size.Base)
+      var orientation: BpkRating.Orientation by markInvalidOnUpdate(BpkRating.Orientation.Horizontal)
     }
   }
 }

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/RNBpkRating.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/rating/RNBpkRating.kt
@@ -23,82 +23,31 @@ import android.widget.FrameLayout
 import net.skyscanner.backpack.rating.BpkRating
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.bridge.ReactContext
+import net.skyscanner.backpack.reactnative.BpkViewStateHolder
 
-private const val STATE_CLEAN = 0
-private const val STATE_DIRTY = 1
-private const val STATE_INVALID_INSTANCE = 2
+class RNBpkRating(
+  private val reactContext: ReactContext,
+  val state: StateHolder = StateHolder()
+): FrameLayout(reactContext) {
 
-open class RNBpkRating(private val reactContext: ReactContext): FrameLayout(reactContext) {
-
-  private var state = STATE_INVALID_INSTANCE
   private var rating: BpkRating? = null
 
   init {
     layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+    state.onAfterUpdateTransaction(::render)
   }
-
-  var title: ((BpkRating.Score) -> String)? = null
-    set(value) {
-      field = value
-      markDirty()
-    }
-
-  var subtitle: ((BpkRating.Score) -> String)? = null
-    set(value) {
-      field = value
-      markDirty()
-    }
-
-  var value: Float = 0f
-    set(value) {
-      field = value
-      markDirty()
-    }
-
-  var icon: ((BpkRating.Score) -> Drawable)? = null
-    set(value) {
-      field = value
-      markDirty()
-    }
-
-  var size: BpkRating.Size = BpkRating.Size.Base
-    set(value) {
-      field = value
-      markInvalid()
-    }
-
-  var orientation: BpkRating.Orientation = BpkRating.Orientation.Horizontal
-    set(value) {
-      field = value
-      markInvalid()
-    }
 
   fun render() {
-    if (shouldUpdate()) {
-      val view = getUpdatedView(orientation, size)
-      val uiManager = reactContext.getNativeModule(UIManagerModule::class.java)
-      val localData = BpkRatingLocalData(view, orientation, size)
-      // This will trigger measure to run in BpkRatingShadowNode
-      uiManager.setViewLocalData(id, localData)
-      rating = view
-      state = STATE_CLEAN
-    }
+    val view = getUpdatedView(state.orientation, state.size)
+    val uiManager = reactContext.getNativeModule(UIManagerModule::class.java)
+    val localData = BpkRatingLocalData(view, state.orientation, state.size)
+    // This will trigger measure to run in BpkRatingShadowNode
+    uiManager.setViewLocalData(id, localData)
+    rating = view
   }
-
-  private fun markDirty() {
-    state = state or STATE_DIRTY
-  }
-
-  private fun markInvalid() {
-    state = state or STATE_INVALID_INSTANCE
-  }
-
-  private fun isInvalid() = state and STATE_INVALID_INSTANCE == STATE_INVALID_INSTANCE
-
-  private fun shouldUpdate() = state != STATE_CLEAN
 
   private fun getUpdatedView(orientation: BpkRating.Orientation, size: BpkRating.Size): BpkRating {
-    val view = if (rating == null || isInvalid()) {
+    val view = if (rating == null || state.isInvalid()) {
       // Orientation and Size can only be set in the constructor, so we need a new instance for that
       removeAllViews()
       val view = BpkRating(context, orientation, size)
@@ -108,10 +57,10 @@ open class RNBpkRating(private val reactContext: ReactContext): FrameLayout(reac
       rating!!
     }
 
-    title?.let { view.title = it }
-    subtitle?.let { view.subtitle = it }
-    icon?.let { view.icon = it }
-    view.value = value
+    state.title?.let { view.title = it }
+    state.subtitle?.let { view.subtitle = it }
+    state.icon?.let { view.icon = it }
+    view.value = state.value
 
     requestLayout()
 
@@ -134,5 +83,45 @@ open class RNBpkRating(private val reactContext: ReactContext): FrameLayout(reac
     // Rating relies on a measure + layout pass happening after ir calls requestLayout()
     // based on: https://github.com/facebook/react-native/blob/8d5ac8de766b9e435cbfa9bfa6b8a2b75b0e2a19/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbar.java#L175
     this.post(measureAndLayout)
+  }
+
+  companion object {
+    class StateHolder: BpkViewStateHolder() {
+      var title: ((BpkRating.Score) -> String)? = null
+        set(value) {
+          field = value
+          markDirty()
+        }
+
+      var subtitle: ((BpkRating.Score) -> String)? = null
+        set(value) {
+          field = value
+          markDirty()
+        }
+
+      var value: Float = 0f
+        set(value) {
+          field = value
+          markDirty()
+        }
+
+      var icon: ((BpkRating.Score) -> Drawable)? = null
+        set(value) {
+          field = value
+          markDirty()
+        }
+
+      var size: BpkRating.Size = BpkRating.Size.Base
+        set(value) {
+          field = value
+          markInvalid()
+        }
+
+      var orientation: BpkRating.Orientation = BpkRating.Orientation.Horizontal
+        set(value) {
+          field = value
+          markInvalid()
+        }
+    }
   }
 }


### PR DESCRIPTION
# Mockk

This updates the mocking library to [mockk](https://mockk.io/) because of a few issues I had with Mockito, but especially because mockito does not support mocking final classes (classes that cannot be extended), which was forcing us to open the classes just so we could test them.

Another reason for the move is that this lib is much better for Kotlin code.

The tests now will only work with API >= 28 which is already the API used to create the `bpk-avd` emulator so no changes are needed.

# Refactoring

I've found a bug when any of the Android views is mocked, all tests that run after the mock will fail with some weird internal error in the mocking lib (this is true for both mocking libs), so I decided to refactor the code a bit to make the logic of handling state updates and rendering the view less coupled. It's now possible to do this [test](https://github.com/Skyscanner/backpack-react-native/pull/416/files#diff-fa9e16e0dc120f7cec6e29ebc9878d30R226) without having to mock the whole view.

Another benefit is that the logic to handle state update doesn't need to be repeated inside every bridge component anymore.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
