### PR TITLE
[No Jira] Add props for custom styling horizontal nav

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -278,6 +278,7 @@ scrimAction
 selectedDates
 selectedId
 selectedIndex
+selectedIndicatorStyle
 selectedValue
 selectionType
 SELECTION_TYPES

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,7 +4,8 @@
 **Added:**
 
 - bpk-component-horizontal-nav:
-  - New `textStyle` prop for `BpkHorizontalNavItem` to enable styling of text in nav items.
+  - New `selectedIndicatorStyle` prop for `BpkHorizontalNav` for styling the indicator underneath the selected nav item.
+  - New `textStyle` prop for `BpkHorizontalNavItem` for styling the text inside the nav item.
 
 
 ## How to write a good changelog entry

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,11 @@
 # Unreleased
 
 > Place your changes below this line.
+**Added:**
+
+- bpk-component-horizontal-nav:
+  - New `textStyle` prop for `BpkHorizontalNavItem` to enable styling of text in nav items.
+
 
 ## How to write a good changelog entry
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - FSCalendar (~> 2.8)
     - MBProgressHUD (~> 0.9.1)
     - TTTAttributedLabel (~> 1.13.4)
-  - BackpackReactNative (1.4.1):
+  - BackpackReactNative (1.4.2):
     - Backpack (~> 29.0)
     - React
   - boost-for-react-native (1.63.0)
@@ -343,7 +343,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Backpack: 2373a80d5d57eec734f55466565ef4950e97bc6b
-  BackpackReactNative: 5b5c0c84947e030bf923e43cd75fa791580dc737
+  BackpackReactNative: 3a0c820efcaeeca2dcde77ea46c613cb0d1c03ff
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2

