### PR TITLE
Revert "Bump flow-bin from 0.107.0 to 0.134.0 (#623)"

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,3 +9,7 @@ update_configs:
           # 5.3.x of this dependency stops the addon panel from appearing.
           # See https://github.com/storybookjs/react-native/issues/24
           dependency_name: "@storybook/react-native-server"
+      - match:
+          # Ignoring as per our decision to ignore flow updates
+          # See https://github.com/skyscanner/backpack-react-native/decisions/flow_versions.md
+          dependency_name: "flow-bin"

--- a/.flowconfig
+++ b/.flowconfig
@@ -34,10 +34,6 @@ node_modules/warning/.*
 .*/react-native-linear-gradient/.*
 .*/theming/.*
 
-; This has been added due to a number of library errors that this throws
-; We should ensure we revisit this in the future once Flow/RN have patched internal issues.
-.*/node_modules/react-native/Libraries/*
-
 [include]
 
 [libs]
@@ -56,6 +52,23 @@ module.file_ext=.ios.js
 module.file_ext=.android.js
 module.file_ext=.native.js
 
+module.system=haste
+module.system.haste.use_name_reducers=true
+# get basename
+module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
+# strip .js or .js.flow suffix
+module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
+# strip .ios suffix
+module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
+module.system.haste.paths.blacklist=.*/__tests__/.*
+module.system.haste.paths.blacklist=.*/__mocks__/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/Libraries/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react_native/RNTester/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react_native/IntegrationTests/.*
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/react-native/react-native-implementation.js
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/Animated/src/polyfills/.*
+
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
@@ -65,9 +78,9 @@ suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 
-; This config turns off Types-First a now default behaviour from Flow: https://flow.org/en/docs/lang/types-first/
-; We should probably look at doing this but currently it produces over 255 errors so not simple, so for this PR disabling with the idea we create a future PR with this
-types_first=false
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [lints]
 sketchy-null-number=warn
@@ -77,7 +90,9 @@ untyped-type-import=warn
 nonstrict-import=warn
 deprecated-type=warn
 unsafe-getters-setters=warn
+inexact-spread=warn
 unnecessary-invariant=warn
+signature-verification-failure=warn
 deprecated-utility=error
 
 [strict]
@@ -90,4 +105,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.134.0
+^0.107.0

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -33,7 +33,6 @@ node_modules/warning/.*
 .*/node_modules/@react-native-community/cli/.*/.*
 .*/react-native-linear-gradient/.*
 .*/theming/.*
-.*/node_modules/react-native/Libraries/*
 
 [include]
 
@@ -53,6 +52,23 @@ module.file_ext=.ios.js
 module.file_ext=.android.js
 module.file_ext=.native.js
 
+module.system=haste
+module.system.haste.use_name_reducers=true
+# get basename
+module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
+# strip .js or .js.flow suffix
+module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
+# strip .android suffix
+module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
+module.system.haste.paths.blacklist=.*/__tests__/.*
+module.system.haste.paths.blacklist=.*/__mocks__/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/Libraries/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react_native/RNTester/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react_native/IntegrationTests/.*
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/react-native/react-native-implementation.js
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/Animated/src/polyfills/.*
+
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
@@ -61,10 +77,9 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
-
-; This config turns off Types-First a now default behaviour from Flow: https://flow.org/en/docs/lang/types-first/
-; We should probably look at doing this but currently it produces over 255 errors so not simple, so for this PR disabling with the idea we create a future PR with this
-types_first=false
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [lints]
 sketchy-null-number=warn
@@ -74,7 +89,9 @@ untyped-type-import=warn
 nonstrict-import=warn
 deprecated-type=warn
 unsafe-getters-setters=warn
+inexact-spread=warn
 unnecessary-invariant=warn
+signature-verification-failure=warn
 deprecated-utility=error
 
 [strict]
@@ -87,4 +104,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.134.0
+^0.107.0

--- a/.spelling
+++ b/.spelling
@@ -77,6 +77,7 @@ BpkTicket
 Artifactory
 Cocoapods
 CommonJS
+Dependabot
 ESLint
 GitHub
 gradle
@@ -96,6 +97,7 @@ rvm
 Sass
 Segoe
 Skyscanner
+Snyk
 travelpro
 Webpack
 XCode

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,7 @@
 
 **Fixed:**
 
+- Reverted flow-bin upgrade from 0.134.0.
 - Fixed flow typing for refs.
 
 

--- a/decisions/flow_versions.md
+++ b/decisions/flow_versions.md
@@ -1,0 +1,11 @@
+# Flow versions
+
+## Decision
+The version of `flow-bin` that we use in Backpack React Native should align to the same version that React Native is using.
+
+
+## Thinking
+The reason for this is newer versions of Flow use different concepts and features that when we make changes within Backpack could actually mean we misuse and violate types that React Native expects.
+
+## Anything else
+**Note:** Any pull requests that Dependabot or Snyk raise to upgrade flow should only be done if the version being updated aligns to the version in React Native. If the version bump is higher the PR should be closed.

--- a/lib/bpk-appearance/src/BpkDynamicStyleSheet.js
+++ b/lib/bpk-appearance/src/BpkDynamicStyleSheet.js
@@ -20,7 +20,7 @@
 
 /* @flow */
 import { StyleSheet } from 'react-native';
