### PR TITLE
[No JIRA] Revert Storybook upgrade and lock using a Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    ignored_updates:
+      - match:
+          # TODO remove this.
+          # When these deps upgrade, addons stop working. We should fix this.
+          # See BPK-3800.
+          dependency_name: "@storybook/react-native*"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - FSCalendar (~> 2.8)
     - MBProgressHUD (~> 0.9.1)
     - TTTAttributedLabel (~> 1.13.4)
-  - BackpackReactNative (1.4.0):
+  - BackpackReactNative (1.4.1):
     - Backpack (~> 28.0)
     - React
   - boost-for-react-native (1.63.0)
@@ -343,7 +343,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Backpack: 05228ac31b7b4b671464e21f2bac71dc3fe7ffa8
-  BackpackReactNative: 264c1adfc525be289123dc2ebb1921873fdfa9b5
+  BackpackReactNative: 68a4dbd89eab7f49def52e46df887aa1d028891b
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2

--- a/package-lock.json
+++ b/package-lock.json
@@ -3504,21 +3504,21 @@
       }
     },
     "@storybook/channel-websocket": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-5.3.17.tgz",
-      "integrity": "sha512-JJl9t8mL27bt8sI0OShbhJJ8pbg7vt79hvXCGU3K8XkjUe1PoSl7DfWe9UKgUxN0sS1K112VFUtT5WXZ3An5yA==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-5.2.8.tgz",
+      "integrity": "sha512-k+YOQlQ+qBw+Nh5LUBVEf+sqRxKVq1XhBKpYOb5FONe4i5MtiDEf8iJn3nqHtCR3uu6uqKXJTus/LPU+STCuUw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "5.3.17",
+        "@storybook/channels": "5.2.8",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "telejson": "^3.2.0"
+        "json-fn": "^1.1.1"
       },
       "dependencies": {
         "@storybook/channels": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.17.tgz",
-          "integrity": "sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
@@ -3612,115 +3612,107 @@
       }
     },
     "@storybook/core": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.3.17.tgz",
-      "integrity": "sha512-H6G8ygjb4RSVSKPdWz6su3Nvzxm8CfrHuCyUo4DLC46mirXfYRrJV1HiwXriViqoZV4gFbpaNKTDzTl/QKFDAg==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.2.8.tgz",
+      "integrity": "sha512-P1Xx4setLBESPgS5KgL7Jskf5Q6fRa3ApwPt+ocjDoSDGCvsV7cUEpAp09U65u+89e5K4nQxvaZouhknFQBc1A==",
       "dev": true,
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
         "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-        "@babel/plugin-transform-react-constant-elements": "^7.2.0",
-        "@babel/preset-env": "^7.4.5",
-        "@storybook/addons": "5.3.17",
-        "@storybook/channel-postmessage": "5.3.17",
-        "@storybook/client-api": "5.3.17",
-        "@storybook/client-logger": "5.3.17",
-        "@storybook/core-events": "5.3.17",
-        "@storybook/csf": "0.0.1",
-        "@storybook/node-logger": "5.3.17",
-        "@storybook/router": "5.3.17",
-        "@storybook/theming": "5.3.17",
-        "@storybook/ui": "5.3.17",
-        "airbnb-js-shims": "^2.2.1",
+        "@babel/plugin-transform-react-constant-elements": "^7.6.3",
+        "@babel/preset-env": "^7.7.1",
+        "@storybook/addons": "5.2.8",
+        "@storybook/channel-postmessage": "5.2.8",
+        "@storybook/client-api": "5.2.8",
+        "@storybook/client-logger": "5.2.8",
+        "@storybook/core-events": "5.2.8",
+        "@storybook/node-logger": "5.2.8",
+        "@storybook/router": "5.2.8",
+        "@storybook/theming": "5.2.8",
+        "@storybook/ui": "5.2.8",
+        "airbnb-js-shims": "^1 || ^2",
         "ansi-to-html": "^0.6.11",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.4.9",
         "babel-plugin-add-react-displayname": "^0.0.5",
-        "babel-plugin-emotion": "^10.0.20",
-        "babel-plugin-macros": "^2.7.0",
+        "babel-plugin-emotion": "^10.0.14",
+        "babel-plugin-macros": "^2.4.5",
         "babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
-        "boxen": "^4.1.0",
+        "boxen": "^3.0.0",
         "case-sensitive-paths-webpack-plugin": "^2.2.0",
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-table3": "0.5.1",
-        "commander": "^4.0.1",
+        "commander": "^2.19.0",
+        "common-tags": "^1.8.0",
         "core-js": "^3.0.1",
         "corejs-upgrade-webpack-plugin": "^2.2.0",
         "css-loader": "^3.0.0",
         "detect-port": "^1.3.0",
         "dotenv-webpack": "^1.7.0",
-        "ejs": "^2.7.4",
+        "ejs": "^2.6.1",
         "express": "^4.17.0",
-        "file-loader": "^4.2.0",
+        "file-loader": "^3.0.1",
         "file-system-cache": "^1.0.5",
         "find-cache-dir": "^3.0.0",
-        "find-up": "^4.1.0",
         "fs-extra": "^8.0.1",
-        "glob-base": "^0.3.0",
         "global": "^4.3.2",
         "html-webpack-plugin": "^4.0.0-beta.2",
-        "inquirer": "^7.0.0",
-        "interpret": "^2.0.0",
+        "inquirer": "^6.2.0",
+        "interpret": "^1.2.0",
         "ip": "^1.1.5",
