### PR TITLE
[BPK-3693] Improve mask behaviour

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- bpk-component-text-input:
+  - Fixed an issue where masked inputs would sometimes behave erratically when deleting characters.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/lib/bpk-component-text-input/src/BpkTextInput-test.common.js
+++ b/lib/bpk-component-text-input/src/BpkTextInput-test.common.js
@@ -183,6 +183,17 @@ const commonTests = () => {
         expect(testRenderer.toJSON()).toMatchSnapshot();
       });
 
+      it('should mask correctly when given an unusual value to mask', () => {
+        /* The value here simulates entering '1234-5678', then cursoring back
+          and removing the '3'. It should be correctly re-masked to make '1245-678'.
+        */
+        const testRenderer = TestRenderer.create(
+          <WithColorScheme label="Name" value="124-5678" mask="9999-9999" />,
+        );
+
+        expect(testRenderer.toJSON()).toMatchSnapshot();
+      });
+
       it('should support theming', () => {
         const theme = {
           textInputFocusedColor: 'green',

--- a/lib/bpk-component-text-input/src/BpkTextInput.js
+++ b/lib/bpk-component-text-input/src/BpkTextInput.js
@@ -266,7 +266,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
     const sanitizeMaskedValue = valueToSanitize => {
       // We don't sanitise if the mask contains '*' because '*' in tinymask
       // means allow any character.
-      if (mask.includes('*')) {
+      if (mask && mask.includes('*')) {
         return valueToSanitize;
       }
       return valueToSanitize.replace(/[^a-zA-Z0-9]+/g, '');

--- a/lib/bpk-component-text-input/src/BpkTextInput.js
+++ b/lib/bpk-component-text-input/src/BpkTextInput.js
@@ -203,7 +203,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
     } = this.props;
     const styles = getStyles(bpkAppearance);
     const hasAccessoryView = accessoryView !== null;
-    const placeholerValue = this.getPlaceholderValue();
+    const placeholderValue = this.getPlaceholderValue();
     const placeholderColor = getPlaceholderColor(bpkAppearance);
 
     const validityIcon = valid ? (
@@ -287,7 +287,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
               ref={inputRef}
               underlineColorAndroid="transparent"
               {...rest}
-              placeholder={placeholerValue}
+              placeholder={placeholderValue}
               placeholderTextColor={placeholderColor}
             />
             {!isFocused && validityIcon}

--- a/lib/bpk-component-text-input/src/BpkTextInput.js
+++ b/lib/bpk-component-text-input/src/BpkTextInput.js
@@ -263,6 +263,22 @@ class BpkTextInput extends Component<EnhancedProps, State> {
       return null;
     };
 
+    const sanitizeMaskedValue = valueToSanitize => {
+      // We don't sanitise if the mask contains '*' because '*' in tinymask
+      // means allow any character.
+      if (mask.includes('*')) {
+        return valueToSanitize;
+      }
+      return valueToSanitize.replace(/[^a-zA-Z0-9]+/g, '');
+    };
+
+    const formatValue = valueToFormat => {
+      if (mask) {
+        return this.tinymask.mask(sanitizeMaskedValue(valueToFormat));
+      }
+      return valueToFormat || '';
+    };
+
     return (
       <View style={userStyle}>
         <View style={styles.rowContainer}>
@@ -278,7 +294,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
           <Animated.View style={animatedInputStyle}>
             <TextInput
               editable={editable}
-              value={mask ? this.tinymask.mask(value) : value || ''}
+              value={formatValue(value)}
               style={inputTextStyle}
               onFocus={this.onFocus}
               onBlur={this.onBlur}

--- a/lib/bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
+++ b/lib/bpk-component-text-input/src/__snapshots__/BpkTextInput-RTL-test.js.snap
@@ -73,6 +73,79 @@ exports[`RTL BpkTextInput dark mode should ignore when placeholder is provided, 
 </View>
 `;
 
+exports[`RTL BpkTextInput dark mode should mask correctly when given an unusual value to mask 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(142, 142, 147, 1)",
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 17,
+          "position": "absolute",
+          "top": 0,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(72, 72, 74, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(178, 178, 191)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(255, 255, 255)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "right",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="1245-678"
+      />
+    </View>
+  </View>
+</View>
+`;
+
 exports[`RTL BpkTextInput dark mode should render correctly 1`] = `
 <View
   style={null}
@@ -1489,6 +1562,79 @@ exports[`RTL BpkTextInput light mode should ignore when placeholder is provided,
         }
         underlineColorAndroid="transparent"
         value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`RTL BpkTextInput light mode should mask correctly when given an unusual value to mask 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(104, 105, 127, 1)",
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 17,
+          "position": "absolute",
+          "top": 0,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(221, 221, 229, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(205, 205, 215)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(17, 18, 54)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "right",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="1245-678"
       />
     </View>
   </View>

--- a/lib/bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
+++ b/lib/bpk-component-text-input/src/__snapshots__/BpkTextInput-test.android.js.snap
@@ -73,6 +73,79 @@ exports[`Android BpkTextInput dark mode should ignore when placeholder is provid
 </View>
 `;
 
+exports[`Android BpkTextInput dark mode should mask correctly when given an unusual value to mask 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 16,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(142, 142, 147, 1)",
+          "fontFamily": "sans-serif",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 16,
+          "position": "absolute",
+          "top": 0,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(72, 72, 74, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(178, 178, 191)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(255, 255, 255)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="1245-678"
+      />
+    </View>
+  </View>
+</View>
+`;
+
 exports[`Android BpkTextInput dark mode should render correctly 1`] = `
 <View
   style={null}
@@ -1489,6 +1562,79 @@ exports[`Android BpkTextInput light mode should ignore when placeholder is provi
         }
         underlineColorAndroid="transparent"
         value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkTextInput light mode should mask correctly when given an unusual value to mask 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 16,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(104, 105, 127, 1)",
+          "fontFamily": "sans-serif",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 16,
+          "position": "absolute",
+          "top": 0,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(221, 221, 229, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(205, 205, 215)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(17, 18, 54)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="1245-678"
       />
     </View>
   </View>

--- a/lib/bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
+++ b/lib/bpk-component-text-input/src/__snapshots__/BpkTextInput-test.ios.js.snap
@@ -73,6 +73,79 @@ exports[`iOS BpkTextInput dark mode should ignore when placeholder is provided, 
 </View>
 `;
 
+exports[`iOS BpkTextInput dark mode should mask correctly when given an unusual value to mask 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(142, 142, 147, 1)",
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 17,
+          "position": "absolute",
+          "top": 0,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(72, 72, 74, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(178, 178, 191)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(255, 255, 255)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="1245-678"
+      />
+    </View>
+  </View>
+</View>
+`;
+
 exports[`iOS BpkTextInput dark mode should render correctly 1`] = `
 <View
   style={null}
@@ -1489,6 +1562,79 @@ exports[`iOS BpkTextInput light mode should ignore when placeholder is provided,
         }
         underlineColorAndroid="transparent"
         value=""
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`iOS BpkTextInput light mode should mask correctly when given an unusual value to mask 1`] = `
+<View
+  style={null}
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+        "paddingTop": 17,
+      }
+    }
+  >
+    <Text
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      numberOfLines={1}
+      style={
+        Object {
+          "color": "rgba(104, 105, 127, 1)",
+          "fontFamily": "System",
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 17,
+          "position": "absolute",
+          "top": 0,
+        }
+      }
+    >
+      Name
+    </Text>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "borderBottomColor": "rgba(221, 221, 229, 1)",
+          "borderBottomWidth": 1,
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <TextInput
+        allowFontScaling={true}
+        clearButtonMode="while-editing"
+        editable={true}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        placeholder={null}
+        placeholderTextColor="rgb(205, 205, 215)"
+        rejectResponderTermination={true}
+        style={
+          Array [
+            Object {
+              "borderBottomWidth": 0,
+              "color": "rgb(17, 18, 54)",
+              "flex": 1,
+              "fontSize": 16,
+              "fontWeight": "400",
+              "minHeight": 27,
+              "paddingHorizontal": 0,
+              "paddingVertical": 4,
+              "textAlign": "left",
+            },
+          ]
+        }
+        underlineColorAndroid="transparent"
+        value="1245-678"
       />
     </View>
   </View>

--- a/lib/bpk-component-text-input/stories.js
+++ b/lib/bpk-component-text-input/stories.js
@@ -18,8 +18,7 @@
 
 /* @flow */
 
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import { ScrollView, View } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
 import {
@@ -50,36 +49,16 @@ const dynamicStyles = BpkDynamicStyleSheet.create({
   },
 });
 
-class StatefulBpkTextInput extends Component<
-  { initialValue: string, label: string },
-  { value: string },
-> {
-  static propTypes = {
-    initialValue: PropTypes.string.isRequired,
+const StatefulBpkTextInput = (props: {
+  initialValue: string,
+  label: string,
+}) => {
+  const [value, setValue] = useState(props.initialValue);
+  const onChange = newValue => {
+    setValue(newValue);
   };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      value: this.props.initialValue,
-    };
-  }
-
-  onChange = value => {
-    this.setState(() => ({ value }));
-  };
-
-  render() {
-    return (
-      <BpkTextInput
-        {...this.props}
-        value={this.state.value}
-        onChangeText={this.onChange}
-      />
-    );
-  }
-}
+  return <BpkTextInput {...props} value={value} onChangeText={onChange} />;
+};
 
 storiesOf('bpk-component-text-input', module)
   .addDecorator(CenterDecorator)


### PR DESCRIPTION
`tinymask` sometimes formats things strangely when they contain special characters. For example:

```
const maskInstance = new tinymask('9999-9999');

// Works as expected.
maskInstance.mask('01234567') // 0123-4567
maskInstance.mask('0123-456') // 0123-456

// WTF?
maskInstance.mask('012-456') // 012 
```

This manifests in the component in the GIF you see below - when you remove a character from certain places in the string, `tinymask` reformats it and some of the characters disappear.

This PR fixes this by sanitising masked values before they're given to `tinymask`. I've also added a test for it, and made the example in our storybook make use of `useState` to make it shorter.

## Before fix
![before-fix](https://user-images.githubusercontent.com/73652/77154574-e0a70380-6a93-11ea-8c26-82995fd062d6.gif)

## After fix
![after-fix](https://user-images.githubusercontent.com/73652/77154581-e56bb780-6a93-11ea-834a-2b3c47d31499.gif)

