### PR TITLE
[No JIRA] Fix ref flow types

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+**Fixed:**
+
+- Fixed flow typing for refs.
+
+
 > Place your changes below this line.
 
 ## How to write a good changelog entry

--- a/lib/bpk-component-animate-height/src/BpkAnimateHeight.js
+++ b/lib/bpk-component-animate-height/src/BpkAnimateHeight.js
@@ -19,14 +19,13 @@
 /* @flow */
 
 import PropTypes from 'prop-types';
-import React, { Component, type Node, type ElementProps } from 'react';
-import {
-  View,
-  Animated,
-  ViewPropTypes,
-  StyleSheet,
-  ReactNativeView,
-} from 'react-native';
+import React, {
+  Component,
+  type Node,
+  type ElementProps,
+  type ElementRef,
+} from 'react';
+import { View, Animated, ViewPropTypes, StyleSheet } from 'react-native';
 import { animationDurationSm } from 'bpk-tokens/tokens/base.react.native';
 import AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 
@@ -73,7 +72,7 @@ export type Props = {
 };
 
 class BpkAnimateHeight extends Component<Props, { computedHeight: ?number }> {
-  innerViewRef: ?typeof ReactNativeView;
+  innerViewRef: ?ElementRef<typeof View>;
 
   height: ?typeof AnimatedValue;
 

--- a/lib/bpk-component-banner-alert/src/AnimateAndFade.js
+++ b/lib/bpk-component-banner-alert/src/AnimateAndFade.js
@@ -19,14 +19,8 @@
 /* @flow */
 
 import PropTypes from 'prop-types';
-import React, { Component, type Node } from 'react';
-import {
-  View,
-  Animated,
-  ViewPropTypes,
-  StyleSheet,
-  ReactNativeView,
-} from 'react-native';
+import React, { Component, type Node, type ElementRef } from 'react';
+import { View, Animated, ViewPropTypes, StyleSheet } from 'react-native';
 import { animationDurationSm } from 'bpk-tokens/tokens/base.react.native';
 
 const COLLAPSED_HEIGHT = 0.01;
@@ -57,7 +51,7 @@ class AnimateAndFade extends Component<Props> {
 
   opacity: typeof Animated.Value;
 
-  innerViewRef: ?typeof ReactNativeView;
+  innerViewRef: ?ElementRef<typeof View>;
 
   shouldRenderHeight: boolean;
 

--- a/lib/bpk-component-dialog/src/NativeDialog.ios.js
+++ b/lib/bpk-component-dialog/src/NativeDialog.ios.js
@@ -25,7 +25,7 @@ import {
   NativeEventEmitter,
   processColor,
 } from 'react-native';
-import EmitterSubscription from 'react-native/Libraries/vendor/emitter/EmitterSubscription';
+import { EmitterSubscription } from 'react-native/Libraries/vendor/emitter/EmitterSubscription';
 import isNil from 'lodash/isNil';
 import { colors } from 'bpk-tokens/tokens/base.react.native';
 


### PR DESCRIPTION
Based on reading the RN source I believe this is the correct way to do refs. It doesn't result in a particularly useful type atm(`ElementRef<any>`) but at least it type checks cleanly.

<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