-        "json5": "^2.1.1",
+        "json5": "^2.1.0",
         "lazy-universal-dotenv": "^3.0.1",
-        "micromatch": "^4.0.2",
         "node-fetch": "^2.6.0",
-        "open": "^7.0.0",
-        "pnp-webpack-plugin": "1.5.0",
+        "open": "^6.1.0",
+        "pnp-webpack-plugin": "1.4.3",
         "postcss-flexbugs-fixes": "^4.1.0",
         "postcss-loader": "^3.0.0",
         "pretty-hrtime": "^1.0.3",
         "qs": "^6.6.0",
-        "raw-loader": "^3.1.0",
+        "raw-loader": "^2.0.0",
         "react-dev-utils": "^9.0.0",
-        "regenerator-runtime": "^0.13.3",
+        "regenerator-runtime": "^0.12.1",
         "resolve": "^1.11.0",
         "resolve-from": "^5.0.0",
         "semver": "^6.0.0",
         "serve-favicon": "^2.5.0",
         "shelljs": "^0.8.3",
-        "style-loader": "^1.0.0",
-        "terser-webpack-plugin": "^2.1.2",
-        "ts-dedent": "^1.1.0",
+        "style-loader": "^0.23.1",
+        "terser-webpack-plugin": "^1.2.4",
         "unfetch": "^4.1.0",
         "url-loader": "^2.0.1",
         "util-deprecate": "^1.0.2",
         "webpack": "^4.33.0",
         "webpack-dev-middleware": "^3.7.0",
-        "webpack-hot-middleware": "^2.25.0",
-        "webpack-virtual-modules": "^0.2.0"
+        "webpack-hot-middleware": "^2.25.0"
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.17.tgz",
-          "integrity": "sha512-zg6O1bmffRsHXJOWAnSD2O3tPnVMoD8Yfu+a5zBVXDiUP1E/TGzgjjjYBUUCU3yQg1Ted5rIn4o6ql/rZNNlgA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.3.17",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.17.tgz",
-          "integrity": "sha512-G40jtXFY10hQo6GSw5JeFYt41loD4+7s0uU18Rm6lfa/twOgp6vqqyDCWDvpRRxRBB5uDIKKHLt13X9gWe8tQQ==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
           "dev": true,
           "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
-            "@storybook/csf": "0.0.1",
-            "@storybook/router": "5.3.17",
-            "@storybook/theming": "5.3.17",
-            "@types/reach__router": "^1.2.3",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -3731,45 +3723,45 @@
             "semver": "^6.0.0",
             "shallow-equal": "^1.1.0",
             "store2": "^2.7.1",
-            "telejson": "^3.2.0",
+            "telejson": "^3.0.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/channel-postmessage": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.17.tgz",
-          "integrity": "sha512-1aSQNeO2+roPRgMFjW3AWTO3uS93lbCMUTYCBdi20md4bQ9SutJy33rynCQcWuMj1prCQ2Ekz4BGhdcIQVKlzg==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.8.tgz",
+          "integrity": "sha512-RS3iDW1kpfODN+kBq3youn+KtLqHslZ4m7mTlOL80BUHKb4YkrA1lVkzpy1kVMWBU523pyDVQUVXr+M8y3iVug==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "telejson": "^3.2.0"
+            "telejson": "^3.0.2"
           }
         },
         "@storybook/channels": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.17.tgz",
-          "integrity": "sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-api": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.17.tgz",
-          "integrity": "sha512-oe55FPTGVL2k+j45eCN3oE7ePkE4VpgUQ/dhJbjU0R2L+HyRyBhd0wnMYj1f5E8uVNbtjFYAtbjjgcf1R1imeg==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.8.tgz",
+          "integrity": "sha512-OCKhZ+2sS3ot0ZV48nD79BWVzvvdMjUFYl0073ps5q+1+TLic1AlNmH0Sb5/9NrYXNV86v3VrM2jUbGsKe1qyw==",
           "dev": true,
           "requires": {
-            "@storybook/addons": "5.3.17",
-            "@storybook/channel-postmessage": "5.3.17",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
-            "@storybook/csf": "0.0.1",
-            "@types/webpack-env": "^1.15.0",
+            "@storybook/addons": "5.2.8",
+            "@storybook/channel-postmessage": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "eventemitter3": "^4.0.0",
             "global": "^4.3.2",
@@ -3778,110 +3770,117 @@
             "memoizerific": "^1.11.3",
             "qs": "^6.6.0",
             "stable": "^0.1.8",
-            "ts-dedent": "^1.1.0",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.17.tgz",
-          "integrity": "sha512-GYYvVGIOs+fq11LXXy7x2sr3hhC9LMI1jtIckjKV1dsY9MJ5g22M+Wl5Iw4nf6VMWsqcN9LSlYE+u/H+Q2uCHw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/core-events": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.17.tgz",
-          "integrity": "sha512-DOeX9fpeGW4o9Gocxa4VW9wAlAyfIVNDTzq0wVvvMBthTTo9u58NmndglEMDgDa2Cq6iAIPh7vz2bRJCNexzLw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.17.tgz",
-          "integrity": "sha512-ANsiehGRTVSremgTW0Vt47dQ4JA86a4/w/4G6QqHU8Cm4jO3cw/wAcCxlzfcgCXOUiq+SuyPTU43+0O5uBx33g==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
-            "@storybook/csf": "0.0.1",
             "@types/reach__router": "^1.2.3",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "lodash": "^4.17.15",
             "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "util-deprecate": "^1.0.2"
+            "qs": "^6.6.0"
           }
         },
         "@storybook/theming": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.17.tgz",
