### PR TITLE
[BPK-3800] Upgrade most Storybook dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,6 +6,6 @@ update_configs:
     ignored_updates:
       - match:
           # TODO remove this.
-          # When these deps upgrade, addons stop working. We should fix this.
-          # See BPK-3800.
-          dependency_name: "@storybook/react-native*"
+          # 5.3.x of this dependency stops the addon panel from appearing.
+          # See https://github.com/storybookjs/react-native/issues/24
+          dependency_name: "@storybook/react-native-server"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3417,65 +3417,177 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-5.2.5.tgz",
-      "integrity": "sha512-81N+M1GX4XB7Mirhhu3kiZJkjspfk2e1ysoJtwULjWeZfo2CLYLUAil4onr08Os2LH4RLJaj2hpS3hLflBio4g==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-5.3.18.tgz",
+      "integrity": "sha512-jdBVCcfyWin274Lkwg5cL+1fJ651NCuIWxuJVsmHQtIl2xTjf2MyoMoKQZNdt4xtE+W9w+rS4bYt04elrizThg==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.2.5",
-        "@storybook/api": "5.2.5",
-        "@storybook/client-api": "5.2.5",
-        "@storybook/components": "5.2.5",
-        "@storybook/core-events": "5.2.5",
-        "@storybook/theming": "5.2.5",
+        "@storybook/addons": "5.3.18",
+        "@storybook/api": "5.3.18",
+        "@storybook/client-api": "5.3.18",
+        "@storybook/components": "5.3.18",
+        "@storybook/core-events": "5.3.18",
+        "@storybook/theming": "5.3.18",
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
         "polished": "^3.3.1",
         "prop-types": "^15.7.2",
         "react": "^16.8.3",
-        "react-inspector": "^3.0.2",
+        "react-inspector": "^4.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.18.tgz",
+          "integrity": "sha512-ZQjDgTUDFRLvAiBg2d8FgPgghfQ+9uFyXQbtiGlTBLinrPCeQd7J86qiUES0fcGoohCCw0wWKtvB0WF2z1XNDg==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.3.18",
+            "@storybook/channels": "5.3.18",
+            "@storybook/client-logger": "5.3.18",
+            "@storybook/core-events": "5.3.18",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.18.tgz",
+          "integrity": "sha512-QXaccNCARHzPWOuxYndiebGWBZmwiUvRgB9ji0XTJBS3y8K0ZPb5QyuqiKPaEWUj8dBA8rzdDtkW3Yt95Namaw==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/channels": "5.3.18",
+            "@storybook/client-logger": "5.3.18",
+            "@storybook/core-events": "5.3.18",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "5.3.18",
+            "@storybook/theming": "5.3.18",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.18.tgz",
+          "integrity": "sha512-scP/6td/BJSEOgfN+qaYGDf3E793xye7tIw6W+sYqwg+xdMFO39wVXgVZNpQL6sLEwpJZTaPywCjC6p6ksErqQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.18.tgz",
+          "integrity": "sha512-RZjxw4uqZX3Yk27IirbB/pQG+wRsQSSRlKqYa8KQ5bSanm4IrcV9VA1OQbuySW9njE+CexAnakQJ/fENdmurNg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.18.tgz",
+          "integrity": "sha512-uQ6NYJ5WODXK8DJ7m8y3yUAtWB3n+6XtYztjY+tdkCsLYvTYDXNS+epV+f5Hu9+gB+/Dm+b5Su4jDD+LZB2QWA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.18.tgz",
+          "integrity": "sha512-6B2U2C75KTSVaCuYYgcubeJGcCSnwsXuEf50hEd5mGqWgHZfojCtGvB7Ko4X+0h8rEC+eNA4p7YBOhlUv9WNrQ==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/csf": "0.0.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.18.tgz",
+          "integrity": "sha512-lfFTeLoYwLMKg96N3gn0umghMdAHgJBGuk2OM8Ll84yWtdl9RGnzfiI1Fl7Cr5k95dCF7drLJlJCao1VxUkFSA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.18",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          }
+        }
       }
     },
     "@storybook/addon-ondevice-actions": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-ondevice-actions/-/addon-ondevice-actions-5.2.5.tgz",
