### PR TITLE
[BPK-3855] Add descriptionOnly prop to highlightedDaysFooterView

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,12 @@
 
 > Place your changes below this line.
 
+**Added:**
+
+- `bpk-component-calendar`:
+  - Added new `descriptionOnly` prop to `highlightedDaysFooterView`.
+  - Upgraded `backpack-android` to `23.2.0`.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 
 ext {
   internalBuild       = project.hasProperty("internalBuild") && project.internalBuild
-  backpackVersion     = "23.1.1${ext.internalBuild || isUseRelative() ? '-internal' : ''}"
+  backpackVersion     = "23.2.0${ext.internalBuild || isUseRelative() ? '-internal' : ''}"
   compileSdkVersion   = 29
   targetSdkVersion    = 29
   minSdkVersion       = 21

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -22,7 +22,7 @@ def getPackageJson(project) {
 }
 
 def _reactNativeVersion = safeExtGet("reactNative", "+")
-def _backpackAndroidVersion = safeExtGet("backpackVersion", "23.1.1")
+def _backpackAndroidVersion = safeExtGet("backpackVersion", "23.2.0")
 def _compileSdkVersion = safeExtGet("compileSdkVersion", 28)
 def _targetSdkVersion = safeExtGet("targetSdkVersion", 28)
 def _minSdkVersion = safeExtGet("minSdkVersion", 21)

--- a/lib/android/src/main/java/net/skyscanner/backpack/reactnative/calendar/RNFooterView.kt
+++ b/lib/android/src/main/java/net/skyscanner/backpack/reactnative/calendar/RNFooterView.kt
@@ -66,11 +66,13 @@ internal data class RNHighlightedDaysFooterView(
         val cellStyle = day.getOptional("cellStyle") { map, key ->
           map.getString(key)?.let(TypeConversions::stringToCellStyle)
         }
+        val descriptionOnly = day.getOptional("descriptionOnly", ReadableMap::getBoolean)
 
         HighlightedDaysAdapter.HighlightedDay(
           date = date,
           description = description,
-          color = cellStyle?.color(context) ?: color
+          color = cellStyle?.color(context) ?: color,
+          descriptionOnly = descriptionOnly ?: false
         )
       }.toSet())
     }

--- a/lib/bpk-component-calendar/src/footerView-test.common.js
+++ b/lib/bpk-component-calendar/src/footerView-test.common.js
@@ -36,6 +36,7 @@ const commonTests = () => {
               description: 'test day',
               color: colorSagano,
               cellStyle: 'positive',
+              descriptionOnly: true,
             },
           ],
         });
@@ -48,6 +49,7 @@ const commonTests = () => {
               description: 'test day',
               color: processColor(colorSagano),
               cellStyle: 'positive',
+              descriptionOnly: true,
             },
           ],
         });

--- a/lib/bpk-component-calendar/src/footerView.js
+++ b/lib/bpk-component-calendar/src/footerView.js
@@ -41,6 +41,14 @@ export type HighlightedDay = {
    * @ignore
    */
   cellStyle?: CellStyle,
+  /**
+   * Optionally set this highlight to show only the description provided and
+   * not the date.
+   *
+   * @see description
+   * @ignore
+   */
+  descriptionOnly?: boolean,
 };
 
 type NativeHighlightedDay = {

--- a/lib/bpk-component-calendar/stories.js
+++ b/lib/bpk-component-calendar/stories.js
@@ -487,6 +487,7 @@ storiesOf('bpk-component-calendar', module)
             date: Date.UTC(today.getFullYear(), 0, 13),
             description: 'A day to forget',
             cellStyle: 'negative',
+            descriptionOnly: true,
           },
         ],
       })}


### PR DESCRIPTION

![Screenshot_1587474123](https://user-images.githubusercontent.com/1457263/79869568-760e1e00-83d9-11ea-89bd-a5fd5e976b88.png)

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