-          "integrity": "sha512-4JeOZnDDHtb4LOt5sXe/s1Jhbb2UPsr8zL9NWmKJmTsgnyTvBipNHOmFYDUsIacB5K4GXSqm+cZ7Z4AkUgWCDw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
           "dev": true,
           "requires": {
-            "@emotion/core": "^10.0.20",
-            "@emotion/styled": "^10.0.17",
-            "@storybook/client-logger": "5.3.17",
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.19",
+            "emotion-theming": "^10.0.14",
             "global": "^4.3.2",
             "memoizerific": "^1.11.3",
             "polished": "^3.3.1",
             "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^1.1.0"
+            "resolve-from": "^5.0.0"
           }
         },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
         },
-        "chalk": {
+        "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-          "dev": true
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-plain-object": {
@@ -3893,16 +3892,22 @@
             "isobject": "^4.0.0"
           }
         },
-        "is-wsl": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
-          "dev": true
-        },
         "isobject": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
         },
         "node-fetch": {
@@ -3911,23 +3916,67 @@
           "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
           "dev": true
         },
-        "open": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/open/-/open-7.0.3.tgz",
-          "integrity": "sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==",
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "is-docker": "^2.0.0",
-            "is-wsl": "^2.1.1"
+            "mimic-fn": "^1.0.0"
           }
         },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "has-flag": "^4.0.0"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
           }
         }
       }
@@ -3941,128 +3990,72 @@
         "core-js": "^3.0.1"
       }
     },
-    "@storybook/csf": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
-      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "@storybook/node-logger": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.3.17.tgz",
-      "integrity": "sha512-onfcxl37BYZI1HGuPI9MelkyUWjn7NpfN8RUYdqG9P6WKiIY5xbpG0V6qod5jvIKIypK0NmfJTtneOu46L/oDg==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.2.8.tgz",
+      "integrity": "sha512-3TK5mx6VWbfJO+WUrqwPhTbTQ4qESTnwJY/02xPzOhvuC6tIG1QOxzi+Rq6rFlwxTpUuWh6iyDYnGIqFFQywkA==",
       "dev": true,
       "requires": {
-        "@types/npmlog": "^4.1.2",
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "core-js": "^3.0.1",
         "npmlog": "^4.1.2",
         "pretty-hrtime": "^1.0.3",
-        "regenerator-runtime": "^0.13.3"
+        "regenerator-runtime": "^0.12.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
           "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
     "@storybook/react-native": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-5.3.17.tgz",
-      "integrity": "sha512-AS+9Cv2iBseaoo1Ctd5NcaNraLlzcAUhvxdFjvE7KMWYnorj9EXGU1faCp78zWw3bpfHwkGsYbTFNqOY37vY6Q==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-5.2.8.tgz",
+      "integrity": "sha512-uRbetQcC/42843+4XZMiBrLnWqFDS7Tqy5svyX1qMyoexYTQ6Pz9wLT3YhctAu2oK8Gfdiay1Tpg/OTrene1Sg==",
       "dev": true,
       "requires": {
-        "@emotion/core": "^10.0.20",
+        "@emotion/core": "^10.0.14",
         "@emotion/native": "^10.0.14",
-        "@storybook/addons": "5.3.17",
-        "@storybook/channel-websocket": "5.3.17",
-        "@storybook/channels": "5.3.17",
-        "@storybook/client-api": "5.3.17",
-        "@storybook/core-events": "5.3.17",
+        "@storybook/addons": "5.2.8",
+        "@storybook/channel-websocket": "5.2.8",
+        "@storybook/channels": "5.2.8",
+        "@storybook/client-api": "5.2.8",
+        "@storybook/core-events": "5.2.8",
         "core-js": "^3.0.1",
-        "emotion-theming": "^10.0.19",
-        "react-native-swipe-gestures": "^1.0.4"
+        "emotion-theming": "^10.0.14",
+        "react-native-swipe-gestures": "^1.0.3",
+        "rn-host-detect": "^1.1.5"
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.17.tgz",
-          "integrity": "sha512-zg6O1bmffRsHXJOWAnSD2O3tPnVMoD8Yfu+a5zBVXDiUP1E/TGzgjjjYBUUCU3yQg1Ted5rIn4o6ql/rZNNlgA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.3.17",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.17.tgz",
-          "integrity": "sha512-G40jtXFY10hQo6GSw5JeFYt41loD4+7s0uU18Rm6lfa/twOgp6vqqyDCWDvpRRxRBB5uDIKKHLt13X9gWe8tQQ==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
           "dev": true,
           "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
-            "@storybook/csf": "0.0.1",
-            "@storybook/router": "5.3.17",
-            "@storybook/theming": "5.3.17",
-            "@types/reach__router": "^1.2.3",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -4073,57 +4066,45 @@
             "semver": "^6.0.0",
             "shallow-equal": "^1.1.0",
             "store2": "^2.7.1",
-            "telejson": "^3.2.0",
+            "telejson": "^3.0.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/channel-postmessage": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.17.tgz",
-          "integrity": "sha512-1aSQNeO2+roPRgMFjW3AWTO3uS93lbCMUTYCBdi20md4bQ9SutJy33rynCQcWuMj1prCQ2Ekz4BGhdcIQVKlzg==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.8.tgz",
+          "integrity": "sha512-RS3iDW1kpfODN+kBq3youn+KtLqHslZ4m7mTlOL80BUHKb4YkrA1lVkzpy1kVMWBU523pyDVQUVXr+M8y3iVug==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "telejson": "^3.2.0"
-          }
-        },
-        "@storybook/channel-websocket": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-5.3.17.tgz",
-          "integrity": "sha512-JJl9t8mL27bt8sI0OShbhJJ8pbg7vt79hvXCGU3K8XkjUe1PoSl7DfWe9UKgUxN0sS1K112VFUtT5WXZ3An5yA==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "5.3.17",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "telejson": "^3.2.0"
+            "telejson": "^3.0.2"
           }
         },
         "@storybook/channels": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.17.tgz",
