### PR TITLE
[BPK-4165] Allow banner-alert to accept node or string for message

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+ - `bpk-banner-alert` can now accept either string or Node for its message prop.
 
 ## How to write a good changelog entry
 

--- a/lib/bpk-component-banner-alert/README.md
+++ b/lib/bpk-component-banner-alert/README.md
@@ -34,16 +34,15 @@ export default class App extends Component {
       showDismissable: true,
       expanded: false,
     };
-
   }
 
   onDismiss = () => {
     this.setState({ showDismissable: false });
-  }
+  };
 
   onExpandablePress = () => {
     this.setState({ expanded: !this.state.expanded });
-  }
+  };
 
   render() {
     return (
@@ -71,9 +70,11 @@ export default class App extends Component {
           expanded={this.state.expanded}
         >
           <BpkText textStyle="sm">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sagittis sagittis purus, id blandit ipsum.
-            Pellentesque nec diam nec erat condimentum dapibus. Nunc diam augue, egestas id egestas ut, facilisis nec mi.
-            Donec et congue odio, nec laoreet est. Integer rhoncus varius arcu, a fringilla libero laoreet at.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+            sagittis sagittis purus, id blandit ipsum. Pellentesque nec diam nec
+            erat condimentum dapibus. Nunc diam augue, egestas id egestas ut,
+            facilisis nec mi. Donec et congue odio, nec laoreet est. Integer
+            rhoncus varius arcu, a fringilla libero laoreet at.
           </BpkText>
         </BpkBannerAlert>
       </View>
@@ -86,7 +87,7 @@ export default class App extends Component {
 
 | Property                  | PropType           | Required | Default Value |
 | ------------------------- | ------------------ | -------- | ------------- |
-| message                   | string             | true     | -             |
+| message                   | string or Node     | true     | -             |
 | type                      | oneOf(ALERT_TYPES) | true     | -             |
 | animateOnEnter            | bool               | false    | false         |
 | animateOnLeave            | bool               | false    | false         |

--- a/lib/bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
+++ b/lib/bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
@@ -66,7 +66,7 @@ const commonTests = () => {
       it('should render correctly with Node message', () => {
         const tree = renderer
           .create(
-            <BpkBannerAlertWithColorScheme
+            <BpkBannerAlert
               type={ALERT_TYPES.neutral}
               message={
                 <>
@@ -77,9 +77,6 @@ const commonTests = () => {
                   .
                 </>
               }
-              dismissable
-              dismissButtonLabel="Dismiss"
-              onDismiss={() => null}
             />,
           )
           .toJSON();

--- a/lib/bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
+++ b/lib/bpk-component-banner-alert/src/BpkBannerAlert-test.common.js
@@ -63,6 +63,29 @@ const commonTests = () => {
         expect(tree).toMatchSnapshot();
       });
 
+      it('should render correctly with Node message', () => {
+        const tree = renderer
+          .create(
+            <BpkBannerAlertWithColorScheme
+              type={ALERT_TYPES.neutral}
+              message={
+                <>
+                  Neutral{' '}
+                  <BpkText textStyle="sm" weight="emphasized">
+                    alert
+                  </BpkText>
+                  .
+                </>
+              }
+              dismissable
+              dismissButtonLabel="Dismiss"
+              onDismiss={() => null}
+            />,
+          )
+          .toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+
       it('should accept userland styling', () => {
         const tree = renderer
           .create(

--- a/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -209,7 +209,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
       style={
         Array [
           Object {
-            "backgroundColor": "rgb(29, 27, 32)",
+            "backgroundColor": "rgb(241, 242, 248)",
             "borderRadius": 4,
             "minHeight": 1,
           },
@@ -233,7 +233,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "BpkIcon",
                 "fontSize": 24,
                 "includeFontPadding": false,
@@ -246,7 +246,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
                   "marginEnd": 8,
                 },
                 Object {
-                  "color": "rgb(142, 142, 147)",
+                  "color": "rgb(104, 105, 127)",
                 },
               ],
             ]
@@ -259,7 +259,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "sans-serif",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -280,7 +280,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
             style={
               Array [
                 Object {
-                  "color": "rgb(255, 255, 255)",
+                  "color": "rgb(17, 18, 54)",
                   "fontFamily": "sans-serif",
                   "fontSize": 14,
                   "fontWeight": "400",
@@ -297,79 +297,6 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
           </Text>
           .
         </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 0,
-                "overflow": "hidden",
-              },
-              Object {
-                "marginStart": 8,
-              },
-            ]
-          }
-        >
-          <View
-            accessibilityLabel="Dismiss"
-            accessibilityRole="button"
-            accessibilityStates={Array []}
-            accessible={true}
-            focusable={true}
-            isTVSelectable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "borderless": true,
-                "color": -9934465,
-                "type": "RippleAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              numberOfLines={1}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(255, 255, 255)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "textAlign": "left",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Array [
-                    Object {
-                      "color": "rgb(109, 159, 235)",
-                    },
-                  ],
-                ]
-              }
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
       </View>
     </View>
   </View>
@@ -384,7 +311,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
       style={
         Array [
           Object {
-            "backgroundColor": "rgb(29, 27, 32)",
+            "backgroundColor": "rgb(241, 242, 248)",
             "borderRadius": 4,
             "minHeight": 1,
           },
@@ -408,7 +335,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "BpkIcon",
                 "fontSize": 24,
                 "includeFontPadding": false,
@@ -421,7 +348,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
                   "marginEnd": 8,
                 },
                 Object {
-                  "color": "rgb(142, 142, 147)",
+                  "color": "rgb(104, 105, 127)",
                 },
               ],
             ]
@@ -434,7 +361,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "sans-serif",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -455,7 +382,7 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
             style={
               Array [
                 Object {
-                  "color": "rgb(255, 255, 255)",
+                  "color": "rgb(17, 18, 54)",
                   "fontFamily": "sans-serif",
                   "fontSize": 14,
                   "fontWeight": "400",
@@ -472,79 +399,6 @@ exports[`Android BpkBannerAlert dark mode should render correctly with Node mess
           </Text>
           .
         </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 0,
-                "overflow": "hidden",
-              },
-              Object {
-                "marginStart": 8,
-              },
-            ]
-          }
-        >
-          <View
-            accessibilityLabel="Dismiss"
-            accessibilityRole="button"
-            accessibilityStates={Array []}
-            accessible={true}
-            focusable={true}
-            isTVSelectable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "borderless": true,
-                "color": -9934465,
-                "type": "RippleAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              numberOfLines={1}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(255, 255, 255)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "textAlign": "left",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Array [
-                    Object {
-                      "color": "rgb(109, 159, 235)",
-                    },
-                  ],
-                ]
-              }
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
       </View>
     </View>
   </View>
@@ -2254,79 +2108,6 @@ exports[`Android BpkBannerAlert light mode should render correctly with Node mes
           </Text>
           .
         </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 0,
-                "overflow": "hidden",
-              },
-              Object {
-                "marginStart": 8,
-              },
-            ]
-          }
-        >
-          <View
-            accessibilityLabel="Dismiss"
-            accessibilityRole="button"
-            accessibilityStates={Array []}
-            accessible={true}
-            focusable={true}
-            isTVSelectable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "borderless": true,
-                "color": null,
-                "type": "RippleAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              numberOfLines={1}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(17, 18, 54)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "textAlign": "left",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Array [
-                    Object {
-                      "color": "rgb(7, 112, 227)",
-                    },
-                  ],
-                ]
-              }
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
       </View>
     </View>
   </View>
@@ -2429,79 +2210,6 @@ exports[`Android BpkBannerAlert light mode should render correctly with Node mes
           </Text>
           .
         </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "borderRadius": 0,
-                "overflow": "hidden",
-              },
-              Object {
-                "marginStart": 8,
-              },
-            ]
-          }
-        >
-          <View
-            accessibilityLabel="Dismiss"
-            accessibilityRole="button"
-            accessibilityStates={Array []}
-            accessible={true}
-            focusable={true}
-            isTVSelectable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "borderless": true,
-                "color": null,
-                "type": "RippleAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "minHeight": 32,
-                },
-              ]
-            }
-          >
-            <Text
-              allowFontScaling={false}
-              numberOfLines={1}
-              style={
-                Array [
-                  Object {
-                    "color": "rgb(17, 18, 54)",
-                    "fontFamily": "sans-serif",
-                    "fontSize": 14,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "textAlign": "left",
-                  },
-                  Object {
-                    "fontFamily": "sans-serif-medium",
-                  },
-                  Array [
-                    Object {
-                      "color": "rgb(7, 112, 227)",
-                    },
-                  ],
-                ]
-              }
-            >
-              DISMISS
-            </Text>
-          </View>
-        </View>
       </View>
     </View>
   </View>

--- a/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
+++ b/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.android.js.snap
@@ -181,6 +181,376 @@ exports[`Android BpkBannerAlert dark mode should accept userland styling 1`] = `
 </View>
 `;
 
+exports[`Android BpkBannerAlert dark mode should render correctly with Node message 1`] = `
+<View
+  style={
+    Object {
+      "borderRadius": 0,
+      "height": null,
+      "opacity": 1,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Array [
+        null,
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(29, 27, 32)",
+            "borderRadius": 4,
+            "minHeight": 1,
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "minHeight": 48,
+            "paddingHorizontal": 24,
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 8,
+                },
+                Object {
+                  "color": "rgb(142, 142, 147)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "sans-serif",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(255, 255, 255)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontFamily": "sans-serif-medium",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "borderRadius": 0,
+                "overflow": "hidden",
+              },
+              Object {
+                "marginStart": 8,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Dismiss"
+            accessibilityRole="button"
+            accessibilityStates={Array []}
+            accessible={true}
+            focusable={true}
+            isTVSelectable={true}
+            nativeBackgroundAndroid={
+              Object {
+                "borderless": true,
+                "color": -9934465,
+                "type": "RippleAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "minHeight": 32,
+                },
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(255, 255, 255)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Array [
+                    Object {
+                      "color": "rgb(109, 159, 235)",
+                    },
+                  ],
+                ]
+              }
+            >
+              DISMISS
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        null,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(29, 27, 32)",
+            "borderRadius": 4,
+            "minHeight": 1,
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "minHeight": 48,
+            "paddingHorizontal": 24,
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 8,
+                },
+                Object {
+                  "color": "rgb(142, 142, 147)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "sans-serif",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(255, 255, 255)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontFamily": "sans-serif-medium",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "borderRadius": 0,
+                "overflow": "hidden",
+              },
+              Object {
+                "marginStart": 8,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Dismiss"
+            accessibilityRole="button"
+            accessibilityStates={Array []}
+            accessible={true}
+            focusable={true}
+            isTVSelectable={true}
+            nativeBackgroundAndroid={
+              Object {
+                "borderless": true,
+                "color": -9934465,
+                "type": "RippleAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "minHeight": 32,
+                },
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(255, 255, 255)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Array [
+                    Object {
+                      "color": "rgb(109, 159, 235)",
+                    },
+                  ],
+                ]
+              }
+            >
+              DISMISS
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`Android BpkBannerAlert dark mode should render correctly with dismissable 1`] = `
 <View
   style={
@@ -1762,6 +2132,376 @@ exports[`Android BpkBannerAlert light mode should accept userland styling 1`] = 
         >
           Neutral alert.
         </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Android BpkBannerAlert light mode should render correctly with Node message 1`] = `
+<View
+  style={
+    Object {
+      "borderRadius": 0,
+      "height": null,
+      "opacity": 1,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Array [
+        null,
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(241, 242, 248)",
+            "borderRadius": 4,
+            "minHeight": 1,
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "minHeight": 48,
+            "paddingHorizontal": 24,
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 8,
+                },
+                Object {
+                  "color": "rgb(104, 105, 127)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "sans-serif",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(17, 18, 54)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontFamily": "sans-serif-medium",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "borderRadius": 0,
+                "overflow": "hidden",
+              },
+              Object {
+                "marginStart": 8,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Dismiss"
+            accessibilityRole="button"
+            accessibilityStates={Array []}
+            accessible={true}
+            focusable={true}
+            isTVSelectable={true}
+            nativeBackgroundAndroid={
+              Object {
+                "borderless": true,
+                "color": null,
+                "type": "RippleAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "minHeight": 32,
+                },
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(17, 18, 54)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Array [
+                    Object {
+                      "color": "rgb(7, 112, 227)",
+                    },
+                  ],
+                ]
+              }
+            >
+              DISMISS
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        null,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(241, 242, 248)",
+            "borderRadius": 4,
+            "minHeight": 1,
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "minHeight": 48,
+            "paddingHorizontal": 24,
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 8,
+                },
+                Object {
+                  "color": "rgb(104, 105, 127)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "sans-serif",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(17, 18, 54)",
+                  "fontFamily": "sans-serif",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontFamily": "sans-serif-medium",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "borderRadius": 0,
+                "overflow": "hidden",
+              },
+              Object {
+                "marginStart": 8,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Dismiss"
+            accessibilityRole="button"
+            accessibilityStates={Array []}
+            accessible={true}
+            focusable={true}
+            isTVSelectable={true}
+            nativeBackgroundAndroid={
+              Object {
+                "borderless": true,
+                "color": null,
+                "type": "RippleAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "minHeight": 32,
+                },
+              ]
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "color": "rgb(17, 18, 54)",
+                    "fontFamily": "sans-serif",
+                    "fontSize": 14,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "textAlign": "left",
+                  },
+                  Object {
+                    "fontFamily": "sans-serif-medium",
+                  },
+                  Array [
+                    Object {
+                      "color": "rgb(7, 112, 227)",
+                    },
+                  ],
+                ]
+              }
+            >
+              DISMISS
+            </Text>
+          </View>
+        </View>
       </View>
     </View>
   </View>

--- a/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -217,7 +217,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
             "borderWidth": 1,
           },
           Object {
-            "borderColor": "rgb(142, 142, 147)",
+            "borderColor": "rgb(143, 144, 160)",
           },
           null,
         ]
@@ -231,9 +231,6 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
               "paddingHorizontal": 8,
               "paddingVertical": 7,
             },
-            Object {
-              "paddingEnd": 32,
-            },
           ]
         }
       >
@@ -242,7 +239,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "BpkIcon",
                 "fontSize": 24,
                 "includeFontPadding": false,
@@ -255,7 +252,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
                   "marginEnd": 4,
                 },
                 Object {
-                  "color": "rgb(142, 142, 147)",
+                  "color": "rgb(104, 105, 127)",
                 },
               ],
             ]
@@ -268,7 +265,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -289,7 +286,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
             style={
               Array [
                 Object {
-                  "color": "rgb(255, 255, 255)",
+                  "color": "rgb(17, 18, 54)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "400",
@@ -306,62 +303,6 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
           </Text>
           .
         </Text>
-      </View>
-      <View
-        accessibilityLabel="Dismiss"
-        accessibilityRole="button"
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "paddingHorizontal": 8,
-            "paddingVertical": 7,
-            "position": "absolute",
-            "right": 0,
-          }
-        }
-      >
-        <Text
-          allowFontScaling={false}
-          style={
-            Array [
-              Object {
-                "color": "rgb(255, 255, 255)",
-                "fontFamily": "BpkIcon",
-                "fontSize": 24,
-                "includeFontPadding": false,
-              },
-              Object {
-                "fontSize": 16,
-              },
-            ]
-          }
-        >
-          
-        </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgb(255, 255, 255)",
-                "bottom": 0,
-                "flex": 1,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -380,7 +321,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
             "borderWidth": 1,
           },
           Object {
-            "borderColor": "rgb(142, 142, 147)",
+            "borderColor": "rgb(143, 144, 160)",
           },
           null,
         ]
@@ -394,9 +335,6 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
               "paddingHorizontal": 8,
               "paddingVertical": 7,
             },
-            Object {
-              "paddingEnd": 32,
-            },
           ]
         }
       >
@@ -405,7 +343,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "BpkIcon",
                 "fontSize": 24,
                 "includeFontPadding": false,
@@ -418,7 +356,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
                   "marginEnd": 4,
                 },
                 Object {
-                  "color": "rgb(142, 142, 147)",
+                  "color": "rgb(104, 105, 127)",
                 },
               ],
             ]
@@ -431,7 +369,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
           style={
             Array [
               Object {
-                "color": "rgb(255, 255, 255)",
+                "color": "rgb(17, 18, 54)",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "fontWeight": "400",
@@ -452,7 +390,7 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
             style={
               Array [
                 Object {
-                  "color": "rgb(255, 255, 255)",
+                  "color": "rgb(17, 18, 54)",
                   "fontFamily": "System",
                   "fontSize": 14,
                   "fontWeight": "400",
@@ -469,62 +407,6 @@ exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 
           </Text>
           .
         </Text>
-      </View>
-      <View
-        accessibilityLabel="Dismiss"
-        accessibilityRole="button"
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "paddingHorizontal": 8,
-            "paddingVertical": 7,
-            "position": "absolute",
-            "right": 0,
-          }
-        }
-      >
-        <Text
-          allowFontScaling={false}
-          style={
-            Array [
-              Object {
-                "color": "rgb(255, 255, 255)",
-                "fontFamily": "BpkIcon",
-                "fontSize": 24,
-                "includeFontPadding": false,
-              },
-              Object {
-                "fontSize": 16,
-              },
-            ]
-          }
-        >
-          
-        </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgb(255, 255, 255)",
-                "bottom": 0,
-                "flex": 1,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -2168,9 +2050,6 @@ exports[`iOS BpkBannerAlert light mode should render correctly with Node message
               "paddingHorizontal": 8,
               "paddingVertical": 7,
             },
-            Object {
-              "paddingEnd": 32,
-            },
           ]
         }
       >
@@ -2243,62 +2122,6 @@ exports[`iOS BpkBannerAlert light mode should render correctly with Node message
           </Text>
           .
         </Text>
-      </View>
-      <View
-        accessibilityLabel="Dismiss"
-        accessibilityRole="button"
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "paddingHorizontal": 8,
-            "paddingVertical": 7,
-            "position": "absolute",
-            "right": 0,
-          }
-        }
-      >
-        <Text
-          allowFontScaling={false}
-          style={
-            Array [
-              Object {
-                "color": "rgb(17, 18, 54)",
-                "fontFamily": "BpkIcon",
-                "fontSize": 24,
-                "includeFontPadding": false,
-              },
-              Object {
-                "fontSize": 16,
-              },
-            ]
-          }
-        >
-          
-        </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgb(17, 18, 54)",
-                "bottom": 0,
-                "flex": 1,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>
@@ -2331,9 +2154,6 @@ exports[`iOS BpkBannerAlert light mode should render correctly with Node message
               "paddingHorizontal": 8,
               "paddingVertical": 7,
             },
-            Object {
-              "paddingEnd": 32,
-            },
           ]
         }
       >
