### PR TITLE
[BPK-3680] Use internal backpack

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,10 @@
 # Unreleased
+
 > Place your changes below this line.
+
+**Added:**
+
+- Added new `BackpackReactNative.init` method that should be called before the application starts to configure `backpack-react-native` for Android.
 
 ## How to write a good changelog entry
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation "com.google.android.material:material:1.0.0"
+    implementation "com.jakewharton.threetenabp:threetenabp:${rootProject.ext.threetenabpVersion}"
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "androidx.test:runner:1.1.0"

--- a/android/app/src/main/java/net/skyscanner/backpack/MainApplication.kt
+++ b/android/app/src/main/java/net/skyscanner/backpack/MainApplication.kt
@@ -11,6 +11,7 @@ import com.facebook.react.shell.MainReactPackage
 import com.facebook.soloader.SoLoader
 import com.jakewharton.threetenabp.AndroidThreeTen
 import java.util.Arrays
+import net.skyscanner.backpack.reactnative.BackpackReactNative
 import net.skyscanner.backpack.reactnative.calendar.CalendarPackage
 import net.skyscanner.backpack.reactnative.dialog.DialogPackage
 import net.skyscanner.backpack.reactnative.flare.BpkFlarePackage
@@ -49,6 +50,7 @@ class MainApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
         AndroidThreeTen.init(this)