-          "integrity": "sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-api": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.17.tgz",
-          "integrity": "sha512-oe55FPTGVL2k+j45eCN3oE7ePkE4VpgUQ/dhJbjU0R2L+HyRyBhd0wnMYj1f5E8uVNbtjFYAtbjjgcf1R1imeg==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.8.tgz",
+          "integrity": "sha512-OCKhZ+2sS3ot0ZV48nD79BWVzvvdMjUFYl0073ps5q+1+TLic1AlNmH0Sb5/9NrYXNV86v3VrM2jUbGsKe1qyw==",
           "dev": true,
           "requires": {
-            "@storybook/addons": "5.3.17",
-            "@storybook/channel-postmessage": "5.3.17",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
-            "@storybook/csf": "0.0.1",
-            "@types/webpack-env": "^1.15.0",
+            "@storybook/addons": "5.2.8",
+            "@storybook/channel-postmessage": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "eventemitter3": "^4.0.0",
             "global": "^4.3.2",
@@ -4132,63 +4113,60 @@
             "memoizerific": "^1.11.3",
             "qs": "^6.6.0",
             "stable": "^0.1.8",
-            "ts-dedent": "^1.1.0",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.17.tgz",
-          "integrity": "sha512-GYYvVGIOs+fq11LXXy7x2sr3hhC9LMI1jtIckjKV1dsY9MJ5g22M+Wl5Iw4nf6VMWsqcN9LSlYE+u/H+Q2uCHw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/core-events": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.17.tgz",
-          "integrity": "sha512-DOeX9fpeGW4o9Gocxa4VW9wAlAyfIVNDTzq0wVvvMBthTTo9u58NmndglEMDgDa2Cq6iAIPh7vz2bRJCNexzLw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.17.tgz",
-          "integrity": "sha512-ANsiehGRTVSremgTW0Vt47dQ4JA86a4/w/4G6QqHU8Cm4jO3cw/wAcCxlzfcgCXOUiq+SuyPTU43+0O5uBx33g==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
-            "@storybook/csf": "0.0.1",
             "@types/reach__router": "^1.2.3",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "lodash": "^4.17.15",
             "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "util-deprecate": "^1.0.2"
+            "qs": "^6.6.0"
           }
         },
         "@storybook/theming": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.17.tgz",
-          "integrity": "sha512-4JeOZnDDHtb4LOt5sXe/s1Jhbb2UPsr8zL9NWmKJmTsgnyTvBipNHOmFYDUsIacB5K4GXSqm+cZ7Z4AkUgWCDw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
           "dev": true,
           "requires": {
-            "@emotion/core": "^10.0.20",
-            "@emotion/styled": "^10.0.17",
-            "@storybook/client-logger": "5.3.17",
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.19",
+            "emotion-theming": "^10.0.14",
             "global": "^4.3.2",
             "memoizerific": "^1.11.3",
             "polished": "^3.3.1",
             "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^1.1.0"
+            "resolve-from": "^5.0.0"
           }
         },
         "is-plain-object": {
@@ -4209,56 +4187,53 @@
       }
     },
     "@storybook/react-native-server": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/react-native-server/-/react-native-server-5.3.17.tgz",
-      "integrity": "sha512-nUqXMkR0xfSQKJ0idixxk/6vWzmMUZuqQpjoesvhdiuBJHeIk/Hm8e8ZW+HdwbsWlDTh7WacHRA2NaBukhuoxw==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react-native-server/-/react-native-server-5.2.8.tgz",
+      "integrity": "sha512-i/V05sSJRkKTW/ws7ZkuDTzoQBMKuoZx9MnJWqCy7K/6KLUgtLYWuDS9jZoEcvGrvae3iEYgVndUbO4Wn+LsBw==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.3.17",
-        "@storybook/api": "5.3.17",
-        "@storybook/channel-websocket": "5.3.17",
-        "@storybook/core": "5.3.17",
-        "@storybook/core-events": "5.3.17",
-        "@storybook/ui": "5.3.17",
-        "commander": "^4.0.1",
+        "@storybook/addons": "5.2.8",
+        "@storybook/api": "5.2.8",
+        "@storybook/channel-websocket": "5.2.8",
+        "@storybook/core": "5.2.8",
+        "@storybook/core-events": "5.2.8",
+        "@storybook/ui": "5.2.8",
+        "commander": "^2.19.0",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
         "react": "^16.6.0",
         "react-dom": "^16.8.3",
         "uuid": "^3.3.2",
         "webpack": "^4.33.0",
-        "ws": "^7.1.2"
+        "ws": "^6.1.0"
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.17.tgz",
-          "integrity": "sha512-zg6O1bmffRsHXJOWAnSD2O3tPnVMoD8Yfu+a5zBVXDiUP1E/TGzgjjjYBUUCU3yQg1Ted5rIn4o6ql/rZNNlgA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.3.17",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.17.tgz",
-          "integrity": "sha512-G40jtXFY10hQo6GSw5JeFYt41loD4+7s0uU18Rm6lfa/twOgp6vqqyDCWDvpRRxRBB5uDIKKHLt13X9gWe8tQQ==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
           "dev": true,
           "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
