### PR TITLE
[BPK-4284] Fix backpack-ios dependency

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+ - The `backpack-ios` dependency is now only locked to major version, instead of major and minor version.
 
 ## How to write a good changelog entry
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,8 +4,8 @@ PODS:
     - FSCalendar (~> 2.8)
     - MBProgressHUD (~> 0.9.1)
     - TTTAttributedLabel (~> 1.13.4)
-  - BackpackReactNative (10.0.0):
-    - Backpack (~> 38.0.0)
+  - BackpackReactNative (11.0.0):
+    - Backpack (~> 38.0)
     - React
     - react-native-maps
     - ReactNativeDarkMode
@@ -345,7 +345,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Backpack: 9153d9b64c407f38d57fa2c01c1e248b8fa6d089
-  BackpackReactNative: a8cefd22c1885f97180941dd6062c8b27462d0e7
+  BackpackReactNative: 6e56a788f68d7c9fca3502c190a8771a28e56720
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2

--- a/lib/ios/BackpackReactNative/BackpackReactNative.podspec
+++ b/lib/ios/BackpackReactNative/BackpackReactNative.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'react-native-maps'
   s.dependency 'ReactNativeDarkMode'
-  s.dependency 'Backpack', '~> 38.0.0'
+  s.dependency 'Backpack', '~> 38.0'
 end


### PR DESCRIPTION
This was broken in [this change](https://github.com/Skyscanner/backpack-react-native/commit/a2be01f9e8f70b4ca00090a866104a167d614246#diff-3eec611701a22e8fa36afe52da83484169b97ff2358cc5bd539d6a6147c41843R21). We should only specify the major version, not the minor or patch 👍 

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