-      "integrity": "sha512-SYK9ZtlvmxBe9/uU2zzoUPjr+8FxAundhP+hnMQc9SAdkvL6XVcMcPE6CrZPXc2VMUyXqYrJGCjsXLr+gs9fsg==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-ondevice-actions/-/addon-ondevice-actions-5.3.18.tgz",
+      "integrity": "sha512-EWWtu9cV/l3uXrNkLUqmp2fd3+K6BsyVR0PxHy7hDddn+Zv8iS7QGwkmXUv84k4W5CTy12mGgTVV+ab6btmNGQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.2.5",
-        "@storybook/core-events": "5.2.5",
+        "@storybook/addons": "5.3.18",
+        "@storybook/core-events": "5.3.18",
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1"
       }
     },
     "@storybook/addons": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.5.tgz",
-      "integrity": "sha512-CvMj7Bs3go9tv5rZuAvFwuwe8p/16LDCHS7+5nVFosvcL8nuN339V3rzakw8nLy/S6XKeZ1ACu4t3vYkreRE3w==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.18.tgz",
+      "integrity": "sha512-ZQjDgTUDFRLvAiBg2d8FgPgghfQ+9uFyXQbtiGlTBLinrPCeQd7J86qiUES0fcGoohCCw0wWKtvB0WF2z1XNDg==",
       "dev": true,
       "requires": {
-        "@storybook/api": "5.2.5",
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/core-events": "5.2.5",
+        "@storybook/api": "5.3.18",
+        "@storybook/channels": "5.3.18",
+        "@storybook/client-logger": "5.3.18",
+        "@storybook/core-events": "5.3.18",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
         "util-deprecate": "^1.0.2"
       }
     },
     "@storybook/api": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.5.tgz",
-      "integrity": "sha512-JvLafqFVgA3dIWpLMoGNk4sRuogE5imhD6/g0d8DOwnCID9xowj5xIptSrCTKvGGGxuN3wWRGn6I2lEbY6969g==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.18.tgz",
+      "integrity": "sha512-QXaccNCARHzPWOuxYndiebGWBZmwiUvRgB9ji0XTJBS3y8K0ZPb5QyuqiKPaEWUj8dBA8rzdDtkW3Yt95Namaw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/core-events": "5.2.5",
-        "@storybook/router": "5.2.5",
-        "@storybook/theming": "5.2.5",
+        "@reach/router": "^1.2.1",
+        "@storybook/channels": "5.3.18",
+        "@storybook/client-logger": "5.3.18",
+        "@storybook/core-events": "5.3.18",
+        "@storybook/csf": "0.0.1",
+        "@storybook/router": "5.3.18",
+        "@storybook/theming": "5.3.18",
+        "@types/reach__router": "^1.2.3",
         "core-js": "^3.0.1",
         "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
@@ -3486,21 +3598,41 @@
         "semver": "^6.0.0",
         "shallow-equal": "^1.1.0",
         "store2": "^2.7.1",
-        "telejson": "^3.0.2",
+        "telejson": "^3.2.0",
         "util-deprecate": "^1.0.2"
       }
     },
     "@storybook/channel-postmessage": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.5.tgz",
-      "integrity": "sha512-GoiC6dUM3YfNKpvj3syxQIQJLHBnH61CfLJzz4xygmn+3keHtjtz6yPHaU4+00MSSP2uDzqePkjgXx4DcLedHA==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.18.tgz",
+      "integrity": "sha512-awxBW/aVfNtY9QvYZgsPaMXgUpC2+W3vEyQcl/w4ce0YVH+7yWx3wt3Ku49lQwxZwDrxP3QoC0U+mkPc9hBJwA==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
+        "@storybook/channels": "5.3.18",
+        "@storybook/client-logger": "5.3.18",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "telejson": "^3.0.2"
+        "telejson": "^3.2.0"
+      },
+      "dependencies": {
+        "@storybook/channels": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.18.tgz",
+          "integrity": "sha512-scP/6td/BJSEOgfN+qaYGDf3E793xye7tIw6W+sYqwg+xdMFO39wVXgVZNpQL6sLEwpJZTaPywCjC6p6ksErqQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.18.tgz",
+          "integrity": "sha512-RZjxw4uqZX3Yk27IirbB/pQG+wRsQSSRlKqYa8KQ5bSanm4IrcV9VA1OQbuySW9njE+CexAnakQJ/fENdmurNg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        }
       }
     },
     "@storybook/channel-websocket": {
@@ -3527,27 +3659,27 @@
       }
     },
     "@storybook/channels": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.5.tgz",
-      "integrity": "sha512-I+zB3ym5ozBcNBqyzZbvB6gRIG/ZKKkqy5k6LwKd5NMx7NU7zU74+LQUBBOcSIrigj8kCArZz7rlgb0tlSKXxQ==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.18.tgz",
+      "integrity": "sha512-scP/6td/BJSEOgfN+qaYGDf3E793xye7tIw6W+sYqwg+xdMFO39wVXgVZNpQL6sLEwpJZTaPywCjC6p6ksErqQ==",
       "dev": true,
       "requires": {
         "core-js": "^3.0.1"
       }
     },
     "@storybook/client-api": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.5.tgz",