-            "@storybook/csf": "0.0.1",
-            "@storybook/router": "5.3.17",
-            "@storybook/theming": "5.3.17",
-            "@types/reach__router": "^1.2.3",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -4269,79 +4244,80 @@
             "semver": "^6.0.0",
             "shallow-equal": "^1.1.0",
             "store2": "^2.7.1",
-            "telejson": "^3.2.0",
+            "telejson": "^3.0.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/channels": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.17.tgz",
-          "integrity": "sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.17.tgz",
-          "integrity": "sha512-GYYvVGIOs+fq11LXXy7x2sr3hhC9LMI1jtIckjKV1dsY9MJ5g22M+Wl5Iw4nf6VMWsqcN9LSlYE+u/H+Q2uCHw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/core-events": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.17.tgz",
-          "integrity": "sha512-DOeX9fpeGW4o9Gocxa4VW9wAlAyfIVNDTzq0wVvvMBthTTo9u58NmndglEMDgDa2Cq6iAIPh7vz2bRJCNexzLw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.17.tgz",
-          "integrity": "sha512-ANsiehGRTVSremgTW0Vt47dQ4JA86a4/w/4G6QqHU8Cm4jO3cw/wAcCxlzfcgCXOUiq+SuyPTU43+0O5uBx33g==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
-            "@storybook/csf": "0.0.1",
             "@types/reach__router": "^1.2.3",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "lodash": "^4.17.15",
             "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "util-deprecate": "^1.0.2"
+            "qs": "^6.6.0"
           }
         },
         "@storybook/theming": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.17.tgz",
-          "integrity": "sha512-4JeOZnDDHtb4LOt5sXe/s1Jhbb2UPsr8zL9NWmKJmTsgnyTvBipNHOmFYDUsIacB5K4GXSqm+cZ7Z4AkUgWCDw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
           "dev": true,
           "requires": {
-            "@emotion/core": "^10.0.20",
-            "@emotion/styled": "^10.0.17",
-            "@storybook/client-logger": "5.3.17",
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.19",
+            "emotion-theming": "^10.0.14",
             "global": "^4.3.2",
             "memoizerific": "^1.11.3",
             "polished": "^3.3.1",
             "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^1.1.0"
+            "resolve-from": "^5.0.0"
           }
         },
-        "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-          "dev": true
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
@@ -4381,26 +4357,25 @@
       }
     },
     "@storybook/ui": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.3.17.tgz",
