### PR TITLE
[BPK-3842] Fix a bug where changing the 'mask' prop didn't work

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,11 @@
 - bpk-component-chip
   - New `leadingAccessoryView` prop to allow for icons to be added to the BpkChip.
 
+**Fixed:**
+
+- bpk-component-text-input:
+  - Fixed an issue where updating `props.mask` had no effect.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/lib/bpk-component-text-input/src/BpkTextInput.js
+++ b/lib/bpk-component-text-input/src/BpkTextInput.js
@@ -23,6 +23,7 @@ import React, { Component, type Node, type Config } from 'react';
 import { Animated, TextInput, View, ViewPropTypes } from 'react-native';
 import AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 import { animationDurationSm } from 'bpk-tokens/tokens/base.react.native';
+import memoize from 'lodash/memoize';
 import TinyMask from 'tinymask';
 
 import { getThemeAttributes, withTheme, type Theme } from '../../bpk-theming';
@@ -124,10 +125,10 @@ type State = {
 
 type EnhancedProps = Props & WithBpkAppearanceInjectedProps;
 
+const createTinyMask = memoize(mask => new TinyMask(mask || ''));
+
 class BpkTextInput extends Component<EnhancedProps, State> {
   animatedValues: { color: AnimatedValue, labelPosition: AnimatedValue };
-
-  tinymask: TinyMask;
 
   static propTypes = { ...propTypes };
 
@@ -144,8 +145,6 @@ class BpkTextInput extends Component<EnhancedProps, State> {
       color: new Animated.Value(this.getColorAnimatedValue()),
       labelPosition: new Animated.Value(this.getLabelPositionAnimatedValue()),
     };
-
-    this.tinymask = new TinyMask(props.mask || '');
   }
 
   componentDidUpdate() {
@@ -226,6 +225,8 @@ class BpkTextInput extends Component<EnhancedProps, State> {
     const placeholderValue = this.getPlaceholderValue();
     const placeholderColor = getPlaceholderColor(bpkAppearance);
 
+    const tinymask = createTinyMask(mask);
+
     const validityIcon = valid ? (
       <ValidIcon />
     ) : (
@@ -298,7 +299,7 @@ class BpkTextInput extends Component<EnhancedProps, State> {
           <Animated.View style={animatedInputStyle}>
             <TextInput
               editable={editable}
-              value={formatValue(value, mask, this.tinymask)}
+              value={formatValue(value, mask, tinymask)}
               style={inputTextStyle}
               onFocus={this.onFocus}
               onBlur={this.onBlur}


### PR DESCRIPTION
Pretty straightforward fix. `tinymask` was only being created once, so rerenders triggered by React when props changed had no effect. This moves it to the render function and uses lodash's memoize (thanks @tiagoengel!) for efficiency.

I tested this locally in Storybook but I didn't add an example or test for it, as this is standard functionality that shouldn't regress in future (feel free to disagree, maybe I'm wrong)