### PR TITLE
Add missing dependencies

### DIFF
--- a/lib/ios/BackpackReactNative/BackpackReactNative.podspec
+++ b/lib/ios/BackpackReactNative/BackpackReactNative.podspec
@@ -16,5 +16,7 @@ Pod::Spec.new do |s|
   s.source_files  = "Classes/**/*.{h,m}"
 
   s.dependency 'React'
+  s.dependency 'react-native-maps'
+  s.dependency 'ReactNativeDarkMode'
   s.dependency 'Backpack', '~> 34.0'
 end


### PR DESCRIPTION
Both `react-native-maps` and `ReactNativeDarkMode` are specified in the sample app `Podfile` but not in the actual module `.podspec`.
Without these, the RN code would throw runtime exceptions. Given these dependencies are indeed required by `BackpackReactNative`, they should be explicitly marked as so in the podspec.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