-      "integrity": "sha512-5S9r70QbtNKu8loa5pfO5lLX9coF/ZqesEKcanfvuSwqCSg/Z51UwFCuO6eNhVlpXzyZXi5d8qKbZlbf+uvDAA==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.2.8.tgz",
+      "integrity": "sha512-7t1ARBfylhEsLmGsZBUCj1Wf1oAgCDDrf7fi+Fhdg5Rr16CMoBbe24Gv/mPYv01/pUDhGodxzltKGX5x0Hto2w==",
       "dev": true,
       "requires": {
-        "@emotion/core": "^10.0.20",
-        "@storybook/addons": "5.3.17",
-        "@storybook/api": "5.3.17",
-        "@storybook/channels": "5.3.17",
-        "@storybook/client-logger": "5.3.17",
-        "@storybook/components": "5.3.17",
-        "@storybook/core-events": "5.3.17",
-        "@storybook/router": "5.3.17",
-        "@storybook/theming": "5.3.17",
+        "@storybook/addons": "5.2.8",
+        "@storybook/api": "5.2.8",
+        "@storybook/channels": "5.2.8",
+        "@storybook/client-logger": "5.2.8",
+        "@storybook/components": "5.2.8",
+        "@storybook/core-events": "5.2.8",
+        "@storybook/router": "5.2.8",
+        "@storybook/theming": "5.2.8",
         "copy-to-clipboard": "^3.0.8",
         "core-js": "^3.0.1",
         "core-js-pure": "^3.0.1",
-        "emotion-theming": "^10.0.19",
+        "emotion-theming": "^10.0.14",
         "fast-deep-equal": "^2.0.1",
-        "fuse.js": "^3.4.6",
+        "fuse.js": "^3.4.4",
         "global": "^4.3.2",
         "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.9.3",
@@ -4412,45 +4387,42 @@
         "react-dom": "^16.8.3",
         "react-draggable": "^4.0.3",
         "react-helmet-async": "^1.0.2",
-        "react-hotkeys": "2.0.0",
+        "react-hotkeys": "2.0.0-pre4",
         "react-sizeme": "^2.6.7",
         "regenerator-runtime": "^0.13.2",
         "resolve-from": "^5.0.0",
         "semver": "^6.0.0",
         "store2": "^2.7.1",
-        "telejson": "^3.2.0",
+        "telejson": "^3.0.2",
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.17.tgz",
-          "integrity": "sha512-zg6O1bmffRsHXJOWAnSD2O3tPnVMoD8Yfu+a5zBVXDiUP1E/TGzgjjjYBUUCU3yQg1Ted5rIn4o6ql/rZNNlgA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
+          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.3.17",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
+            "@storybook/api": "5.2.8",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.17.tgz",
-          "integrity": "sha512-G40jtXFY10hQo6GSw5JeFYt41loD4+7s0uU18Rm6lfa/twOgp6vqqyDCWDvpRRxRBB5uDIKKHLt13X9gWe8tQQ==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
+          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
           "dev": true,
           "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/channels": "5.3.17",
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/core-events": "5.3.17",
-            "@storybook/csf": "0.0.1",
-            "@storybook/router": "5.3.17",
-            "@storybook/theming": "5.3.17",
-            "@types/reach__router": "^1.2.3",
+            "@storybook/channels": "5.2.8",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/core-events": "5.2.8",
+            "@storybook/router": "5.2.8",
+            "@storybook/theming": "5.2.8",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -4461,41 +4433,40 @@
             "semver": "^6.0.0",
             "shallow-equal": "^1.1.0",
             "store2": "^2.7.1",
-            "telejson": "^3.2.0",
+            "telejson": "^3.0.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/channels": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.17.tgz",
-          "integrity": "sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
+          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.17.tgz",
-          "integrity": "sha512-GYYvVGIOs+fq11LXXy7x2sr3hhC9LMI1jtIckjKV1dsY9MJ5g22M+Wl5Iw4nf6VMWsqcN9LSlYE+u/H+Q2uCHw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
+          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/components": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.17.tgz",
-          "integrity": "sha512-M5oqbzcqFX4VDNI8siT3phT7rmFwChQ/xPwX9ygByBsZCoNuLMzafavfTOhZvxCPiliFbBxmxtK/ibCsSzuKZg==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.8.tgz",
+          "integrity": "sha512-h9l/LAMaj+emUCOyY/+ETy/S3P0npwQU280J88uL4O9XJALJ72EKfyttBCvMLvpM50E+fAPeDzuYn0t5qzGGxg==",
           "dev": true,
           "requires": {
-            "@storybook/client-logger": "5.3.17",
-            "@storybook/theming": "5.3.17",
-            "@types/react-syntax-highlighter": "11.0.4",
+            "@storybook/client-logger": "5.2.8",
+            "@storybook/theming": "5.2.8",
+            "@types/react-syntax-highlighter": "10.1.0",
             "@types/react-textarea-autosize": "^4.3.3",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "lodash": "^4.17.15",
             "markdown-to-jsx": "^6.9.1",
             "memoizerific": "^1.11.3",
             "polished": "^3.3.1",
@@ -4503,111 +4474,56 @@
             "prop-types": "^15.7.2",
             "react": "^16.8.3",
             "react-dom": "^16.8.3",
-            "react-focus-lock": "^2.1.0",
+            "react-focus-lock": "^1.18.3",
             "react-helmet-async": "^1.0.2",
             "react-popper-tooltip": "^2.8.3",
-            "react-syntax-highlighter": "^11.0.2",
+            "react-syntax-highlighter": "^8.0.1",
             "react-textarea-autosize": "^7.1.0",
-            "simplebar-react": "^1.0.0-alpha.6",
-            "ts-dedent": "^1.1.0"
+            "simplebar-react": "^1.0.0-alpha.6"
           }
         },
         "@storybook/core-events": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.17.tgz",
-          "integrity": "sha512-DOeX9fpeGW4o9Gocxa4VW9wAlAyfIVNDTzq0wVvvMBthTTo9u58NmndglEMDgDa2Cq6iAIPh7vz2bRJCNexzLw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
+          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.17.tgz",
-          "integrity": "sha512-ANsiehGRTVSremgTW0Vt47dQ4JA86a4/w/4G6QqHU8Cm4jO3cw/wAcCxlzfcgCXOUiq+SuyPTU43+0O5uBx33g==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
+          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
-            "@storybook/csf": "0.0.1",
             "@types/reach__router": "^1.2.3",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "lodash": "^4.17.15",
             "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "util-deprecate": "^1.0.2"
+            "qs": "^6.6.0"
           }
         },
         "@storybook/theming": {
-          "version": "5.3.17",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.17.tgz",
-          "integrity": "sha512-4JeOZnDDHtb4LOt5sXe/s1Jhbb2UPsr8zL9NWmKJmTsgnyTvBipNHOmFYDUsIacB5K4GXSqm+cZ7Z4AkUgWCDw==",
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
+          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
           "dev": true,
           "requires": {
-            "@emotion/core": "^10.0.20",
-            "@emotion/styled": "^10.0.17",
-            "@storybook/client-logger": "5.3.17",
+            "@emotion/core": "^10.0.14",
+            "@emotion/styled": "^10.0.14",
+            "@storybook/client-logger": "5.2.8",
+            "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.19",
+            "emotion-theming": "^10.0.14",
             "global": "^4.3.2",
             "memoizerific": "^1.11.3",
             "polished": "^3.3.1",
             "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^1.1.0"
-          }
-        },
-        "@types/react-syntax-highlighter": {
-          "version": "11.0.4",
-          "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
-          "integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
-          "dev": true,
-          "requires": {
-            "@types/react": "*"
-          }
-        },
-        "highlight.js": {
-          "version": "9.13.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-          "dev": true
-        },
-        "lowlight": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-          "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
-          "dev": true,
-          "requires": {
-            "fault": "^1.0.2",
-            "highlight.js": "~9.13.0"
-          }
-        },
-        "react-focus-lock": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
-          "integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "focus-lock": "^0.6.6",
-            "prop-types": "^15.6.2",
-            "react-clientside-effect": "^1.2.2",
-            "use-callback-ref": "^1.2.1",
-            "use-sidecar": "^1.0.1"
-          }
-        },
-        "react-syntax-highlighter": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
-          "integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "highlight.js": "~9.13.0",
-            "lowlight": "~1.11.0",
-            "prismjs": "^1.8.4",
-            "refractor": "^2.4.1"
+            "resolve-from": "^5.0.0"
           }
         }
       }