-      "integrity": "sha512-n7CAZ3+DZ7EUdmXbq8mXRb+stOavC8GMw3CzjGSo8O6t4rFcMpZQAzjS0YRX1RG/CGFSv9d3R3TNvEBcBGTwRg==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.18.tgz",
+      "integrity": "sha512-QiXTDUpjdyW19BlocLw07DrkOnEzVaWGJcRze2nSs29IKKuq1Ncv2LOAZt6ySSq0PmIKsjBou3bmS1/aXmDMdw==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.2.5",
-        "@storybook/channel-postmessage": "5.2.5",
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/core-events": "5.2.5",
-        "@storybook/router": "5.2.5",
-        "common-tags": "^1.8.0",
+        "@storybook/addons": "5.3.18",
+        "@storybook/channel-postmessage": "5.3.18",
+        "@storybook/channels": "5.3.18",
+        "@storybook/client-logger": "5.3.18",
+        "@storybook/core-events": "5.3.18",
+        "@storybook/csf": "0.0.1",
+        "@types/webpack-env": "^1.15.0",
         "core-js": "^3.0.1",
         "eventemitter3": "^4.0.0",
         "global": "^4.3.2",
@@ -3555,9 +3687,118 @@
         "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
+        "stable": "^0.1.8",
+        "ts-dedent": "^1.1.0",
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
+        "@storybook/addons": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.18.tgz",
+          "integrity": "sha512-ZQjDgTUDFRLvAiBg2d8FgPgghfQ+9uFyXQbtiGlTBLinrPCeQd7J86qiUES0fcGoohCCw0wWKtvB0WF2z1XNDg==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.3.18",
+            "@storybook/channels": "5.3.18",
+            "@storybook/client-logger": "5.3.18",
+            "@storybook/core-events": "5.3.18",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.18.tgz",
+          "integrity": "sha512-QXaccNCARHzPWOuxYndiebGWBZmwiUvRgB9ji0XTJBS3y8K0ZPb5QyuqiKPaEWUj8dBA8rzdDtkW3Yt95Namaw==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/channels": "5.3.18",
+            "@storybook/client-logger": "5.3.18",
+            "@storybook/core-events": "5.3.18",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "5.3.18",
+            "@storybook/theming": "5.3.18",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.18.tgz",
+          "integrity": "sha512-scP/6td/BJSEOgfN+qaYGDf3E793xye7tIw6W+sYqwg+xdMFO39wVXgVZNpQL6sLEwpJZTaPywCjC6p6ksErqQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.18.tgz",
+          "integrity": "sha512-RZjxw4uqZX3Yk27IirbB/pQG+wRsQSSRlKqYa8KQ5bSanm4IrcV9VA1OQbuySW9njE+CexAnakQJ/fENdmurNg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.18.tgz",
+          "integrity": "sha512-uQ6NYJ5WODXK8DJ7m8y3yUAtWB3n+6XtYztjY+tdkCsLYvTYDXNS+epV+f5Hu9+gB+/Dm+b5Su4jDD+LZB2QWA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.18.tgz",
+          "integrity": "sha512-6B2U2C75KTSVaCuYYgcubeJGcCSnwsXuEf50hEd5mGqWgHZfojCtGvB7Ko4X+0h8rEC+eNA4p7YBOhlUv9WNrQ==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/csf": "0.0.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.18.tgz",
+          "integrity": "sha512-lfFTeLoYwLMKg96N3gn0umghMdAHgJBGuk2OM8Ll84yWtdl9RGnzfiI1Fl7Cr5k95dCF7drLJlJCao1VxUkFSA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.18",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          }
+        },
         "is-plain-object": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
@@ -3576,26 +3817,27 @@
       }
     },
     "@storybook/client-logger": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.5.tgz",
-      "integrity": "sha512-6DyYUrMgAvF+th0foH7UNz+2JJpRdvNbpvYKtvi/+hlvRIaI6AqANgLkPUgMibaif5TLzjCr0bLdAYcjeJz03w==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.18.tgz",
+      "integrity": "sha512-RZjxw4uqZX3Yk27IirbB/pQG+wRsQSSRlKqYa8KQ5bSanm4IrcV9VA1OQbuySW9njE+CexAnakQJ/fENdmurNg==",
       "dev": true,
       "requires": {
         "core-js": "^3.0.1"
       }
     },
     "@storybook/components": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.5.tgz",