+        BackpackReactNative.init(this)
         SoLoader.init(this, /* native exopackage */ false)
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ allprojects {
 }
 
 ext {
-    backpackVersion     = "22.0.0"
+    backpackVersion     = "22.0.0-internal"
     compileSdkVersion   = 29
     targetSdkVersion    = 29
     minSdkVersion       = 21

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+import org.gradle.api.artifacts.repositories.PasswordCredentials
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.70'
     repositories {
-        google()
-        jcenter()
-        mavenCentral()
+      google()
+      jcenter()
+      mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.kezong:fat-aar:1.2.7'
+        classpath 'com.kezong:fat-aar:1.2.9'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -22,6 +23,7 @@ allprojects {
         mavenLocal()
         google()
         jcenter()
+
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
@@ -30,6 +32,19 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
+
+        maven {
+          url project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_URL"]?.toString()
+          credentials(PasswordCredentials.class) {
+            username = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_USER"]?.toString()
+            password = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_PASSWORD"]?.toString()
+          }
+
+          content {
+            includeModule("com.github.skyscanner", "backpack-android")
+          }
+        }
+
         maven { url 'https://jitpack.io' }
 
         buildscript {
@@ -55,17 +70,18 @@ allprojects {
 }
 
 ext {
-    backpackVersion     = "22.0.0-internal"
-    compileSdkVersion   = 29
-    targetSdkVersion    = 29
-    minSdkVersion       = 21
-    buildToolsVersion   = "29.0.2"
-    androidx            = '1.0.2'
-    appcompat           = '1.0.2'
-    supportLibVersion = "27.1.1"
-    playServicesVersion = "xxx"
-    androidMapsUtilsVersion = "0.5+"
-    internalBuild = project.hasProperty("internalBuild") && project.internalBuild
+  internalBuild       = project.hasProperty("internalBuild") && project.internalBuild
+  backpackVersion     = "22.2.0${ext.internalBuild || isUseRelative() ? '-internal' : ''}"
+  compileSdkVersion   = 29
+  targetSdkVersion    = 29
+  minSdkVersion       = 21
+  buildToolsVersion   = "29.0.2"
+  androidx            = '1.0.2'
+  appcompat           = '1.0.2'
+  supportLibVersion = "27.1.1"
+  playServicesVersion = "xxx"
+  androidMapsUtilsVersion = "0.5+"
+  threetenabpVersion = "1.2.1"
 }
 
 allprojects { project ->
@@ -102,5 +118,15 @@ allprojects { project ->
       }
     }
   }
+}
+
+def isUseRelative() {
+  Properties localProps = new Properties()
+  def localPropsFile = rootProject.file('../.env')
+  if (localPropsFile.exists()) {
+    localProps.load(localPropsFile.newDataInputStream())
+  }
+
+  return localProps.getOrDefault("USE_RELATIVE", "false") == "true"
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,6 +17,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
+SKYSCANNER_ARTIFACTORY_MAVEN_URL=https://artifactory.skyscannertools.net/artifactory/infrastructure-maven
 android.enableJetifier=true
 android.useAndroidX=true
-android.useDeprecatedNdk=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -63,7 +63,7 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
-  implementation "com.github.skyscanner:backpack-android:22.0.0"
+  implementation "com.github.skyscanner:backpack-android:22.0.0-internal"
   if (_internalBuild) {
     // embed deps will be added to the arr directly (fat-jar) and not as a dependency
     embed project(path: ':react-native-dark-mode', configuration: 'default')

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -22,6 +22,7 @@ def getPackageJson(project) {
 }
 
 def _reactNativeVersion = safeExtGet("reactNative", "+")
+def _backpackAndroidVersion = safeExtGet("backpackVersion", "22.2.0")
 def _compileSdkVersion = safeExtGet("compileSdkVersion", 28)
 def _targetSdkVersion = safeExtGet("targetSdkVersion", 28)
 def _minSdkVersion = safeExtGet("minSdkVersion", 21)
@@ -63,7 +64,10 @@ android {
 
 dependencies {
   compileOnly "com.facebook.react:react-native:${_reactNativeVersion}"
-  implementation "com.github.skyscanner:backpack-android:22.0.0-internal"
+  implementation "com.github.skyscanner:backpack-android:${_backpackAndroidVersion}"
+  implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+  implementation "com.jakewharton.threetenabp:threetenabp:${rootProject.ext.threetenabpVersion}"
+
   if (_internalBuild) {
     // embed deps will be added to the arr directly (fat-jar) and not as a dependency
     embed project(path: ':react-native-dark-mode', configuration: 'default')

--- a/lib/android/gradle-maven-push.gradle
+++ b/lib/android/gradle-maven-push.gradle
@@ -1,13 +1,7 @@
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 
-Properties localProps = new Properties()
-def localPropsFile = rootProject.file('local.properties')
-if (localPropsFile.exists()) {
-    localProps.load(localPropsFile.newDataInputStream())
-}
-
-def artifactoryURL = "https://artifactory.skyscannertools.net/artifactory/infrastructure-maven"
+def artifactoryURL = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_URL"]?.toString()
 
 task sourceJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BackpackReactNative.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BackpackReactNative.kt
@@ -1,0 +1,67 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2020 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.reactnative
+
+import android.content.Context
+import android.content.res.Resources
+import android.util.Log
+import com.facebook.react.views.text.ReactFontManager
+
+/**
+ * [BackpackReactNative] is the entry point of backpack-react-native for Android.
+ */
+class BackpackReactNative {
+  companion object {
+    private const val TAG = "BackpackReactNative"
+    private val RELATIVE_MAPPINGS = mapOf(
+      "skyscanner_relative_android" to "skyscanner_relative_android_book",
+      "skyscanner_relative_android_bold" to "skyscanner_relative_android_bold",
+      "skyscanner_relative_android_black" to "skyscanner_relative_android_black"
+    )
+
+    /**
+     * Initializes backpack-react-native.
+     *
+     * This should be called before the javascript code is loaded, e.g. in the Application's "onCreate"
+     * method.
+     */
+    @JvmStatic
+    fun init(context: Context) {
+      setupRelative(context)
+    }
+
+    private fun setupRelative(context: Context) {
+      val resources: Resources = context.resources
+      try {
+        val fontManger = ReactFontManager.getInstance()
+
+        RELATIVE_MAPPINGS.entries.forEach { entry ->
+          val rnName = entry.key
+          val resourceName = entry.value
+          val resourceId = resources.getIdentifier(resourceName, "font", context.packageName)
+          fontManger.addCustomFont(context, rnName, resourceId)
+        }
+
+      } catch (e: Throwable) {
+        val msg = "Unable to load relative font for Android. To use relative ensure you are using the internal version of backpack-android (backpack-android:X.X.X-internal)"
+        Log.w(TAG, msg, e)
+      }
+    }
+  }
+}

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BackpackReactNative.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/BackpackReactNative.kt
@@ -58,6 +58,7 @@ class BackpackReactNative {
           fontManger.addCustomFont(context, rnName, resourceId)
         }
 
+        Log.i(TAG, "Relative font configured successfully")
       } catch (e: Throwable) {
         val msg = "Unable to load relative font for Android. To use relative ensure you are using the internal version of backpack-android (backpack-android:X.X.X-internal)"
         Log.w(TAG, msg, e)


### PR DESCRIPTION
## Summary of the changes

- Now if `USE_RELATIVE` is set to true (.env file) the native project will use the `-internal` version of backpack-android which contains relative.
- The internal build of `backpack-react-native` will now also always depend on the `-internal` version of backpack-android, this will eliminate the transitive dependency problems we been having in the app.
- Add `BackpackReactNative.init` function that will configure relative for the RN Android side when the font files are available. This will replace the custom logic we have in the app.
- It is not necessary to download and copy the relative font files for Android to use relative in the local app, as long as `USE_RELATIVE` is true and you are logged in to internal maven, relative will be used.
- While I was at it, updated gradle to latest version :).

I've tested this in the app and it's working as expected.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