@@ -4720,12 +4636,6 @@
       "integrity": "sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA==",
       "dev": true
     },
-    "@types/npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==",
-      "dev": true
-    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -4827,9 +4737,9 @@
       "dev": true
     },
     "@types/webpack": {
-      "version": "4.41.9",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.9.tgz",
-      "integrity": "sha512-R68AotLGtaVL6HGfZRvEyYKsWcMv0CBFfSr4gxoYzhMn3LnjLV/ksP4dNi9de8dVG+Dn/GuDr1NwB/sDApB3pA==",
+      "version": "4.41.10",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.10.tgz",
+      "integrity": "sha512-vIy0qaq8AjOjZLuFPqpo7nAJzcoVXMdw3mvpNN07Uvdy0p1IpJeLNBe3obdRP7FX2jIusDE7z1pZa0A6qYUgnA==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -4847,12 +4757,6 @@
           "dev": true
         }
       }
-    },
-    "@types/webpack-env": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.1.tgz",
-      "integrity": "sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA==",
-      "dev": true
     },
     "@types/webpack-sources": {
       "version": "0.1.7",
@@ -5157,24 +5061,6 @@
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
-      }
-    },
-    "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
-        }
       }
     },
     "airbnb-js-shims": {
@@ -5753,15 +5639,15 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.11.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-          "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+          "version": "4.11.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+          "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001035",
-            "electron-to-chromium": "^1.3.380",
-            "node-releases": "^1.1.52",
-            "pkg-up": "^3.1.0"
+            "caniuse-lite": "^1.0.30001038",
+            "electron-to-chromium": "^1.3.390",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
           }
         },
         "caniuse-lite": {
@@ -5771,9 +5657,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.390",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-          "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag==",
+          "version": "1.3.391",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.391.tgz",
+          "integrity": "sha512-WOi6loSnDmfICOqGRrgeK7bZeWDAbGjCptDhI5eyJAqSzWfoeRuOOU1rOTZRL29/9AaxTndZB6Uh8YrxRfZJqw==",
           "dev": true
         },
         "node-releases": {
@@ -6576,108 +6462,58 @@
       "dev": true
     },
     "boxen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
       "dev": true,
       "requires": {
         "ansi-align": "^3.0.0",
         "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
+        "chalk": "^2.4.2",
         "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
+        "string-width": "^3.0.0",
+        "term-size": "^1.2.0",
+        "type-fest": "^0.3.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
         }
       }
     },
@@ -6967,10 +6803,25 @@
         "y18n": "^4.0.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "y18n": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -7234,12 +7085,6 @@
           "dev": true
         }
       }
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
     },
     "cli-boxes": {
       "version": "2.2.0",
@@ -8374,12 +8219,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true
-    },
-    "detect-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
     "detect-port": {
@@ -10872,25 +10711,13 @@
       }
     },
     "file-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.3.0.tgz",
-      "integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
+      "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.5.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-          "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.0",
-            "ajv-keywords": "^3.4.1"
-          }
-        }
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^1.0.0"
       }
     },
     "file-system-cache": {
@@ -11245,15 +11072,6 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
       }
     },
     "fs-mkdirp-stream": {
@@ -12112,42 +11930,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -13152,9 +12934,9 @@
       }
     },
     "interpret": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.0.0.tgz",
-      "integrity": "sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
     "invariant": {
@@ -13351,12 +13133,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
-    },
-    "is-docker": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
       "dev": true
     },
     "is-dom": {
@@ -18361,6 +18137,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-fn": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-fn/-/json-fn-1.1.1.tgz",
+      "integrity": "sha1-QpPJGYpILWaX0zSm4yzQ0iESHoA=",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -19431,12 +19213,13 @@
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "macos-release": {
@@ -21040,50 +20823,6 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
-    "minipass": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
-    "minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
-    "minipass-pipeline": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
-      }
-    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -22314,22 +22053,62 @@
       }
     },
     "pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "^2.0.0"
           }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
         }
       }
     },
@@ -22406,9 +22185,9 @@
       "dev": true
     },
     "pnp-webpack-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz",
-      "integrity": "sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-ExrNwuFH3DudHwWY2uRMqyiCOBEDdhQYHIAsqW/CM6hIZlSgXC/ma/p08FoNOUhVyh9hl1NGnMpR94T5i3SHaQ==",
       "dev": true,
       "requires": {
         "ts-pnp": "^1.1.2"
@@ -22935,25 +22714,13 @@
       }
     },
     "raw-loader": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-3.1.0.tgz",
-      "integrity": "sha512-lzUVMuJ06HF4rYveaz9Tv0WRlUMxJ0Y1hgSkkgg+50iEdaI0TthyEDe08KIHb0XsF6rn8WYTqPCaGTZg3sX+qA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-2.0.0.tgz",
+      "integrity": "sha512-kZnO5MoIyrojfrPWqrhFNLZemIAX8edMOCp++yC5RKxzFB3m92DqKNhKlU6+FvpOhWtvyh3jOaD7J6/9tpdIKg==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
-        "schema-utils": "^2.0.1"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-          "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.0",
-            "ajv-keywords": "^3.4.1"
-          }
-        }
+        "schema-utils": "^1.0.0"
       }
     },
     "react": {
@@ -23176,71 +22943,11 @@
             "mimic-fn": "^1.0.0"
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
-        },
-        "pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-          "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "dev": true,
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-              "dev": true,
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-              }
-            }
-          }
         },
         "restore-cursor": {
           "version": "2.0.0",
@@ -23381,9 +23088,9 @@
       }
     },
     "react-hotkeys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