-      "integrity": "sha512-6NVaBJm5wY53e9k+2ZiL2ABsHghE1ssQciLTG3jJPahnM6rfkM8ue66rhxhP88jE9isT48JgOZOJepEyxDz/fg==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.18.tgz",
+      "integrity": "sha512-LIN4aVCCDY7klOwtuqQhfYz4tHaMADhXEzZpij+3r8N68Inck6IJ1oo9A9umXQPsTioQi8e6FLobH1im90j/2A==",
       "dev": true,
       "requires": {
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/theming": "5.2.5",
-        "@types/react-syntax-highlighter": "10.1.0",
+        "@storybook/client-logger": "5.3.18",
+        "@storybook/theming": "5.3.18",
+        "@types/react-syntax-highlighter": "11.0.4",
         "@types/react-textarea-autosize": "^4.3.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
+        "lodash": "^4.17.15",
         "markdown-to-jsx": "^6.9.1",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
@@ -3603,12 +3845,96 @@
         "prop-types": "^15.7.2",
         "react": "^16.8.3",
         "react-dom": "^16.8.3",
-        "react-focus-lock": "^1.18.3",
+        "react-focus-lock": "^2.1.0",
         "react-helmet-async": "^1.0.2",
         "react-popper-tooltip": "^2.8.3",
-        "react-syntax-highlighter": "^8.0.1",
+        "react-syntax-highlighter": "^11.0.2",
         "react-textarea-autosize": "^7.1.0",
-        "simplebar-react": "^1.0.0-alpha.6"
+        "simplebar-react": "^1.0.0-alpha.6",
+        "ts-dedent": "^1.1.0"
+      },
+      "dependencies": {
+        "@storybook/client-logger": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.18.tgz",
+          "integrity": "sha512-RZjxw4uqZX3Yk27IirbB/pQG+wRsQSSRlKqYa8KQ5bSanm4IrcV9VA1OQbuySW9njE+CexAnakQJ/fENdmurNg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.18.tgz",
+          "integrity": "sha512-lfFTeLoYwLMKg96N3gn0umghMdAHgJBGuk2OM8Ll84yWtdl9RGnzfiI1Fl7Cr5k95dCF7drLJlJCao1VxUkFSA==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.18",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "@types/react-syntax-highlighter": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
+          "integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
+          "dev": true,
+          "requires": {
+            "@types/react": "*"
+          }
+        },
+        "highlight.js": {
+          "version": "9.13.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+          "dev": true
+        },
+        "lowlight": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
+          "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+          "dev": true,
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.13.0"
+          }
+        },
+        "react-focus-lock": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
+          "integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "focus-lock": "^0.6.6",
+            "prop-types": "^15.6.2",
+            "react-clientside-effect": "^1.2.2",
+            "use-callback-ref": "^1.2.1",
+            "use-sidecar": "^1.0.1"
+          }
+        },
+        "react-syntax-highlighter": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
+          "integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "~9.13.0",
+            "lowlight": "~1.11.0",
+            "prismjs": "^1.8.4",
+            "refractor": "^2.4.1"
+          }
+        }
       }
     },
     "@storybook/core": {
@@ -3982,12 +4308,21 @@
       }
     },
     "@storybook/core-events": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.5.tgz",
-      "integrity": "sha512-O5GM8XEBbYNbM6Z7a4H1bbnbO2cxQrXMhEwansC7a7YinQdkTPiuGxke3NiyK+7pLDh778kpQyjoCjXq6UfAoQ==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.18.tgz",
+      "integrity": "sha512-uQ6NYJ5WODXK8DJ7m8y3yUAtWB3n+6XtYztjY+tdkCsLYvTYDXNS+epV+f5Hu9+gB+/Dm+b5Su4jDD+LZB2QWA==",
       "dev": true,
       "requires": {
         "core-js": "^3.0.1"
+      }
+    },
+    "@storybook/csf": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "@storybook/node-logger": {
@@ -4012,177 +4347,34 @@
       }
     },
     "@storybook/react-native": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-5.2.8.tgz",
