### PR TITLE
[BPK-4190]: Migrate to upstream lib

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,9 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+  - Migrate `bpk-component-card` from forked `react-native-dash` to upstream.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/lib/bpk-component-card/src/withDivider.js
+++ b/lib/bpk-component-card/src/withDivider.js
@@ -19,7 +19,7 @@
 /* @flow */
 
 import PropTypes from 'prop-types';
-import Dash from '@skyscanner/react-native-dash';
+import Dash from 'react-native-dash';
 import {
   spacingSm,
   spacingMd,

--- a/lib/package.json
+++ b/lib/package.json
@@ -21,11 +21,11 @@
     "tinymask": "^1.0.2"
   },
   "peerDependencies": {
-    "@skyscanner/react-native-dash": "0.0.11",
     "@skyscanner/react-native-transitiongroup": "^1.1.3",
     "react": "^16.9.0",
     "react-native": ">= 0.61.5",
     "react-native-dark-mode": "^0.2.2",
+    "react-native-dash": "0.0.11",
     "react-native-linear-gradient": "react-native-community/react-native-linear-gradient",
     "react-native-maps": "^0.26.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3570,16 +3570,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@skyscanner/react-native-dash": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@skyscanner/react-native-dash/-/react-native-dash-0.0.11.tgz",
-      "integrity": "sha512-9IsVdDO1U/8NVphcESj7D/FoVm/ircsGJqc8aXHlvQvs4WEHUmOR/LExxFAEdiBF5W/6QZb1ymC3bVqAP+nVSg==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.10",
-        "react-native-measureme": "0.0.1"
-      }
-    },
     "@skyscanner/react-native-transitiongroup": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@skyscanner/react-native-transitiongroup/-/react-native-transitiongroup-1.1.3.tgz",
@@ -24426,6 +24416,16 @@
         "toolkit.ts": "^0.0.2"
       }
     },
+    "react-native-dash": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/react-native-dash/-/react-native-dash-0.0.11.tgz",
+      "integrity": "sha512-edgspmVtGVYxOhGs8STCj7+VyQYUR1RkiGHkWDGwiQkEEIFrxWLa3D9ZIrLsm3LKU4XGQ2iEqCv9fJQSeTyAJA==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.10",
+        "react-native-measureme": "0.0.2"
+      }
+    },
     "react-native-dotenv": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-0.2.0.tgz",
@@ -24448,9 +24448,9 @@
       "dev": true
     },
     "react-native-measureme": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-measureme/-/react-native-measureme-0.0.1.tgz",
-      "integrity": "sha1-ixxVlc27HP34W/+Y/jbTPpi2Fiw=",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-measureme/-/react-native-measureme-0.0.2.tgz",
+      "integrity": "sha512-m7Td7w1pVdIf7a3ejN7K/67AU+TtkZqTt9/ieKamirLRI3fjLToupmOKDtIOU3Y56oKojzTKz1lBbYSPN28HWA==",
       "dev": true
     },
     "react-native-swipe-gestures": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     ]
   },
   "devDependencies": {
-    "@skyscanner/react-native-dash": "0.0.11",
     "@skyscanner/react-native-transitiongroup": "^1.1.3",
     "@storybook/addon-actions": "^5.3.19",
     "@storybook/addon-ondevice-actions": "^5.3.21",
@@ -106,6 +105,7 @@
     "react-dom": "16.9.0",
     "react-native": "0.61.5",
     "react-native-dark-mode": "^0.2.2",
+    "react-native-dash": "0.0.11",
     "react-native-dotenv": "^0.2.0",
     "react-native-linear-gradient": "^2.5.3",
     "react-native-maps": "^0.27.1",


### PR DESCRIPTION
Backpack RN had utilised a fork of react-native-dash due to an extraneous `new StyleSheet.create` which we changed to `StyleSheet.create`. https://github.com/obipawan/react-native-dash/compare/master...Skyscanner:master#diff-63f3aa32c5cc5d42a250b081693e9dc2R20
 
This has now seen to be fixed in upstream:master - https://github.com/obipawan/react-native-dash/blob/master/util.js#L20

The purpose of this PR is to migrate over to that library so that our fork can now be removed. 

As everything is still the same in the upstream library this PR just updates the package files and also the file import reference - therefore no tests have changed