-      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
+      "version": "2.0.0-pre4",
+      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0-pre4.tgz",
+      "integrity": "sha512-oa+UncSWyOwMK3GExt+oELXaR7T3ItgcMolsupQFdKvwkEhVAluJd5rYczsRSQpQlVkdNoHG46De2NUeuS+88Q==",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.1"
@@ -24627,6 +24334,12 @@
         "inherits": "^2.0.1"
       }
     },
+    "rn-host-detect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.2.0.tgz",
+      "integrity": "sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A==",
+      "dev": true
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -25005,14 +24718,6 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
-      },
-      "dependencies": {
-        "interpret": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-          "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-          "dev": true
-        }
       }
     },
     "shellwords": {
@@ -25751,25 +25456,13 @@
       "dev": true
     },
     "style-loader": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.3.tgz",
-      "integrity": "sha512-rlkH7X/22yuwFYK357fMN/BxYOorfnfq0eD7+vqlemSK4wEcejFF1dg4zxP0euBW8NrYx2WZzZ8PPFevr7D+Kw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+      "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.6.4"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-          "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.0",
-            "ajv-keywords": "^3.4.1"
-          }
-        }
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0"
       }
     },
     "subarg": {
@@ -25931,10 +25624,47 @@
       }
     },
     "term-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
     },
     "terminal-link": {
       "version": "2.1.1",
@@ -25974,9 +25704,9 @@
       }
     },
     "terser": {
-      "version": "4.6.7",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.7.tgz",
-      "integrity": "sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==",
+      "version": "4.6.10",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.10.tgz",
+      "integrity": "sha512-qbF/3UOo11Hggsbsqm2hPa6+L4w7bkr+09FNseEe8xrcVD3APGLFqE+Oz1ZKAxjYnFsj80rLOfgAtJ0LNJjtTA==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -25993,65 +25723,31 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.5.tgz",
-      "integrity": "sha512-WlWksUoq+E4+JlJ+h+U+QUzXpcsMSSNXkDy9lBVkSqDn1w23Gg29L/ary9GeJVYCGiNJJX7LnVc4bwL1N3/g1w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
-        "cacache": "^13.0.1",
-        "find-cache-dir": "^3.2.0",
-        "jest-worker": "^25.1.0",
-        "p-limit": "^2.2.2",
-        "schema-utils": "^2.6.4",
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
         "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
-        "terser": "^4.4.3",
-        "webpack-sources": "^1.4.3"
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
       },
       "dependencies": {
-        "cacache": {
-          "version": "13.0.1",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-          "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.2",
-            "figgy-pudding": "^3.5.1",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
-            "minipass": "^3.0.0",
-            "minipass-collect": "^1.0.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "p-map": "^3.0.0",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.7.1",
-            "ssri": "^7.0.0",
-            "unique-filename": "^1.1.1"
-          }
-        },
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-          "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.0",
-            "ajv-keywords": "^3.4.1"
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
         "source-map": {
@@ -26059,16 +25755,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "ssri": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-          "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1",
-            "minipass": "^3.1.1"
-          }
         }
       }
     },
@@ -26396,12 +26082,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
-    },
-    "ts-dedent": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
-      "integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==",
       "dev": true
     },
     "ts-object-utils": {
@@ -26888,22 +26568,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "use-callback-ref": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
-      "integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==",
-      "dev": true
-    },
-    "use-sidecar": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
-      "integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
-      "dev": true,
-      "requires": {
-        "detect-node": "^2.0.4",
-        "tslib": "^1.9.3"
-      }
-    },
     "util": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
@@ -27323,17 +26987,6 @@
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
-        "find-cache-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
-          }
-        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -27368,29 +27021,6 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "terser-webpack-plugin": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-          "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
-          "dev": true,
-          "requires": {
-            "cacache": "^12.0.2",
-            "find-cache-dir": "^2.1.0",
-            "is-wsl": "^1.1.0",
-            "schema-utils": "^1.0.0",
-            "serialize-javascript": "^2.1.2",
-            "source-map": "^0.6.1",
-            "terser": "^4.1.2",
-            "webpack-sources": "^1.4.0",
-            "worker-farm": "^1.7.0"
           }
         }
       }
@@ -27454,15 +27084,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
-      }
-    },
-    "webpack-virtual-modules": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.2.1.tgz",
-      "integrity": "sha512-0PWBlxyt4uGDofooIEanWhhyBOHdd+lr7QpYNDLC7/yc5lqJT8zlc04MTIBnKj+c2BlQNNuwE5er/Tg4wowHzA==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
       }
     },
     "websocket-driver": {
@@ -27545,50 +27166,43 @@
       }
     },
     "widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
-        "string-width": "^4.0.0"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -27742,9 +27356,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
   "devDependencies": {
     "@storybook/addon-actions": "5.2.5",
     "@storybook/addon-ondevice-actions": "5.2.5",
-    "@storybook/react-native": "5.3.17",
-    "@storybook/react-native-server": "5.3.17",
+    "@storybook/react-native": "5.2.8",
+    "@storybook/react-native-server": "5.2.8",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-jest-hoist": "^24.9.0",


### PR DESCRIPTION
Upgrading Storybook stops the addons panel from working. I've made BPK-3800 to fix it, but for now let's lock the dependency.