-      "integrity": "sha512-uRbetQcC/42843+4XZMiBrLnWqFDS7Tqy5svyX1qMyoexYTQ6Pz9wLT3YhctAu2oK8Gfdiay1Tpg/OTrene1Sg==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-5.3.18.tgz",
+      "integrity": "sha512-pJBtVLnzLDjYHuPjsTN99BfwruYYq1B9bGSMWfGwLjWL9i+vreg0ek+y76ua+w98GZldkq8u2HI+UZ26s7nu+w==",
       "dev": true,
       "requires": {
-        "@emotion/core": "^10.0.14",
+        "@emotion/core": "^10.0.20",
         "@emotion/native": "^10.0.14",
-        "@storybook/addons": "5.2.8",
-        "@storybook/channel-websocket": "5.2.8",
-        "@storybook/channels": "5.2.8",
-        "@storybook/client-api": "5.2.8",
-        "@storybook/core-events": "5.2.8",
+        "@storybook/addons": "5.3.18",
+        "@storybook/channel-websocket": "5.3.18",
+        "@storybook/channels": "5.3.18",
+        "@storybook/client-api": "5.3.18",
+        "@storybook/core-events": "5.3.18",
         "core-js": "^3.0.1",
-        "emotion-theming": "^10.0.14",
-        "react-native-swipe-gestures": "^1.0.3",
-        "rn-host-detect": "^1.1.5"
+        "emotion-theming": "^10.0.19",
+        "react-native-swipe-gestures": "^1.0.4"
       },
       "dependencies": {
-        "@storybook/addons": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.8.tgz",
-          "integrity": "sha512-yAo1N5z/45bNIQP8SD+HVTr7X898bYAtz1EZBrQ6zD8bGamzA2Br06rOLL9xXw29eQhsaVnPlqgDwCS1sTC7aQ==",
+        "@storybook/channel-websocket": {
+          "version": "5.3.18",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-5.3.18.tgz",
+          "integrity": "sha512-I/j1tT3ZVzroL9JGWXhqID5DrHgWDVw1YERUu+PSI6ojPpj1TPjn1/YJEItzCrHEOS5ec1zreHr/OZum+0hhtg==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.2.8",
-            "@storybook/channels": "5.2.8",
-            "@storybook/client-logger": "5.2.8",
-            "@storybook/core-events": "5.2.8",
+            "@storybook/channels": "5.3.18",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "util-deprecate": "^1.0.2"
+            "telejson": "^3.2.0"
           }
-        },
-        "@storybook/api": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.8.tgz",
-          "integrity": "sha512-rFrPtTFDIPQoicLwq1AVsOvZNTUKnjD1w/NX1kKcyuWLL9BcOkU3YNLBlliGBg2JX/yS+fJKMyKk4NMzNBCZCg==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "5.2.8",
-            "@storybook/client-logger": "5.2.8",
-            "@storybook/core-events": "5.2.8",
-            "@storybook/router": "5.2.8",
-            "@storybook/theming": "5.2.8",
-            "core-js": "^3.0.1",
-            "fast-deep-equal": "^2.0.1",
-            "global": "^4.3.2",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "prop-types": "^15.6.2",
-            "react": "^16.8.3",
-            "semver": "^6.0.0",
-            "shallow-equal": "^1.1.0",
-            "store2": "^2.7.1",
-            "telejson": "^3.0.2",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/channel-postmessage": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.8.tgz",
-          "integrity": "sha512-RS3iDW1kpfODN+kBq3youn+KtLqHslZ4m7mTlOL80BUHKb4YkrA1lVkzpy1kVMWBU523pyDVQUVXr+M8y3iVug==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "5.2.8",
-            "@storybook/client-logger": "5.2.8",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "telejson": "^3.0.2"
-          }
-        },
-        "@storybook/channels": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.8.tgz",
-          "integrity": "sha512-mFwQec27QSrqcl+IH0xA+4jfoEqC4m1G99LBHt/aTDjLZXclX1A470WqeZCp7Gx4OALpaPEVTaaaKPbiKz4C6w==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/client-api": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.8.tgz",
-          "integrity": "sha512-OCKhZ+2sS3ot0ZV48nD79BWVzvvdMjUFYl0073ps5q+1+TLic1AlNmH0Sb5/9NrYXNV86v3VrM2jUbGsKe1qyw==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "5.2.8",
-            "@storybook/channel-postmessage": "5.2.8",
-            "@storybook/channels": "5.2.8",
-            "@storybook/client-logger": "5.2.8",
-            "@storybook/core-events": "5.2.8",
-            "@storybook/router": "5.2.8",
-            "common-tags": "^1.8.0",
-            "core-js": "^3.0.1",
-            "eventemitter3": "^4.0.0",
-            "global": "^4.3.2",
-            "is-plain-object": "^3.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "stable": "^0.1.8",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/client-logger": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.8.tgz",
-          "integrity": "sha512-+oVSEJdeh7TQ1Bhanb3mCr7fc3Bug3+K79abZ28J45Ub5x4L/ZVClj1xMgUsJs30BZ5FB8vhdgH6TQb0NSxR4A==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/core-events": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.8.tgz",
-          "integrity": "sha512-NkQKC5doO/YL9gsO61bqaxgveKktkiJWZ3XyyhL1ZebgnO9wTlrU+i9b5aX73Myk1oxbicQw9KcwDGYk0qFuNQ==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/router": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.8.tgz",
-          "integrity": "sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==",
-          "dev": true,
-          "requires": {
-            "@reach/router": "^1.2.1",
-            "@types/reach__router": "^1.2.3",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.6.0"
-          }
-        },
-        "@storybook/theming": {
-          "version": "5.2.8",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.8.tgz",
-          "integrity": "sha512-rGb66GkXb0jNJMH8UQ3Ru4FL+m1x0+UdxM8a8HSE/qb1GMv2qOwjVETfAL6nVL9u6ZmrtbhHoero4f6xDwZdRg==",
-          "dev": true,
-          "requires": {
-            "@emotion/core": "^10.0.14",
-            "@emotion/styled": "^10.0.14",
-            "@storybook/client-logger": "5.2.8",
-            "common-tags": "^1.8.0",
-            "core-js": "^3.0.1",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.14",
-            "global": "^4.3.2",
-            "memoizerific": "^1.11.3",
-            "polished": "^3.3.1",
-            "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0"
-          }
-        },
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-          "dev": true
         }
       }
     },
