### PR TITLE
[BPK-3818] Add dialog dynamic color example

### DIFF
--- a/lib/bpk-component-dialog/stories.js
+++ b/lib/bpk-component-dialog/stories.js
@@ -25,6 +25,10 @@ import { storiesOf } from '@storybook/react-native';
 import BpkButton from '../bpk-component-button';
 import { icons } from '../bpk-component-icon';
 import BpkText from '../bpk-component-text';
+import {
+  BpkAppearanceConsumer,
+  unpackBpkDynamicValue,
+} from '../bpk-appearance';
 import CenterDecorator from '../../storybook/CenterDecorator';
 
 import BpkDialog, { DIALOG_TYPE, BUTTON_TYPE } from './index';
@@ -61,8 +65,10 @@ const disabledScrimAction = {
 };
 
 type DialogState = {
-  ...$Exact<BpkDialogProps>,
   text: string,
+  isOpen: boolean,
+  actions: Array<ActionButton>,
+  scrimAction: ScrimAction,
 };
 
 class TriggerDialogComponent extends Component<BpkDialogProps, DialogState> {
@@ -70,10 +76,6 @@ class TriggerDialogComponent extends Component<BpkDialogProps, DialogState> {
     super(props);
 
     this.state = {
-      dialogType: props.dialogType,
-      title: props.title,
-      description: props.description,
-      icon: props.icon,
       actions: props.actions,
       scrimAction: props.scrimAction,
       isOpen: false,
@@ -84,7 +86,8 @@ class TriggerDialogComponent extends Component<BpkDialogProps, DialogState> {
   openDialog = () => this.setState({ isOpen: true });
 
   render() {
-    const { text, dialogType, title, description, icon, isOpen } = this.state;
+    const { text, isOpen } = this.state;
+    const { icon, dialogType, title, description } = this.props;
 
     let actions: Array<ActionButton> = [];
     if (this.state.actions) {
@@ -213,4 +216,28 @@ storiesOf('bpk-component-dialog', module)
       scrimAction={defaultScrimAction}
       isOpen
     />
+  ))
+  .add('dynamic-color', () => (
+    <BpkAppearanceConsumer>
+      {({ bpkAppearance }) => {
+        const icon = {
+          iconId: icons.trash,
+          iconColor: unpackBpkDynamicValue(
+            { light: 'colorPanjin', dark: 'colorMonteverde' },
+            bpkAppearance,
+          ),
+        };
+        return (
+          <TriggerDialogComponent
+            dialogType={DIALOG_TYPE.alert}
+            title={dialogTitle}
+            description={dialogDescription}
+            icon={icon}
+            actions={simpleAction}
+            scrimAction={defaultScrimAction}
+            isOpen
+          />
+        );
+      }}
+    </BpkAppearanceConsumer>
   ));


### PR DESCRIPTION
This new story uses different icon colours for light and dark mode. Note that the colour of the dialog does not change as this is only simulating dark mode in RN, not at system level, and the dialog code is native.

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-07 at 11 58 53](https://user-images.githubusercontent.com/30267516/78662373-2c491200-78c8-11ea-8415-6b2225d22859.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-07 at 11 58 49](https://user-images.githubusercontent.com/30267516/78662378-2e12d580-78c8-11ea-9cc7-4eff073f277a.png)

![Screenshot_1586266644](https://user-images.githubusercontent.com/30267516/78675722-5d800d00-78dd-11ea-95ce-7cedf728103f.png)

![Screenshot_1586266616](https://user-images.githubusercontent.com/30267516/78675728-5eb13a00-78dd-11ea-86ee-1332796c9e9c.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