@@ -2406,62 +2226,6 @@ exports[`iOS BpkBannerAlert light mode should render correctly with Node message
           </Text>
           .
         </Text>
-      </View>
-      <View
-        accessibilityLabel="Dismiss"
-        accessibilityRole="button"
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "paddingHorizontal": 8,
-            "paddingVertical": 7,
-            "position": "absolute",
-            "right": 0,
-          }
-        }
-      >
-        <Text
-          allowFontScaling={false}
-          style={
-            Array [
-              Object {
-                "color": "rgb(17, 18, 54)",
-                "fontFamily": "BpkIcon",
-                "fontSize": 24,
-                "includeFontPadding": false,
-              },
-              Object {
-                "fontSize": 16,
-              },
-            ]
-          }
-        >
-          
-        </Text>
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgb(17, 18, 54)",
-                "bottom": 0,
-                "flex": 1,
-                "left": 0,
-                "opacity": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-            ]
-          }
-        />
       </View>
     </View>
   </View>

--- a/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
+++ b/lib/bpk-component-banner-alert/src/__snapshots__/BpkBannerAlert-test.ios.js.snap
@@ -185,6 +185,352 @@ exports[`iOS BpkBannerAlert dark mode should accept userland styling 1`] = `
 </View>
 `;
 
+exports[`iOS BpkBannerAlert dark mode should render correctly with Node message 1`] = `
+<View
+  style={
+    Object {
+      "borderRadius": 0,
+      "height": null,
+      "opacity": 1,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Array [
+        null,
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "borderRadius": 4,
+            "borderWidth": 1,
+          },
+          Object {
+            "borderColor": "rgb(142, 142, 147)",
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+              "paddingHorizontal": 8,
+              "paddingVertical": 7,
+            },
+            Object {
+              "paddingEnd": 32,
+            },
+          ]
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 4,
+                },
+                Object {
+                  "color": "rgb(142, 142, 147)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.154,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(255, 255, 255)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.154,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontWeight": "700",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Dismiss"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "paddingHorizontal": 8,
+            "paddingVertical": 7,
+            "position": "absolute",
+            "right": 0,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(255, 255, 255)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        null,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "borderRadius": 4,
+            "borderWidth": 1,
+          },
+          Object {
+            "borderColor": "rgb(142, 142, 147)",
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+              "paddingHorizontal": 8,
+              "paddingVertical": 7,
+            },
+            Object {
+              "paddingEnd": 32,
+            },
+          ]
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 4,
+                },
+                Object {
+                  "color": "rgb(142, 142, 147)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.154,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(255, 255, 255)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.154,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontWeight": "700",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Dismiss"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "paddingHorizontal": 8,
+            "paddingVertical": 7,
+            "position": "absolute",
+            "right": 0,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(255, 255, 255)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(255, 255, 255)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`iOS BpkBannerAlert dark mode should render correctly with dismissable 1`] = `
 <View
   style={
@@ -1770,6 +2116,352 @@ exports[`iOS BpkBannerAlert light mode should accept userland styling 1`] = `
         >
           Neutral alert.
         </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`iOS BpkBannerAlert light mode should render correctly with Node message 1`] = `
+<View
+  style={
+    Object {
+      "borderRadius": 0,
+      "height": null,
+      "opacity": 1,
+      "overflow": "hidden",
+    }
+  }
+>
+  <View
+    collapsable={false}
+    style={
+      Array [
+        null,
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "position": "absolute",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "borderRadius": 4,
+            "borderWidth": 1,
+          },
+          Object {
+            "borderColor": "rgb(143, 144, 160)",
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+              "paddingHorizontal": 8,
+              "paddingVertical": 7,
+            },
+            Object {
+              "paddingEnd": 32,
+            },
+          ]
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 4,
+                },
+                Object {
+                  "color": "rgb(104, 105, 127)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.154,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(17, 18, 54)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.154,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontWeight": "700",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Dismiss"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "paddingHorizontal": 8,
+            "paddingVertical": 7,
+            "position": "absolute",
+            "right": 0,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(17, 18, 54)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        null,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "borderRadius": 4,
+            "borderWidth": 1,
+          },
+          Object {
+            "borderColor": "rgb(143, 144, 160)",
+          },
+          null,
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flexDirection": "row",
+              "paddingHorizontal": 8,
+              "paddingVertical": 7,
+            },
+            Object {
+              "paddingEnd": 32,
+            },
+          ]
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+              Array [
+                Object {
+                  "marginEnd": 4,
+                },
+                Object {
+                  "color": "rgb(104, 105, 127)",
+                },
+              ],
+            ]
+          }
+        >
+          
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "letterSpacing": 0.154,
+                "textAlign": "left",
+              },
+              Object {},
+              Object {
+                "flex": 1,
+              },
+            ]
+          }
+        >
+          Neutral
+           
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "rgb(17, 18, 54)",
+                  "fontFamily": "System",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "letterSpacing": 0.154,
+                  "textAlign": "left",
+                },
+                Object {
+                  "fontWeight": "700",
+                },
+              ]
+            }
+          >
+            alert
+          </Text>
+          .
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Dismiss"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "paddingHorizontal": 8,
+            "paddingVertical": 7,
+            "position": "absolute",
+            "right": 0,
+          }
+        }
+      >
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": "rgb(17, 18, 54)",
+                "fontFamily": "BpkIcon",
+                "fontSize": 24,
+                "includeFontPadding": false,
+              },
+              Object {
+                "fontSize": 16,
+              },
+            ]
+          }
+        >
+          
+        </Text>
+        <View
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgb(17, 18, 54)",
+                "bottom": 0,
+                "flex": 1,
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+        />
       </View>
     </View>
   </View>

--- a/lib/bpk-component-banner-alert/src/common-types.js
+++ b/lib/bpk-component-banner-alert/src/common-types.js
@@ -39,7 +39,7 @@ export const ALERT_TYPES = {
 };
 
 export type Props = {
-  message: string,
+  message: string | Node,
   type: $Keys<typeof ALERT_TYPES>,
   animateOnEnter: boolean,
   animateOnLeave: boolean,
@@ -55,7 +55,7 @@ export type Props = {
 };
 
 export const propTypes = {
-  message: PropTypes.string.isRequired,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   type: PropTypes.oneOf(Object.keys(ALERT_TYPES)).isRequired,
   animateOnEnter: PropTypes.bool,
   animateOnLeave: PropTypes.bool,

--- a/lib/bpk-component-banner-alert/stories.js
+++ b/lib/bpk-component-banner-alert/stories.js
@@ -402,6 +402,18 @@ storiesOf('bpk-component-banner-alert', module)
         <BpkBannerAlert
           style={styles.bannerAlert}
           type={ALERT_TYPES.neutral}
+          message={
+            <>
+              Your booking was successful. Your booking reference is{' '}
+              <BpkText textStyle="sm" weight="emphasized">
+                fr33sh4v0c4d0
+              </BpkText>
+            </>
+          }
+        />
+        <BpkBannerAlert
+          style={styles.bannerAlert}
+          type={ALERT_TYPES.neutral}
           message={message}
         />
         <BpkBannerAlert


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_

Turns out the iOS font “Didot” has the same emoji problem in RN

![image](https://user-images.githubusercontent.com/30267516/91414268-37371b80-e844-11ea-904d-71f17b75dc91.png)