@@ -4322,38 +4514,40 @@
       }
     },
     "@storybook/router": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.5.tgz",
-      "integrity": "sha512-e6ElDAWSoEW1KSnsTbVwbpzaZ8CNWYw0Ok3b5AHfY2fuSH5L4l6s6k/bP7QSYqvWUeTvkFQYux7A2rOFCriAgA==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.18.tgz",
+      "integrity": "sha512-6B2U2C75KTSVaCuYYgcubeJGcCSnwsXuEf50hEd5mGqWgHZfojCtGvB7Ko4X+0h8rEC+eNA4p7YBOhlUv9WNrQ==",
       "dev": true,
       "requires": {
         "@reach/router": "^1.2.1",
+        "@storybook/csf": "0.0.1",
         "@types/reach__router": "^1.2.3",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
         "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
-        "qs": "^6.6.0"
+        "qs": "^6.6.0",
+        "util-deprecate": "^1.0.2"
       }
     },
     "@storybook/theming": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.5.tgz",
-      "integrity": "sha512-PGZNYrRgAhXFJKnktFpyyKlaDXEhtTi5XPq5ASVJrsPW6l963Mk2EMKSm4TCTxIJhs0Kx4cv2MnNZFDqHf47eg==",
+      "version": "5.3.18",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.18.tgz",
+      "integrity": "sha512-lfFTeLoYwLMKg96N3gn0umghMdAHgJBGuk2OM8Ll84yWtdl9RGnzfiI1Fl7Cr5k95dCF7drLJlJCao1VxUkFSA==",
       "dev": true,
       "requires": {
-        "@emotion/core": "^10.0.14",
-        "@emotion/styled": "^10.0.14",
-        "@storybook/client-logger": "5.2.5",
-        "common-tags": "^1.8.0",
+        "@emotion/core": "^10.0.20",
+        "@emotion/styled": "^10.0.17",
+        "@storybook/client-logger": "5.3.18",
         "core-js": "^3.0.1",
         "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.14",
+        "emotion-theming": "^10.0.19",
         "global": "^4.3.2",
         "memoizerific": "^1.11.3",
         "polished": "^3.3.1",
         "prop-types": "^15.7.2",
-        "resolve-from": "^5.0.0"
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^1.1.0"
       }
     },
     "@storybook/ui": {
@@ -4669,9 +4863,9 @@
       }
     },
     "@types/react-native": {
-      "version": "0.61.17",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.61.17.tgz",
-      "integrity": "sha512-12qKZz/ob56lglVRAIDgqDchcyO0g5lZtrjxCTQDNJv8HFHZMcZx78+/CjKsu3LGs6KbajkZ1+0htqiaxr5JVA==",
+      "version": "0.62.2",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.2.tgz",
+      "integrity": "sha512-oIUIbqZNN9vRnGKWHYbTVp/GyTqdaM5mfy1s4zsi6BYvHAaFOPZ32IrhIHno/A5XOv4wuGfE7g5fliDk/H0+/Q==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -4714,9 +4908,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
-      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
+      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -4757,6 +4951,12 @@
           "dev": true
         }
       }
