### PR TITLE
Bpk 3818 enable changing dialog icon color at runtime

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Fixed**
+- bpk-component-dialog:
+  - Changing the icon background color at runtime will now result in an immediate update to the presented dialog.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Backpack (29.2.0):
+  - Backpack (29.2.1):
     - FloatingPanel (= 1.6.6)
     - FSCalendar (~> 2.8)
     - MBProgressHUD (~> 0.9.1)

--- a/lib/ios/BackpackReactNative/Classes/DialogBridge/RCTBPKDialog.m
+++ b/lib/ios/BackpackReactNative/Classes/DialogBridge/RCTBPKDialog.m
@@ -18,6 +18,7 @@
 
 #import "RCTBPKDialog.h"
 #import <Backpack/Color.h>
+#import <Backpack/Icon.h>
 #import <React/RCTBridge.h>
 #import <React/RCTTouchHandler.h>
 #import <React/RCTUIManager.h>
@@ -68,6 +69,17 @@ RCT_NOT_IMPLEMENTED(-(instancetype _Nullable)initWithCoder : coder)
     dispatch_async(dispatch_get_main_queue(), ^{
       [self dismiss];
     });
+}
+
+- (void)setIconColor:(UIColor *)iconColor {
+    if(_iconColor != iconColor){
+        _iconColor = iconColor;
+        if(self.dialogController != nil) {
+            self.dialogController.iconDefinition = [[BPKDialogIconDefinition alloc]
+                                                    initWithIcon:[BPKIcon templateIconNamed:self.iconId size:BPKIconSizeLarge] iconBackgroundColor:iconColor
+                                                    ];
+        }
+    }
 }
 
 @end


### PR DESCRIPTION
We also need to upgrade `backpack-ios` to make this work.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [ ] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