--- a/lib/bpk-component-horizontal-nav/README.md
+++ b/lib/bpk-component-horizontal-nav/README.md
@@ -54,11 +54,16 @@ export default class App extends Component {
 
 ### BpkHorizontalNav
 
-| Property            | PropType                                                    | Required | Default Value |
-| -----------         | ----------------------------------------------------------- | -------- | ------------- |
-| children            | node                                                        | true     | -             |
-| selectedId          | string (matching `id` prop of `BpkHorizontalNavItem` child) | true     | -             |
-| spaceAround         | bool                                                        | false    | false         |
+| Property               | PropType                                                    | Required | Default Value |
+| -----------            | ----------------------------------------------------------- | -------- | ------------- |
+| children               | node                                                        | true     | -             |
+| selectedId             | string (matching `id` prop of `BpkHorizontalNavItem` child) | true     | -             |
+| selectedIndicatorStyle | style object                                                | false    | null          |
+| spaceAround            | bool                                                        | false    | false         |
+
+#### `selectedIndicatorStyle`
+
+Styles to apply to the indicator placed below the selected nav item.
 
 ### BpkHorizontalNavItem
 
@@ -68,10 +73,14 @@ export default class App extends Component {
 | onPress             | func                                  | true     | -             |
 | title               | string                                | true     | -             |
 | accessibilityLabel  | string                                | false    | props.title   |
-| small               | bool                                  | false    | false         |
 | disabled            | bool                                  | false    | false         |
-| theme               | See [Theme Props](#theme-props) below | false    | null          |
+| small               | bool                                  | false    | false         |
 | textStyle           | style object                          | false    | null          |
+| theme               | See [Theme Props](#theme-props) below | false    | null          |
+
+#### `textStyle`
+
+Styles to apply to the `BpkText` component inside the nav item.
 
 
 ## Theme Props

--- a/lib/bpk-component-horizontal-nav/README.md
+++ b/lib/bpk-component-horizontal-nav/README.md
@@ -71,6 +71,7 @@ export default class App extends Component {
 | small               | bool                                  | false    | false         |
 | disabled            | bool                                  | false    | false         |
 | theme               | See [Theme Props](#theme-props) below | false    | null          |
+| textStyle           | style object                          | false    | null          |
 
 
 ## Theme Props

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNav.js
@@ -70,7 +70,8 @@ export type Props = {
   children: Node,
   selectedId: string,
   spaceAround: boolean,
-  style: ViewStyleProp,
+  selectedIndicatorStyle: ?ViewStyleProp,
+  style: ?ViewStyleProp,
 };
 
 type State = {
@@ -79,6 +80,7 @@ type State = {
 };
 
 const defaultProps = {
+  selectedIndicatorStyle: null,
   spaceAround: false,
   style: null,
 };
@@ -90,6 +92,7 @@ class BpkHorizontalNav extends React.Component<
   static propTypes = {
     children: PropTypes.node.isRequired,
     selectedId: PropTypes.string.isRequired,
+    selectedIndicatorStyle: ViewPropTypes.style,
     spaceAround: PropTypes.bool,
     style: ViewPropTypes.style,
   };
@@ -136,6 +139,7 @@ class BpkHorizontalNav extends React.Component<
     const {
       children,
       selectedId,
+      selectedIndicatorStyle,
       spaceAround,
       style,
       bpkAppearance,
@@ -177,6 +181,7 @@ class BpkHorizontalNav extends React.Component<
       return (
         <View style={styles.indicatorWrapper}>
           <AnimatedIndicator
+            style={selectedIndicatorStyle}
             xOffset={this.state.indicatorOffsetX}
             width={this.state.indicatorWidth}
           />

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem-test.common.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { spacingSm } from 'bpk-tokens/tokens/base.react.native';
+import { spacingSm, colorWhite } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkThemeProvider from '../../bpk-theming';
 import { describeEachColorScheme } from '../../bpk-test-utils';
@@ -100,6 +100,22 @@ const commonTests = () => {
             title="Nav"
             onPress={onPressFn}
             style={{ marginBottom: spacingSm }}
+          >
+            My nav content.
+          </BpkHorizontalNavItem>,
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('should render item text correctly with custom "textStyle" prop', () => {
+      const tree = renderer
+        .create(
+          <BpkHorizontalNavItem
+            id="0"
+            title="Nav"
+            onPress={onPressFn}
+            textStyle={{ color: colorWhite }}
           >
             My nav content.
           </BpkHorizontalNavItem>,

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -75,9 +75,9 @@ export type Props = {
   accessibilityLabel: ?string,
   disabled: boolean,
   selected: boolean,
-  style: ViewStyleProp,
-  textStyle: TextStyleProp,
   small: boolean,
+  style: ?ViewStyleProp,
+  textStyle: ?TextStyleProp,
   theme: ?Object,
 };
 
@@ -101,10 +101,6 @@ const BpkHorizontalNavItem = (props: Props) => {
   const textStyles = [styles.text];
   const themeAttributes = getThemeAttributes(REQUIRED_THEME_ATTRIBUTES, theme);
 
-  if (textStyle) {
-    textStyles.push(textStyle);
-  }
-
   if (disabled) {
     accessibilityStates.push('disabled');
     textStyles.push(styles.textDisabled);
@@ -115,6 +111,10 @@ const BpkHorizontalNavItem = (props: Props) => {
         color: themeAttributes.horizontalNavSelectedTextColor,
       });
     }
+  }
+
+  if (textStyle) {
+    textStyles.push(textStyle);
   }
 
   if (small) {

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -18,7 +18,7 @@
 
 /* @flow */
 
-import { Platform, View, ViewPropTypes } from 'react-native';
+import { Platform, View, ViewPropTypes, Text } from 'react-native';
 import React, { type ElementProps } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -45,6 +45,9 @@ import { REQUIRED_THEME_ATTRIBUTES, themePropType } from './theming';
 
 type ViewProps = ElementProps<typeof View>;
 type ViewStyleProp = $PropertyType<ViewProps, 'style'>;
+
+type TextProps = ElementProps<typeof BpkText>;
+type TextStyleProp = $PropertyType<TextProps, 'textStyle'>;
 
 const dynamicStyles = BpkDynamicStyleSheet.create({
   view: {
@@ -73,6 +76,7 @@ export type Props = {
   disabled: boolean,
   selected: boolean,
   style: ViewStyleProp,
+  textStyle: TextStyleProp,
   small: boolean,
   theme: ?Object,
 };
@@ -83,6 +87,7 @@ const BpkHorizontalNavItem = (props: Props) => {
     disabled,
     selected,
     style,
+    textStyle,
     theme,
     small,
     title,
@@ -95,6 +100,10 @@ const BpkHorizontalNavItem = (props: Props) => {
   const viewStyles = [styles.view];
   const textStyles = [styles.text];
   const themeAttributes = getThemeAttributes(REQUIRED_THEME_ATTRIBUTES, theme);
+
+  if (textStyle) {
+    textStyles.push(textStyle);
+  }
 
   if (disabled) {
     accessibilityStates.push('disabled');
@@ -148,6 +157,7 @@ BpkHorizontalNavItem.propTypes = {
   disabled: PropTypes.bool,
   selected: PropTypes.bool,
   style: ViewPropTypes.style,
+  textStyle: Text.propTypes.style,
   small: PropTypes.bool,
   theme: themePropType,
 };
@@ -158,6 +168,7 @@ BpkHorizontalNavItem.defaultProps = {
   selected: false,
   small: false,
   style: null,
+  textStyle: null,
   theme: null,
 };
 

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.common.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator-test.common.js
@@ -20,6 +20,7 @@
 
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { colorWhite } from 'bpk-tokens/tokens/base.react.native';
 
 import BpkThemeProvider from '../../bpk-theming';
 import { describeEachColorScheme } from '../../bpk-test-utils';
@@ -34,6 +35,19 @@ const commonTests = () => {
         it('should render correctly', () => {
           const tree = renderer
             .create(<WithColorScheme xOffset={0} width={100} />)
+            .toJSON();
+          expect(tree).toMatchSnapshot();
+        });
+
+        it('should support custom styles', () => {
+          const tree = renderer
+            .create(
+              <WithColorScheme
+                xOffset={0}
+                width={100}
+                style={{ backgroundColor: colorWhite }}
+              />,
+            )
             .toJSON();
           expect(tree).toMatchSnapshot();
         });

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavSelectedIndicator.js
@@ -18,8 +18,8 @@
 
 /* @flow */
 
-import React from 'react';
-import { Animated } from 'react-native';
+import React, { type ElementProps } from 'react';
+import { Animated, View, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import {
   primaryColor,
@@ -34,6 +34,9 @@ import {
 
 import { REQUIRED_THEME_ATTRIBUTES, themePropType } from './theming';
 
+type ViewProps = ElementProps<typeof View>;
+type ViewStyleProp = $PropertyType<ViewProps, 'style'>;
+
 const dynamicStyles = BpkDynamicStyleSheet.create({
   selectedIndicator: {
     backgroundColor: primaryColor,
@@ -42,13 +45,14 @@ const dynamicStyles = BpkDynamicStyleSheet.create({
 });
 
 export type Props = {
-  xOffset: ?(number | Object),
-  width: ?(number | Object),
+  style: ?ViewStyleProp,
   theme: ?Theme,
+  width: ?(number | Object),
+  xOffset: ?(number | Object),
 };
 
 const BpkHorizontalNavSelectedIndicator = (props: Props) => {
-  const { xOffset, width, theme } = props;
+  const { style: userStyle, theme, width, xOffset } = props;
 
   const styles = useBpkDynamicStyleSheet(dynamicStyles);
   const style = [styles.selectedIndicator];
@@ -59,6 +63,10 @@ const BpkHorizontalNavSelectedIndicator = (props: Props) => {
     style.push({
       backgroundColor: themeAttributes.horizontalNavSelectedTextColor,
     });
+  }
+
+  if (userStyle) {
+    style.push(userStyle);
   }
 
   const animationStyles = {
@@ -74,18 +82,20 @@ const BpkHorizontalNavSelectedIndicator = (props: Props) => {
 };
 
 BpkHorizontalNavSelectedIndicator.propTypes = {
+  style: ViewPropTypes.style,
+  theme: themePropType,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Object)]),
   xOffset: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.instanceOf(Object),
   ]),
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Object)]),
-  theme: themePropType,
 };
 
 BpkHorizontalNavSelectedIndicator.defaultProps = {
-  xOffset: null,
-  width: null,
+  style: null,
   theme: null,
+  width: null,
+  xOffset: null,
 };
 
 export default (withTheme(

--- a/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
+++ b/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.android.js.snap
@@ -586,6 +586,65 @@ exports[`Android BpkHorizontalNavItem should render correctly with custom "style
 </View>
 `;
 
+exports[`Android BpkHorizontalNavItem should render item text correctly with custom "textStyle" prop 1`] = `
+<View
+  accessibilityLabel="Nav"
+  accessibilityRole="button"
+  accessibilityStates={Array []}
+  accessible={true}
+  focusable={true}
+  isTVSelectable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "borderless": false,
+      "color": null,
+      "type": "RippleAndroid",
+    }
+  }
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "height": 33,
+        "justifyContent": "center",
+      },
+    ]
+  }
+>
+  <Text
+    allowFontScaling={false}
+    style={
+      Array [
+        Object {
+          "color": "rgb(17, 18, 54)",
+          "fontFamily": "sans-serif",
+          "fontSize": 16,
+          "fontWeight": "400",
+          "letterSpacing": -0.2,
+        },
+        Object {},
+        Array [
+          Object {
+            "paddingHorizontal": 16,
+          },
+          Object {
+            "color": "rgb(255, 255, 255)",
+          },
+        ],
+      ]
+    }
+  >
+    NAV
+  </Text>
+</View>
+`;
+
 exports[`Android BpkHorizontalNavItem should support theming 1`] = `
 <View
   accessibilityLabel="Nav"

--- a/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
+++ b/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavItem-test.ios.js.snap
@@ -706,6 +706,77 @@ exports[`iOS BpkHorizontalNavItem should render correctly with custom "style" pr
 </View>
 `;
 
+exports[`iOS BpkHorizontalNavItem should render item text correctly with custom "textStyle" prop 1`] = `
+<View
+  accessibilityLabel="Nav"
+  accessibilityRole="button"
+  accessibilityStates={Array []}
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={null}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "height": 33,
+          "justifyContent": "center",
+        },
+      ]
+    }
+  >
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "letterSpacing": 0.12,
+          },
+          Object {},
+          Array [
+            Object {
+              "paddingHorizontal": 16,
+            },
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      Nav
+    </Text>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(17, 18, 54)",
+          "bottom": 0,
+          "flex": 1,
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`iOS BpkHorizontalNavItem should support theming 1`] = `
 <View
   accessibilityLabel="Nav"

--- a/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.android.js.snap
+++ b/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.android.js.snap
@@ -17,11 +17,45 @@ exports[`Android BpkHorizontalNavSelectedIndicator dark mode should render corre
 />
 `;
 
+exports[`Android BpkHorizontalNavSelectedIndicator dark mode should support custom styles 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "rgb(255, 255, 255)",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;
+
 exports[`Android BpkHorizontalNavSelectedIndicator light mode should render correctly 1`] = `
 <View
   style={
     Object {
       "backgroundColor": "rgb(7, 112, 227)",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;
+
+exports[`Android BpkHorizontalNavSelectedIndicator light mode should support custom styles 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "rgb(255, 255, 255)",
       "height": 2,
       "transform": Array [
         Object {

--- a/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.ios.js.snap
+++ b/lib/bpk-component-horizontal-nav/src/__snapshots__/BpkHorizontalNavSelectedIndicator-test.ios.js.snap
@@ -17,11 +17,45 @@ exports[`iOS BpkHorizontalNavSelectedIndicator dark mode should render correctly
 />
 `;
 
+exports[`iOS BpkHorizontalNavSelectedIndicator dark mode should support custom styles 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "rgb(255, 255, 255)",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;
+
 exports[`iOS BpkHorizontalNavSelectedIndicator light mode should render correctly 1`] = `
 <View
   style={
     Object {
       "backgroundColor": "rgb(7, 112, 227)",
+      "height": 2,
+      "transform": Array [
+        Object {
+          "translateX": 0,
+        },
+      ],
+      "width": 100,
+    }
+  }
+/>
+`;
+
+exports[`iOS BpkHorizontalNavSelectedIndicator light mode should support custom styles 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "rgb(255, 255, 255)",
       "height": 2,
       "transform": Array [
         Object {

--- a/lib/bpk-component-horizontal-nav/stories.js
+++ b/lib/bpk-component-horizontal-nav/stories.js
@@ -178,12 +178,13 @@ storiesOf('bpk-component-horizontal-nav', module)
       </BpkHorizontalNav>
     </View>
   ))
-  .add('docs:textStyle', () => (
+  .add('Custom styles', () => (
     <View style={styles.bottomMargin}>
       <BpkHorizontalNav
         spaceAround
         selectedId="1"
         style={{ backgroundColor: colorSkyGray }}
+        selectedIndicatorStyle={{ backgroundColor: colorWhite }}
       >
         <BpkHorizontalNavItem
           title="Flights"

--- a/lib/bpk-component-horizontal-nav/stories.js
+++ b/lib/bpk-component-horizontal-nav/stories.js
@@ -22,7 +22,11 @@ import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react-native';
-import { spacingBase } from 'bpk-tokens/tokens/base.react.native';
+import {
+  spacingBase,
+  colorSkyGray,
+  colorWhite,
+} from 'bpk-tokens/tokens/base.react.native';
 
 import BpkThemeProvider from '../bpk-theming';
 import action from '../../storybook/addons/actions';
@@ -169,6 +173,34 @@ storiesOf('bpk-component-horizontal-nav', module)
         <BpkHorizontalNavItem
           title="Car hire"
           id="2"
+          onPress={action('Nav item three pressed')}
+        />
+      </BpkHorizontalNav>
+    </View>
+  ))
+  .add('docs:textStyle', () => (
+    <View style={styles.bottomMargin}>
+      <BpkHorizontalNav
+        spaceAround
+        selectedId="1"
+        style={{ backgroundColor: colorSkyGray }}
+      >
+        <BpkHorizontalNavItem
+          title="Flights"
+          id="0"
+          textStyle={{ color: colorWhite }}
+          onPress={action('Nav item one pressed')}
+        />
+        <BpkHorizontalNavItem
+          title="Hotels"
+          id="1"
+          textStyle={{ color: colorWhite }}
+          onPress={action('Nav item two pressed')}
+        />
+        <BpkHorizontalNavItem
+          title="Car hire"
+          id="2"
+          textStyle={{ color: colorWhite }}
           onPress={action('Nav item three pressed')}
         />
       </BpkHorizontalNav>


### PR DESCRIPTION
Adds two new props for consumers to set styles for the text and selected indicator.

Please note that this is advanced behaviour intended to give users an 'escape hatch' for when they really need to set some custom styles to fulfil a product requirement that's not officially supported by the component yet. In this case, the product need is to use Monteverde for the colours, which this PR now enables. 

Following on from this we will begin a discussion with designers to have Monteverde an officially supported colour with proper first-party support.

![Simulator Screen Shot - iPhone 8 - 2020-04-02 at 10 16 09](https://user-images.githubusercontent.com/73652/78231875-5ca93e80-74cb-11ea-9c65-2474787f50dc.png)