+    },
+    "@types/webpack-env": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.1.tgz",
+      "integrity": "sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA==",
+      "dev": true
     },
     "@types/webpack-sources": {
       "version": "0.1.7",
@@ -5624,13 +5824,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.5.tgz",
-      "integrity": "sha512-URo6Zvt7VYifomeAfJlMFnYDhow1rk2bufwkbamPEAtQFcL11moLk4PnR7n9vlu7M+BkXAZkHFA0mIcY7tjQFg==",
+      "version": "9.7.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.6.tgz",
+      "integrity": "sha512-F7cYpbN7uVVhACZTeeIeealwdGM6wMtfWARVLTy5xmKtgVdBNJvbDRoCK3YO1orcs7gv/KwYlb3iXwu9Ug9BkQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.11.0",
-        "caniuse-lite": "^1.0.30001036",
+        "browserslist": "^4.11.1",
+        "caniuse-lite": "^1.0.30001039",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
@@ -5651,15 +5851,15 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001038",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
-          "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ==",
+          "version": "1.0.30001039",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
+          "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.391",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.391.tgz",
-          "integrity": "sha512-WOi6loSnDmfICOqGRrgeK7bZeWDAbGjCptDhI5eyJAqSzWfoeRuOOU1rOTZRL29/9AaxTndZB6Uh8YrxRfZJqw==",
+          "version": "1.3.398",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.398.tgz",
+          "integrity": "sha512-BJjxuWLKFbM5axH3vES7HKMQgAknq9PZHBkMK/rEXUQG9i1Iw5R+6hGkm6GtsQSANjSUrh/a6m32nzCNDNo/+w==",
           "dev": true
         },
         "node-releases": {
@@ -6518,15 +6718,15 @@
       }
     },
     "bpk-svgs": {
-      "version": "8.2.31",
-      "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-8.2.31.tgz",
-      "integrity": "sha512-Io5NiAldrvJ6EoQOGHvu7xxdjG96MDw8YBueARoNNatwPtghdmPCpJ3HCLd0/3psiHXIyVtGpXp9UN0279+dPg==",
+      "version": "8.2.36",
+      "resolved": "https://registry.npmjs.org/bpk-svgs/-/bpk-svgs-8.2.36.tgz",
+      "integrity": "sha512-dwtZlL+nj77chBgj3nRGREeUDW1rhl650Bcpuy4KBC8uHHr5TCzltIRkhVrY2bXKUzIEg2HT12CGHIao+6QPWQ==",
       "dev": true
     },
     "bpk-tokens": {
-      "version": "32.0.1",
-      "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-32.0.1.tgz",
-      "integrity": "sha512-aUzCC+SlHys9ug1Pj9hHy1yAAAoAufMJc/hVSRZuAUrxiDHnkr9pyKC9Nz/P9BMk1GullWWx0+SmQ3aeAHSJ4Q==",
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/bpk-tokens/-/bpk-tokens-32.0.2.tgz",
+      "integrity": "sha512-rHWdYs6/g1FEHF19i9HxlTv/5sg/xdUZlLGPcgzZSH2KbAcddOjlWlluKQUw+otWGZQu2YspCZPEident5Em8A==",
       "dev": true,
       "requires": {
         "color": "^3.0.0"
@@ -7774,9 +7974,9 @@
       "dev": true
     },
     "css-loader": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.4.2.tgz",
-      "integrity": "sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.5.1.tgz",
+      "integrity": "sha512-0G4CbcZzQ9D1Q6ndOfjFuMDo8uLYMu5vc9Abs5ztyHcKvmil6GJrMiNjzzi3tQvUF+mVRuDg7bE6Oc0Prolgig==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
@@ -7784,13 +7984,14 @@
         "icss-utils": "^4.1.1",
         "loader-utils": "^1.2.3",
         "normalize-path": "^3.0.0",
-        "postcss": "^7.0.23",
+        "postcss": "^7.0.27",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
-        "postcss-modules-scope": "^2.1.1",
+        "postcss-modules-scope": "^2.2.0",
         "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.0.2",
-        "schema-utils": "^2.6.0"
+        "postcss-value-parser": "^4.0.3",
+        "schema-utils": "^2.6.5",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -8219,6 +8420,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
     "detect-port": {
@@ -12440,9 +12647,9 @@
       "dev": true
     },
     "html-webpack-plugin": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.3.tgz",
-      "integrity": "sha512-XCm5MGK6Yv/ey30fbhqjKIGm1r6G1HxmNorJ/xUdL/Zj3mOLtb9ZHEEIw0e4h3VzgyUrp8szCJh3VN9z1LNx7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.4.tgz",
+      "integrity": "sha512-BREQzUbFfIQS39KqxkT2L1Ot0tuu1isako1CaCQLrgEQ43zi2ScHAe3SMTnVBWsStnIsGtl8jprDdxwZkNhrwQ==",
       "dev": true,
       "requires": {
         "@types/html-minifier-terser": "^5.0.0",
@@ -23097,12 +23304,12 @@
       }
     },
     "react-inspector": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-3.0.2.tgz",
