### PR TITLE
[BPK-3684] Add internal maven repo only when necessary

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,21 @@ buildscript {
     }
 }
 
+ext {
+  internalBuild       = project.hasProperty("internalBuild") && project.internalBuild
+  backpackVersion     = "22.2.0${ext.internalBuild || isUseRelative() ? '-internal' : ''}"
+  compileSdkVersion   = 29
+  targetSdkVersion    = 29
+  minSdkVersion       = 21
+  buildToolsVersion   = "29.0.2"
+  androidx            = '1.0.2'
+  appcompat           = '1.0.2'
+  supportLibVersion = "27.1.1"
+  playServicesVersion = "xxx"
+  androidMapsUtilsVersion = "0.5+"
+  threetenabpVersion = "1.2.1"
+}
+
 allprojects {
     repositories {
         mavenLocal()
@@ -33,15 +48,17 @@ allprojects {
             url("$rootDir/../node_modules/jsc-android/dist")
         }
 
-        maven {
-          url project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_URL"]?.toString()
-          credentials(PasswordCredentials.class) {
-            username = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_USER"]?.toString()
-            password = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_PASSWORD"]?.toString()
-          }
+        if (rootProject.ext.internalBuild || isUseRelative()) {
+          maven {
+            url project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_URL"]?.toString()
+            credentials(PasswordCredentials.class) {
+              username = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_USER"]?.toString()
+              password = project.properties["SKYSCANNER_ARTIFACTORY_MAVEN_PASSWORD"]?.toString()
+            }
 
-          content {
-            includeModule("com.github.skyscanner", "backpack-android")
+            content {
+              includeModule("com.github.skyscanner", "backpack-android")
+            }
           }
         }
 
@@ -67,21 +84,6 @@ allprojects {
             }
         }
     }
-}
-
-ext {
-  internalBuild       = project.hasProperty("internalBuild") && project.internalBuild
-  backpackVersion     = "22.2.0${ext.internalBuild || isUseRelative() ? '-internal' : ''}"
-  compileSdkVersion   = 29
-  targetSdkVersion    = 29
-  minSdkVersion       = 21
-  buildToolsVersion   = "29.0.2"
-  androidx            = '1.0.2'
-  appcompat           = '1.0.2'
-  supportLibVersion = "27.1.1"
-  playServicesVersion = "xxx"
-  androidMapsUtilsVersion = "0.5+"
-  threetenabpVersion = "1.2.1"
 }
 
 allprojects { project ->


### PR DESCRIPTION
Always adding it causes travis to try to download it from the internal repo sometimes, which fails because it's not authenticated. 
We only need it locally when building for the internal version or using relative.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
