### PR TITLE
[No Jira] Add edge case story for badge

### DIFF
--- a/lib/bpk-component-badge/stories.js
+++ b/lib/bpk-component-badge/stories.js
@@ -208,4 +208,17 @@ storiesOf('bpk-component-badge', module)
         config={{ docked: BADGE_DOCKED_TYPES.end }}
       />
     </BpkThemeProvider>
+  ))
+  .add('Edge cases', () => (
+    <View>
+      <BpkBadge
+        message="This is quite a long string, longer than you would typically see."
+        style={{ marginBottom: spacingSm }}
+      />
+      <BpkBadge
+        message="Раницата е най-добрата"
+        style={{ marginBottom: spacingSm }}
+      />
+      <BpkBadge message="حقيبة الظهر هي الأفضل" />
+    </View>
   ));


### PR DESCRIPTION
Question came up from a consumer, so I added a storybook example to save time in future. Not intended to be put on the docs site, just for our own reference.

<img width="589" alt="Screen Shot 2020-09-11 at 11 57 39" src="https://user-images.githubusercontent.com/73652/92917271-3e565000-f426-11ea-91d7-5f96383810a6.png">