-      "integrity": "sha512-PSR8xDoGFN8R3LKmq1NT+hBBwhxjd9Qwz8yKY+5NXY/CHpxXHm01CVabxzI7zFwFav/M3JoC/Z0Ro2kSX6Ef2Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.1.tgz",
+      "integrity": "sha512-xSiM6CE79JBqSj8Fzd9dWBHv57tLTH7OM57GP3VrE5crzVF3D5Khce9w1Xcw75OAbvrA0Mi2vBneR1OajKmXFg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.6.3",
         "is-dom": "^1.0.9",
         "prop-types": "^15.6.1"
       }
@@ -24333,12 +24540,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
-    },
-    "rn-host-detect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.2.0.tgz",
-      "integrity": "sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A==",
-      "dev": true
     },
     "rsvp": {
       "version": "4.8.5",
@@ -25704,9 +25905,9 @@
       }
     },
     "terser": {
-      "version": "4.6.10",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.10.tgz",
-      "integrity": "sha512-qbF/3UOo11Hggsbsqm2hPa6+L4w7bkr+09FNseEe8xrcVD3APGLFqE+Oz1ZKAxjYnFsj80rLOfgAtJ0LNJjtTA==",
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
+      "integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -26082,6 +26283,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
+    },
+    "ts-dedent": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
+      "integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==",
       "dev": true
     },
     "ts-object-utils": {
@@ -26568,6 +26775,22 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-callback-ref": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
+      "integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==",
+      "dev": true
+    },
+    "use-sidecar": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
+      "integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
+      "dev": true,
+      "requires": {
+        "detect-node": "^2.0.4",
+        "tslib": "^1.9.3"
+      }
+    },
     "util": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
@@ -27015,9 +27238,9 @@
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
     ]
   },
   "devDependencies": {
-    "@storybook/addon-actions": "5.2.5",
-    "@storybook/addon-ondevice-actions": "5.2.5",
-    "@storybook/react-native": "5.2.8",
+    "@storybook/addon-actions": "^5.3.18",
+    "@storybook/addon-ondevice-actions": "^5.3.18",
+    "@storybook/react-native": "^5.3.18",
     "@storybook/react-native-server": "5.2.8",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",

--- a/storybook/storybook.js
+++ b/storybook/storybook.js
@@ -19,7 +19,7 @@
 /* @flow */
 import React, { type Node } from 'react';
 import addon from '@storybook/addons';
-import { I18nManager, YellowBox, View } from 'react-native';
+import { I18nManager, View } from 'react-native';
 import { getStorybookUI, configure } from '@storybook/react-native';
 import { backgroundColor } from 'bpk-tokens/tokens/base.react.native';
 
@@ -59,12 +59,6 @@ const initRtlAddon = channel => {
 const initDarkModeAddon = channel => {
   channel.emit(DM_INIT, BpkAppearance.get().colorScheme || 'light');
   channel.on(DM_EVENT, colorScheme => BpkAppearance.set({ colorScheme }));
-};
-
-const hideWarnings = () => {
-  // TODO: this warning is being trigger by an internal react code, we can remove it when it gets fixed
-  // see: https://github.com/facebook/react-native/issues/18868#issuecomment-382671739
-  YellowBox.ignoreWarnings(['Warning: isMounted(...) is deprecated']);
 };
 
 /* eslint-disable global-require */
@@ -109,9 +103,12 @@ configure(() => {
 }, module);
 /* eslint-enable global-require */
 
-const StorybookUI = getStorybookUI({ onDeviceUI: false });
+const StorybookUI = getStorybookUI({
+  onDeviceUI: false,
+  asyncStorage: null,
+});
 
-onChannelAvailable(hideWarnings, initRtlAddon, initDarkModeAddon);
+onChannelAvailable(initRtlAddon, initDarkModeAddon);
 
 const BackgroundWrapper = ({ children }: { children: Node }) => (
   <View


### PR DESCRIPTION
[This issue](https://github.com/storybookjs/react-native/issues/24) is preventing us from upgrading `react-native-server` but I was able to upgrade the rest. I'm now watching that issue so can try upgrading once it's resolved.