-import {
+import type {
   ViewStyle,
   TextStyle,
   ImageStyle,
@@ -34,9 +34,9 @@ import type {
 } from './common-types';
 
 type ReactStylesProps = {|
-  ...$Exact<typeof TextStyle>,
-  ...$Exact<typeof ViewStyle>,
-  ...$Exact<typeof ImageStyle>,
+  ...$Exact<TextStyle>,
+  ...$Exact<ViewStyle>,
+  ...$Exact<ImageStyle>,
 |};
 
 type EnhancedReactStylesProps = $Exact<

--- a/lib/bpk-appearance/src/withBpkAppearance.js
+++ b/lib/bpk-appearance/src/withBpkAppearance.js
@@ -51,11 +51,7 @@ const getDisplayName = Component =>
  * @returns {Component} the wrapped component with an extra `bpkAppearance` prop.
  */
 const withBpkAppearance = <Config>(
-  Component: AbstractComponent<{|
-    // $FlowFixMe[invalid-exact] - Cannot create exact type from Config.
-    ...$Exact<Config>,
-    ...InjectedProps,
-  |}>,
+  Component: AbstractComponent<{| ...$Exact<Config>, ...InjectedProps |}>,
 ): AbstractComponent<Config> => {
   const WithBpkAppearance = React.forwardRef((props, ref) => {
     const appearance = useBpkAppearance();

--- a/lib/bpk-component-animate-height/src/BpkAnimateHeight.js
+++ b/lib/bpk-component-animate-height/src/BpkAnimateHeight.js
@@ -74,7 +74,7 @@ export type Props = {
 class BpkAnimateHeight extends Component<Props, { computedHeight: ?number }> {
   innerViewRef: ?ElementRef<typeof View>;
 
-  height: ?typeof AnimatedValue;
+  height: ?AnimatedValue;
 
   adjustChildHeight: (height: number, onDone: () => mixed) => mixed;
 

--- a/lib/bpk-component-badge/src/BpkBadge.js
+++ b/lib/bpk-component-badge/src/BpkBadge.js
@@ -186,7 +186,7 @@ const BpkBadge = (props: Props) => {
   viewStyle.push(viewStyleMap[type]);
   textStyle.push(textStyleMap[type]);
 
-  const themeAttributes: Object = {
+  const themeAttributes = {
     ...getThemeAttributes(REQUIRED_THEME_ATTRIBUTES, theme),
   };
 

--- a/lib/bpk-component-banner-alert/src/AnimateAndFade.js
+++ b/lib/bpk-component-banner-alert/src/AnimateAndFade.js
@@ -47,9 +47,9 @@ type Props = {
 };
 
 class AnimateAndFade extends Component<Props> {
-  height: ?typeof Animated.Value;
+  height: ?Animated.Value;
 
-  opacity: typeof Animated.Value;
+  opacity: Animated.Value;
 
   innerViewRef: ?ElementRef<typeof View>;
 

--- a/lib/bpk-component-banner-alert/src/BpkBannerAlert.android.js
+++ b/lib/bpk-component-banner-alert/src/BpkBannerAlert.android.js
@@ -185,7 +185,6 @@ const BpkBannerAlert = (props: Props) => {
   );
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <AnimateAndFade
       animateOnEnter={animateOnEnter}
       animateOnLeave={dismissable || animateOnLeave}

--- a/lib/bpk-component-banner-alert/src/common-types.js
+++ b/lib/bpk-component-banner-alert/src/common-types.js
@@ -21,7 +21,7 @@
 import { type Node } from 'react';
 import PropTypes from 'prop-types';
 import { ViewPropTypes } from 'react-native';
-import { PressEvent } from 'react-native/Libraries/Types/CoreEventTypes';
+import type { PressEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 
 import {
   dismissablePropType,
@@ -47,8 +47,8 @@ export type Props = {
   dismissable: boolean,
   dismissButtonLabel: ?string,
   expanded: boolean,
-  onDismiss: ?(event: typeof PressEvent) => mixed,
-  onToggleExpanded: ?(event: typeof PressEvent) => mixed,
+  onDismiss: ?(event: PressEvent) => mixed,
+  onToggleExpanded: ?(event: PressEvent) => mixed,
   show: boolean,
   toggleExpandedButtonLabel: ?string,
   bannerStyle: ?any,

--- a/lib/bpk-component-boilerplate/src/BpkBoilerplate.js
+++ b/lib/bpk-component-boilerplate/src/BpkBoilerplate.js
@@ -42,7 +42,6 @@ const BpkBoilerplate = (props: Props) => {
     style.push(userStyle);
   }
 
-  // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
   return <View style={style} {...rest} />;
 };
 

--- a/lib/bpk-component-button-link/src/BpkButtonLink.android.js
+++ b/lib/bpk-component-button-link/src/BpkButtonLink.android.js
@@ -95,7 +95,6 @@ const BpkButtonLink = (props: Props) => {
 
   return (
     <View style={[styles.wrapper, userStyle]}>
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <BpkTouchableNativeFeedback
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel || title}

--- a/lib/bpk-component-button-link/src/BpkButtonLink.ios.js
+++ b/lib/bpk-component-button-link/src/BpkButtonLink.ios.js
@@ -89,7 +89,6 @@ const BpkButtonLink = (props: Props) => {
   const activeOpacity = useBpkDynamicValue({ light: 0.2, dark: 0.6 });
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <TouchableOpacity
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel || title}

--- a/lib/bpk-component-button-link/src/common-types.js
+++ b/lib/bpk-component-button-link/src/common-types.js
@@ -20,7 +20,7 @@
 
 import { type Node } from 'react';
 import PropTypes from 'prop-types';
-import { PressEvent } from 'react-native/Libraries/Types/CoreEventTypes';
+import type { PressEvent } from 'react-native/Libraries/Types/CoreEventTypes';
 
 import { makeThemePropType } from '../../bpk-theming';
 
@@ -34,7 +34,7 @@ export const ICON_ALIGNMENTS = {
 };
 
 export type CommonProps = {
-  onPress: (event: typeof PressEvent) => mixed,
+  onPress: (event: PressEvent) => mixed,
   title: string,
   disabled: boolean,
   accessibilityLabel: ?string,

--- a/lib/bpk-component-button/src/BpkBorderedButton.android.js
+++ b/lib/bpk-component-button/src/BpkBorderedButton.android.js
@@ -98,7 +98,6 @@ const BpkBorderedButton = (props: Props) => {
 
   return (
     <View style={wrapperStyle}>
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <BpkTouchableNativeFeedback
         disabled={disabled}
         borderlessBackground={Platform.Version !== 28}

--- a/lib/bpk-component-button/src/BpkBorderedButton.ios.js
+++ b/lib/bpk-component-button/src/BpkBorderedButton.ios.js
@@ -110,7 +110,6 @@ const BpkBorderedButton = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkTouchableOverlay
       overlayStyle={{
         borderColor,

--- a/lib/bpk-component-button/src/BpkButton.android.js
+++ b/lib/bpk-component-button/src/BpkButton.android.js
@@ -111,7 +111,6 @@ const BpkButton = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <ButtonComponent
       disabled={disabled}
       title={title}

--- a/lib/bpk-component-button/src/BpkButton.ios.js
+++ b/lib/bpk-component-button/src/BpkButton.ios.js
@@ -128,7 +128,6 @@ const BpkButton = (props: Props) => {
   );
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <ButtonComponent
       disabled={disabled}
       title={title}

--- a/lib/bpk-component-button/src/BpkGradientButton.ios.js
+++ b/lib/bpk-component-button/src/BpkGradientButton.ios.js
@@ -103,7 +103,6 @@ const BpkGradientButton = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkTouchableOverlay
       borderRadius={borderRadius}
       disabled={disabled}

--- a/lib/bpk-component-button/src/BpkStandardButton.android.js
+++ b/lib/bpk-component-button/src/BpkStandardButton.android.js
@@ -104,7 +104,6 @@ const BpkStandardButton = (props: Props) => {
 
   return (
     <View style={wrapperStyle}>
-      {/*  $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <BpkTouchableNativeFeedback
         disabled={disabled}
         borderlessBackground={Platform.Version !== 28}

--- a/lib/bpk-component-calendar/src/BpkCalendar.js
+++ b/lib/bpk-component-calendar/src/BpkCalendar.js
@@ -65,7 +65,6 @@ const BpkCalendar = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <NativeCalendar
       minDate={minDate}
       maxDate={maxDate}

--- a/lib/bpk-component-calendar/src/NativeCalendar.android.js
+++ b/lib/bpk-component-calendar/src/NativeCalendar.android.js
@@ -50,7 +50,6 @@ const BpkCalendar = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <AndroidBPKCalendarView
       minDate={parseDateToNative(minDate)}
       maxDate={parseDateToNative(maxDate)}

--- a/lib/bpk-component-calendar/src/NativeCalendar.ios.js
+++ b/lib/bpk-component-calendar/src/NativeCalendar.ios.js
@@ -77,7 +77,6 @@ class BpkCalendar extends Component<Props, {}> {
     } = this.props;
 
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <RCTBPKCalendar
         ref={this.calendarRef}
         minDate={parseDateToNative(minDate)}

--- a/lib/bpk-component-calendar/src/common-types.js
+++ b/lib/bpk-component-calendar/src/common-types.js
@@ -38,7 +38,6 @@ export const SELECTION_TYPES = {
 
 export type SelectionType = $Keys<typeof SELECTION_TYPES>;
 export type SelectedDatesChanged = ?(Date[]) => mixed;
-// $FlowFixMe - [value-as-type] - If we use typeof here to solve this issue then an error is produced that we cannot supply ReadOnly as the type of event we expect.
 export type NativeEvent = SyntheticEvent<
   $ReadOnly<{| selectedDates: number[] |}>,
 >;

--- a/lib/bpk-component-calendar/stories.js
+++ b/lib/bpk-component-calendar/stories.js
@@ -161,7 +161,6 @@ class BpkCalendarExample extends Component<
       ...rest
     } = this.props;
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <BpkCalendar
         locale={locales.en_GB}
         selectionType={selectionType}
@@ -289,7 +288,6 @@ const CalendarWithPicker = (props: CalendarWithPickerProps) => {
 
 const ChangeableSelectionTypeStory = () => {
   const options = Object.keys(SELECTION_TYPES).reduce(
-    // $FlowFixMe - Literals probably should fix it.
     (acc, type) => ({ ...acc, [type]: { value: type, label: type } }),
     {},
   );

--- a/lib/bpk-component-card/src/BpkCard.android.js
+++ b/lib/bpk-component-card/src/BpkCard.android.js
@@ -111,7 +111,6 @@ const BpkCard = (props: Props) => {
 
   return (
     <View style={style}>
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <BpkTouchableNativeFeedback
         borderlessBackground={Platform.Version !== 28}
         accessibilityRole="button"

--- a/lib/bpk-component-card/src/BpkCard.ios.js
+++ b/lib/bpk-component-card/src/BpkCard.ios.js
@@ -111,7 +111,6 @@ const BpkCard = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkTouchableOverlay
       accessibilityRole="button"
       style={style}

--- a/lib/bpk-component-card/src/withDivider.js
+++ b/lib/bpk-component-card/src/withDivider.js
@@ -123,7 +123,6 @@ const withDivider = (CardComponent: ComponentType<any>): ComponentType<any> => {
     const dashColor = useBpkDynamicValue(lineColor);
 
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <CardComponent padded={false} innerStyle={innerStyle} {...rest}>
         <View style={mainStyle}>{children}</View>
         <Dash

--- a/lib/bpk-component-carousel-indicator/src/BpkCarouselIndicator.js
+++ b/lib/bpk-component-carousel-indicator/src/BpkCarouselIndicator.js
@@ -137,7 +137,6 @@ const BpkCarouselIndicator = (props: Props) => {
   const { begin, end } = getIndicatorSlice(pageCount, selectedIndex);
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <TransitionGroup
       style={[styles.wrapper, style]}
       childrenSortFn={transitionGroupSorter}

--- a/lib/bpk-component-carousel-indicator/src/BpkCarouselIndicatorDot.js
+++ b/lib/bpk-component-carousel-indicator/src/BpkCarouselIndicatorDot.js
@@ -64,7 +64,7 @@ type Props = {
 };
 
 class BpkCarouselIndicatorDot extends React.PureComponent<Props, {}> {
-  size: typeof AnimatedValue;
+  size: AnimatedValue;
 
   static propTypes = {
     selected: PropTypes.bool,

--- a/lib/bpk-component-carousel/src/BpkCarousel.js
+++ b/lib/bpk-component-carousel/src/BpkCarousel.js
@@ -63,7 +63,7 @@ export type Props = {
 
 type State = {
   currentIndex: number,
-  dataProvider: typeof DataProvider,
+  dataProvider: DataProvider,
   width: ?number,
   height: ?number,
 };

--- a/lib/bpk-component-chip/src/BpkChipInner.android.js
+++ b/lib/bpk-component-chip/src/BpkChipInner.android.js
@@ -42,7 +42,6 @@ const BpkChipInner = (props: InnerProps) => {
 
   return (
     <View style={[styles.wrapper, userStyle]}>
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <BpkTouchableNativeFeedback
         borderlessBackground={Platform.Version !== 28}
         accessibilityLabel={accessibilityLabel}

--- a/lib/bpk-component-chip/src/BpkChipInner.ios.js
+++ b/lib/bpk-component-chip/src/BpkChipInner.ios.js
@@ -35,7 +35,6 @@ const BpkChipInner = (props: InnerProps) => {
   } = props;
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkTouchableOverlay
       accessibilityLabel={accessibilityLabel}
       accessibilityRole="button"

--- a/lib/bpk-component-chip/src/BpkChipWrapper.js
+++ b/lib/bpk-component-chip/src/BpkChipWrapper.js
@@ -180,7 +180,7 @@ const BpkChipWrapper = (props: Props) => {
     }
   }
 
-  const themeAttributes: Object = {
+  const themeAttributes = {
     ...getThemeAttributes(REQUIRED_THEME_ATTRIBUTES, theme),
   };
 
@@ -232,7 +232,6 @@ const BpkChipWrapper = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkChipInner
       accessibilityLabel={accessibilityLabel}
       disabled={disabled}

--- a/lib/bpk-component-chip/src/theming.js
+++ b/lib/bpk-component-chip/src/theming.js
@@ -28,7 +28,6 @@ const REQUIRED_THEME_ATTRIBUTES = [
   'chipOutlineSelectedBackgroundColor',
   'chipOutlineSelectedTextColor',
 ];
-
 const themePropType = makeThemePropType(REQUIRED_THEME_ATTRIBUTES);
 
 export { REQUIRED_THEME_ATTRIBUTES, themePropType };

--- a/lib/bpk-component-chip/stories.js
+++ b/lib/bpk-component-chip/stories.js
@@ -79,32 +79,9 @@ class StatefulBpkChipExample extends React.Component<
     };
   }
 
-  toggleChip = (chip: 'flights' | 'hotels' | 'carHire' | 'trains') => {
+  toggleChip = chip => {
     action(`Toggling ${chip}`);
-    switch (chip) {
-      case 'flights':
-        this.setState(prevState => ({
-          flights: !prevState[chip],
-        }));
-        break;
-      case 'hotels':
-        this.setState(prevState => ({
-          hotels: !prevState[chip],
-        }));
-        break;
-      case 'carHire':
-        this.setState(prevState => ({
-          carHire: !prevState[chip],
-        }));
-        break;
-      case 'trains':
-        this.setState(prevState => ({
-          trains: !prevState[chip],
-        }));
-        break;
-      default:
-        break;
-    }
+    this.setState(prevState => ({ [chip]: !prevState[chip] }));
   };
 
   render() {
@@ -169,32 +146,11 @@ class StatefulBpkDismissibleChipExample extends React.Component<
     };
   }
 
-  removeChip = (chip: 'flights' | 'hotels' | 'carHire' | 'trains') => {
+  removeChip = chip => {
     action(`Removing ${chip}`);
-    switch (chip) {
-      case 'flights':
-        this.setState({
-          flights: false,
-        });
-        break;
-      case 'hotels':
-        this.setState({
-          hotels: false,
-        });
-        break;
-      case 'carHire':
-        this.setState({
-          carHire: false,
-        });
-        break;
-      case 'trains':
-        this.setState({
-          trains: false,
-        });
-        break;
-      default:
-        break;
-    }
+    this.setState({
+      [chip]: false,
+    });
   };
 
   render() {

--- a/lib/bpk-component-dialog/src/NativeDialog.android.js
+++ b/lib/bpk-component-dialog/src/NativeDialog.android.js
@@ -45,7 +45,6 @@ const BpkDialog = (props: Props) => {
   const { icon, scrimAction, ...rest } = props;
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <AndroidBPKDialogView
       icon={{
         iconId: `bpk_${icon.iconId.replace(/-/g, '_')}`,

--- a/lib/bpk-component-dialog/src/NativeDialog.ios.js
+++ b/lib/bpk-component-dialog/src/NativeDialog.ios.js
@@ -48,7 +48,7 @@ export type State = {
 };
 
 class BpkDialog extends Component<Props> {
-  eventSubscriptions: Array<typeof EmitterSubscription>;
+  eventSubscriptions: Array<EmitterSubscription>;
 
   identifier: number;
 
@@ -96,7 +96,6 @@ class BpkDialog extends Component<Props> {
     }
 
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <RCTBPKDialog
         identifier={this.identifier}
         scrimEnabled={scrimAction ? scrimAction.enabled : false}

--- a/lib/bpk-component-dialog/src/NativeDialog.ios.js
+++ b/lib/bpk-component-dialog/src/NativeDialog.ios.js
@@ -25,7 +25,7 @@ import {
   NativeEventEmitter,
   processColor,
 } from 'react-native';
-import { EmitterSubscription } from 'react-native/Libraries/vendor/emitter/EmitterSubscription';
+import type EmitterSubscription from 'react-native/Libraries/vendor/emitter/EmitterSubscription';
 import isNil from 'lodash/isNil';
 import { colors } from 'bpk-tokens/tokens/base.react.native';
 

--- a/lib/bpk-component-flare/src/BpkFlare.js
+++ b/lib/bpk-component-flare/src/BpkFlare.js
@@ -52,7 +52,6 @@ const BpkFlare = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <NativeFlare style={style} {...rest}>
       {children}
     </NativeFlare>

--- a/lib/bpk-component-flat-list/src/BpkFlatListItem.android.js
+++ b/lib/bpk-component-flat-list/src/BpkFlatListItem.android.js
@@ -84,7 +84,6 @@ class BpkFlatListItem extends React.PureComponent<
       theme,
       titleProps,
       bpkAppearance,
-      // $FlowFixMe - [incompatible-use] - Ignoring this as it complains about borderlessBackground prop could be in rest but given we don't advertise this consumers are not likely to provide it so we are safe to ignore
       ...rest
     } = this.props;
 
@@ -112,7 +111,6 @@ class BpkFlatListItem extends React.PureComponent<
       : null;
 
     return (
-      // $FlowFixMe - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <BpkTouchableNativeFeedback
         borderlessBackground={false}
         accessibilityLabel={title}

--- a/lib/bpk-component-flat-list/src/BpkFlatListItem.ios.js
+++ b/lib/bpk-component-flat-list/src/BpkFlatListItem.ios.js
@@ -96,7 +96,6 @@ class BpkFlatListItem extends React.PureComponent<
       theme,
       titleProps,
       bpkAppearance,
-      // $FlowFixMe[incompatible-use] - Not sure why it complains about this - might be due to using this.props
       ...rest
     } = this.props;
 

--- a/lib/bpk-component-flat-list/src/BpkFlatListSearchField.js
+++ b/lib/bpk-component-flat-list/src/BpkFlatListSearchField.js
@@ -113,7 +113,6 @@ const BpkFlatListSearchField = (props: Props) => {
   const styles = useBpkDynamicStyleSheet(dynamicStyles);
   return (
     <View style={[styles.wrapper, userStyle]}>
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <TextInput
         style={styles.textInput}
         placeholderTextColor={colorSkyGrayTint03}

--- a/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
+++ b/lib/bpk-component-horizontal-nav/src/BpkHorizontalNavItem.js
@@ -132,7 +132,6 @@ const BpkHorizontalNavItem = (props: Props) => {
   const formattedTitle = isAndroid ? title.toUpperCase() : title;
   const platformProps = isAndroid ? { borderlessBackground: false } : {};
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <Touchable
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel || title}

--- a/lib/bpk-component-icon/src/BpkIcon.js
+++ b/lib/bpk-component-icon/src/BpkIcon.js
@@ -77,7 +77,6 @@ const BpkIcon = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <Text allowFontScaling={false} style={textStyleFinal} {...rest}>
       {mapCharacterCode(characterCode)}
     </Text>

--- a/lib/bpk-component-icon/src/withRtlSupport.js
+++ b/lib/bpk-component-icon/src/withRtlSupport.js
@@ -55,7 +55,6 @@ const withRtlSupport = (IconComponent: typeof BpkIcon): typeof BpkIcon => {
       rtlStyle.push(userStyle);
     }
 
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     return <IconComponent style={rtlStyle} {...rest} />;
   };
 

--- a/lib/bpk-component-image/src/withLoadingBehaviour.js
+++ b/lib/bpk-component-image/src/withLoadingBehaviour.js
@@ -53,7 +53,6 @@ const withLoadingBehavior = (
 
     render() {
       return (
-        // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
         <WrappedComponent
           onLoad={this.onLoad}
           loaded={this.state.loaded}

--- a/lib/bpk-component-navigation-bar/src/BpkNavigationBar.android.js
+++ b/lib/bpk-component-navigation-bar/src/BpkNavigationBar.android.js
@@ -215,7 +215,6 @@ class BpkNavigationBar extends Component<Props, {}> {
     }
 
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <View style={outerBarStyle} {...rest}>
         <View style={barStyle}>
           {leadingButton &&

--- a/lib/bpk-component-navigation-bar/src/BpkNavigationBarBackButtonIOS.ios.js
+++ b/lib/bpk-component-navigation-bar/src/BpkNavigationBarBackButtonIOS.ios.js
@@ -61,7 +61,6 @@ const BpkNavigationBarBackButtonIOS = (props: Props) => {
   const iconStyle = [showTitle ? styles.backIcon : styles.backIconWithoutTitle];
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <TouchableOpacity
       onPress={onPress}
       accessibilityRole="button"

--- a/lib/bpk-component-navigation-bar/src/BpkNavigationBarButtonAndroid.android.js
+++ b/lib/bpk-component-navigation-bar/src/BpkNavigationBarButtonAndroid.android.js
@@ -74,7 +74,6 @@ const BpkNavigationBarButton = (props: Props) => {
 
   return (
     <View style={styles.clipView}>
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <BpkTouchableNativeFeedback
         onPress={onPress}
         accessibilityRole="button"

--- a/lib/bpk-component-navigation-bar/src/BpkNavigationBarIconButtonIOS.ios.js
+++ b/lib/bpk-component-navigation-bar/src/BpkNavigationBarIconButtonIOS.ios.js
@@ -89,7 +89,6 @@ const BpkNavigationBarIconButtonIOS = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <TouchableOpacity
       onPress={onPress}
       accessibilityRole="button"

--- a/lib/bpk-component-navigation-bar/src/BpkNavigationBarTextButtonIOS.ios.js
+++ b/lib/bpk-component-navigation-bar/src/BpkNavigationBarTextButtonIOS.ios.js
@@ -108,7 +108,6 @@ const BpkNavigationBarTextButtonIOS = (props: Props) => {
   ];
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <TouchableOpacity
       onPress={onPress}
       accessibilityRole="button"

--- a/lib/bpk-component-navigation-bar/src/TitleView.js
+++ b/lib/bpk-component-navigation-bar/src/TitleView.js
@@ -80,7 +80,6 @@ const TitleView = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <View style={[styles.container, style]} {...rest}>
       {isLeading && icon}
       <BpkText

--- a/lib/bpk-component-panel/src/withDivider.js
+++ b/lib/bpk-component-panel/src/withDivider.js
@@ -131,7 +131,6 @@ const withDivider = (PanelComponent: ComponentType<BpkPanelProps>) => {
     }
 
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <PanelComponent padded={padded} style={panelStyle} {...rest}>
         <View style={mainStyle}>{children}</View>
         <View style={punchlineStyle} />

--- a/lib/bpk-component-phone-input/src/BpkDialingCodeList.js
+++ b/lib/bpk-component-phone-input/src/BpkDialingCodeList.js
@@ -96,7 +96,6 @@ const BpkDialingCodeList = ({
   suggested,
   ...rest
 }: Props) => (
-  // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
   <BpkSectionList
     sections={convertCodesIntoSections(dialingCodes, suggested)}
     renderItem={({ item }) => (

--- a/lib/bpk-component-phone-input/src/BpkFlag.js
+++ b/lib/bpk-component-phone-input/src/BpkFlag.js
@@ -66,14 +66,12 @@ const BpkFlag = (props: Props) => {
   }
 
   const styledFlag = flag ? (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     React.cloneElement(flag, {
       resizeMode: 'contain',
       style: finalStyle,
       ...rest,
     })
   ) : (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <View style={finalStyle} {...rest} />
   );
 

--- a/lib/bpk-component-phone-input/src/BpkPhoneNumberInput.js
+++ b/lib/bpk-component-phone-input/src/BpkPhoneNumberInput.js
@@ -60,7 +60,6 @@ const BpkPhoneNumberInput = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkTextInput
       editable={editable}
       keyboardType="phone-pad"

--- a/lib/bpk-component-picker/src/BpkPickerItem.ios.js
+++ b/lib/bpk-component-picker/src/BpkPickerItem.ios.js
@@ -23,6 +23,6 @@ import { Picker } from 'react-native';
 
 const BpkPickerItem = Picker.Item;
 
-export type Props = ElementProps<typeof BpkPickerItem>;
+export type Props = ElementProps<BpkPickerItem>;
 
 export default BpkPickerItem;

--- a/lib/bpk-component-picker/stories.js
+++ b/lib/bpk-component-picker/stories.js
@@ -116,7 +116,6 @@ class StatefulBpkPicker extends Component<Props, State> {
               : 'Open picker'
           }
         />
-        {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
         <BpkPicker
           isOpen={this.state.isOpen}
           onClose={this.closePicker}

--- a/lib/bpk-component-progress/src/BpkProgress.js
+++ b/lib/bpk-component-progress/src/BpkProgress.js
@@ -114,7 +114,7 @@ const defaultProps = {
 };
 
 class BpkProgress extends Component<EnhancedProps, State> {
-  progressAnimation: typeof Animated.Value;
+  progressAnimation: Animated.Value;
 
   static propTypes = { ...propTypes };
 

--- a/lib/bpk-component-progress/stories.js
+++ b/lib/bpk-component-progress/stories.js
@@ -71,7 +71,6 @@ class ProgressContainer extends Component<
   render() {
     const { steps, types, ...rest } = this.props;
 
-    // $FlowFixMe - Ignoring this error 'Cannot delete rest.initialValue because undefined is incompatible with number' - as the prop is required and would never be undefined
     delete rest.initialValue;
 
     return (

--- a/lib/bpk-component-rating/stories.js
+++ b/lib/bpk-component-rating/stories.js
@@ -95,7 +95,6 @@ const nextkey = (() => {
 
 const createExamples = (examples: Array<$Shape<Props>>) =>
   examples.map(props => (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <BpkRating
       key={nextkey()}
       style={styles.rating}

--- a/lib/bpk-component-select/src/BpkSelect.js
+++ b/lib/bpk-component-select/src/BpkSelect.js
@@ -173,7 +173,6 @@ const BpkSelect = (props: Props) => {
       accessibilityStates={accessibilityStates}
       {...platformProps}
     >
-      {/* $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'. */}
       <View style={selectStyle} {...rest}>
         {showImage && styledImage}
         {content || label}

--- a/lib/bpk-component-spinner/src/BpkSpinner.js
+++ b/lib/bpk-component-spinner/src/BpkSpinner.js
@@ -84,7 +84,6 @@ const BpkSpinner = (props: Props) => {
     );
   }
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <ActivityIndicator
       color={useSpinnerColor(themeAttributes, spinnerType)}
       size={small ? 'small' : 'large'}

--- a/lib/bpk-component-star-rating/src/BpkStar.js
+++ b/lib/bpk-component-star-rating/src/BpkStar.js
@@ -111,7 +111,6 @@ const BpkStar = (props: Props) => {
    * a yellow half star or star ontop of it.
    */
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <View style={styles.container} {...rest} accessible={false}>
       <BpkIcon icon={icons['star-outline']} style={commonStarStyles} />
       {type !== STAR_TYPES.EMPTY && (

--- a/lib/bpk-component-star-rating/src/BpkStarRating.js
+++ b/lib/bpk-component-star-rating/src/BpkStarRating.js
@@ -52,7 +52,6 @@ const BpkStarRating = (props: Props) => {
       : ratingLabel(rating, maxRating);
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <View
       style={styles.starsContainer}
       accessibilityLabel={label}

--- a/lib/bpk-component-switch/stories.js
+++ b/lib/bpk-component-switch/stories.js
@@ -50,7 +50,6 @@ class SwitchContainer extends Component<{}, { value: boolean }> {
 
   render() {
     return (
-      // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
       <BpkSwitch
         value={this.state.value}
         onValueChange={value => {

--- a/lib/bpk-component-text-input/src/BpkTextInput.js
+++ b/lib/bpk-component-text-input/src/BpkTextInput.js
@@ -111,7 +111,7 @@ const sanitizeMaskedValue = (value: ?string, mask: string) => {
 export const formatValue = (
   value: ?string,
   mask: ?string,
-  tinymask: ?typeof TinyMask,
+  tinymask: ?TinyMask,
 ) => {
   if (mask && tinymask) {
     return tinymask.mask(sanitizeMaskedValue(value, mask));
@@ -128,10 +128,7 @@ type EnhancedProps = Props & WithBpkAppearanceInjectedProps;
 const createTinyMask = memoize(mask => new TinyMask(mask || ''));
 
 class BpkTextInput extends Component<EnhancedProps, State> {
-  animatedValues: {
-    color: typeof AnimatedValue,
-    labelPosition: typeof AnimatedValue,
-  };
+  animatedValues: { color: AnimatedValue, labelPosition: AnimatedValue };
 
   static propTypes = { ...propTypes };
 
@@ -221,7 +218,6 @@ class BpkTextInput extends Component<EnhancedProps, State> {
       accessoryView,
       theme,
       bpkAppearance,
-      // $FlowFixMe[incompatible-use] - Not sure why it complains about this - might be due to using this.props
       ...rest
     } = this.props;
     const styles = getStyles(bpkAppearance);
@@ -311,9 +307,9 @@ class BpkTextInput extends Component<EnhancedProps, State> {
               // $FlowFixMe
               ref={inputRef}
               underlineColorAndroid="transparent"
+              {...rest}
               placeholder={placeholderValue}
               placeholderTextColor={placeholderColor}
-              {...rest}
             />
             {!isFocused && validityIcon}
           </Animated.View>

--- a/lib/bpk-component-text-input/src/styles.js
+++ b/lib/bpk-component-text-input/src/styles.js
@@ -150,8 +150,8 @@ const getLabelTypography = (
   hasAccessoryView ? SMALL_LABEL_TYPOGRAPHY : LARGE_LABEL_TYPOGRAPHY;
 
 const getLabelStyle = (
-  animatedColorValue: typeof AnimatedValue,
-  animatedLabelValue: typeof AnimatedValue,
+  animatedColorValue: AnimatedValue,
+  animatedLabelValue: AnimatedValue,
   {
     value,
     valid,
@@ -205,7 +205,7 @@ const getLabelStyle = (
 };
 
 const getInputContainerStyle = (
-  animatedColorValue: typeof AnimatedValue,
+  animatedColorValue: AnimatedValue,
   hasAccessoryView: boolean,
   valid: ?boolean,
   focusedColor: string | BpkDynamicValue<string> = primaryColor,

--- a/lib/bpk-component-text/src/BpkEmoji.js
+++ b/lib/bpk-component-text/src/BpkEmoji.js
@@ -34,7 +34,6 @@ export type Props = {
 const BpkEmoji = (props: Props) => {
   const { style: userStyle, ...rest } = props;
 
-  // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
   return <Text style={[styles.emoji, userStyle]} {...rest} />;
 };
 

--- a/lib/bpk-component-text/src/BpkText.js
+++ b/lib/bpk-component-text/src/BpkText.js
@@ -220,7 +220,6 @@ const BpkText = (props: Props) => {
   }
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <Text allowFontScaling={false} style={style} {...rest}>
       {children}
     </Text>

--- a/lib/bpk-component-text/src/common-types.js
+++ b/lib/bpk-component-text/src/common-types.js
@@ -21,7 +21,7 @@
 import { type Node } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet } from 'react-native';
-import { TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+import { type TextStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import { type Theme } from '../../bpk-theming';
 
@@ -59,7 +59,7 @@ export type Weight = $Keys<typeof WEIGHT_STYLES>;
 export type Props = {
   children: Node,
   emphasize: ?boolean,
-  style: typeof TextStyleProp,
+  style: TextStyleProp,
   textStyle: TextStyle,
   theme: ?Theme,
   weight: Weight,

--- a/lib/bpk-component-touchable-native-feedback/src/BpkTouchableNativeFeedback.js
+++ b/lib/bpk-component-touchable-native-feedback/src/BpkTouchableNativeFeedback.js
@@ -54,7 +54,6 @@ const BpkTouchableNativeFeedback = (props: Props) => {
     : TouchableNativeFeedback.Ripple(rippleColor, borderlessBackground);
 
   return (
-    // $FlowFixMe[cannot-spread-inexact] - inexact rest. See 'https://github.com/Skyscanner/backpack/tree/master/decisions/flowfixme.md'.
     <TouchableNativeFeedback style={style} background={background} {...rest}>
       {React.Children.only(children)}
     </TouchableNativeFeedback>

--- a/lib/bpk-theming/src/util.js
+++ b/lib/bpk-theming/src/util.js
@@ -168,7 +168,6 @@ export const getThemeAttributes = (
     : {};
 
   const allThemeAttributes = {
-    // $FlowFixMe - [object-literal] - This issue is a valid union as we are building this object where there aren't always attributes for optional.
     ...filteredRequiredAttributes,
     ...filteredOptionalAttributes,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11691,9 +11691,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.134.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.134.0.tgz",
-      "integrity": "sha512-j5aCugO3jmwDsUKc+7KReArgnL6aVjHLo6DlozKhxKYN+TaP8BY+mintPSISjSQtKZFJyvoNAc1oXA79X5WjIA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.107.0.tgz",
+      "integrity": "sha512-hsmwO5Q0+XUXaO2kIKLpleUNNBSFcsGEQGBOTEC/KR/4Ez695I1fweX/ioSjbU4RWhPZhkIqnpbF9opVAauCHg==",
       "dev": true
     },
     "flush-write-stream": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-flowtype": "^4.0.0",
     "eslint-plugin-react-hooks": "^4.1.0",
     "eslint_d": "^8.1.1",
-    "flow-bin": "^0.134.0",
+    "flow-bin": "^0.107.0",
     "globby": "^11.0.1",
     "husky": "^4.0.2",
     "jest": "^26.4.2",


### PR DESCRIPTION
This reverts commit abaa881a82e08619cc48f0b492641f63a0d2c74b.

We found that due to our Flow version being much higher than react native it was actually causing us to change types which were actually incorrect and meant that we would be not following correct types.

As part of this investigation and decision we have added a decision log that for all future flow version upgrades we should be aligning our version to the same version as React Native to ensure that we are correctly using their types.