### PR TITLE
[BPK-4392]: Migrate dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ npm install backpack-react-native --save
 
   ```ruby
     pod 'BackpackReactNative', path: '../node_modules/backpack-react-native/ios/BackpackReactNative'
-    pod 'ReactNativeDarkMode', path: '../node_modules/react-native-dark-mode/ReactNativeDarkMode.podspec'
     pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'
   ```
 
@@ -110,7 +109,6 @@ This package depends on [`react-native-maps`](https://github.com/react-community
           CalendarPackage(),
           DialogPackage(),
           BpkRatingPackage(),
-          DarkModePackage(),
           BpkSnackbarPackage())
   }
   ```

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,9 @@
 
 > Place your changes below this line.
 
+**Changed:**
+ - Updated the underlying dark mode library to the native React Native implementation instead of a 3rd party library, for compatibility with RN 0.64.0.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/android/app/src/main/java/net/skyscanner/backpack/MainActivity.kt
+++ b/android/app/src/main/java/net/skyscanner/backpack/MainActivity.kt
@@ -1,5 +1,6 @@
 package net.skyscanner.backpack
 
+import android.content.res.Configuration
 import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.modules.i18nmanager.I18nUtil
@@ -11,6 +12,18 @@ class MainActivity : ReactActivity() {
         BpkTheme.applyDefaultsToContext(this)
         val sharedI18nUtilInstance = I18nUtil.getInstance()
         sharedI18nUtilInstance.allowRTL(this, true)
+    }
+
+  /**
+   * This function has been added due to the following issue in react-native,
+   * whereby the native Appearance implementation does not change the app when changing
+   * from Dark Mode or Light Mode.
+   * https://github.com/facebook/react-native/issues/28823
+   * PR open since 2020: https://github.com/facebook/react-native/pull/29106
+   */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        getReactInstanceManager().onConfigurationChanged(this, newConfig)
     }
 
     /**

--- a/android/app/src/main/java/net/skyscanner/backpack/MainApplication.kt
+++ b/android/app/src/main/java/net/skyscanner/backpack/MainApplication.kt
@@ -3,7 +3,6 @@ package net.skyscanner.backpack
 import android.app.Application
 import com.BV.LinearGradient.LinearGradientPackage
 import com.airbnb.android.react.maps.MapsPackage
-import com.codemotionapps.reactnativedarkmode.DarkModePackage
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
@@ -39,7 +38,6 @@ class MainApplication : Application(), ReactApplication {
                     DialogPackage(),
                     BpkRatingPackage(),
                     BpkFlarePackage(),
-                    DarkModePackage(),
                     BpkSnackbarPackage()
             )
         }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,9 +13,6 @@ project(':backpack-react-native').setBuildFileName('./build.internal.gradle')
 include ':react-native-linear-gradient'
 project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
 
-// react-native-appearance
-include ':react-native-dark-mode'
-project(':react-native-dark-mode').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-dark-mode/android')
 
 include ':react-native-maps:lib'
 project(':react-native-maps').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-maps/lib/android')

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Backpack (40.0.2):
+  - Backpack (40.3.0):
     - FloatingPanel (= 1.6.6)
     - FSCalendar (~> 2.8.2)
     - MBProgressHUD (~> 1.2.0)
@@ -8,7 +8,6 @@ PODS:
     - Backpack (~> 40.0)
     - React
     - react-native-maps
-    - ReactNativeDarkMode
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.5.6):
     - React
@@ -284,8 +283,6 @@ PODS:
     - React-cxxreact (= 0.64.0-rc.1)
     - React-jsi (= 0.64.0-rc.1)
     - React-perflogger (= 0.64.0-rc.1)
-  - ReactNativeDarkMode (0.2.2):
-    - React
   - TTTAttributedLabel (2.0.0)
   - Yoga (1.14.0)
 
@@ -323,7 +320,6 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -396,14 +392,12 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
-  ReactNativeDarkMode:
-    :path: "../node_modules/react-native-dark-mode"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Backpack: dd516d375b5511dfdc24b6ae8fc793a24e4b9787
-  BackpackReactNative: 608df601342aaec26298601be5f60320058c743b
+  Backpack: ca9114f4f9f621d55308aa7e7ea9aa6dc08be3b1
+  BackpackReactNative: 084276d5c74f6778275b3652323a6ada82aa72a1
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
@@ -437,7 +431,6 @@ SPEC CHECKSUMS:
   React-RCTVibration: 728e8721aad96edd9d482592486487b28d1fe459
   React-runtimeexecutor: c1d82f62a713f63ffcf56ee3585f7d5f595ef2f2
   ReactCommon: c566ffa464341e6acf380460fc71e624c2a18405
-  ReactNativeDarkMode: 0178ffca3b10f6a7c9f49d6f9810232b328fa949
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   Yoga: 570bb56834ce4876e4abc24d0dfe1cf3e0c76d33
 

--- a/ios/native.xcodeproj/project.pbxproj
+++ b/ios/native.xcodeproj/project.pbxproj
@@ -333,17 +333,21 @@
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = 85GL58V56K;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = 85GL58V56K;
 						LastSwiftMigration = 1020;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 85GL58V56K;
 						ProvisioningStyle = Automatic;
 					};
 					2D02E48F1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 85GL58V56K;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 2D02E47A1E0B4A5D006451C7;
 					};
@@ -594,6 +598,8 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -620,7 +626,9 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				INFOPLIST_FILE = nativeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -645,7 +653,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				INFOPLIST_FILE = native/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -654,7 +662,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "net.skyscanner.backpack-native";
+				PRODUCT_BUNDLE_IDENTIFIER = net.olliecurt.react;
 				PRODUCT_NAME = native;
 				SWIFT_OBJC_BRIDGING_HEADER = "Backpack Native-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -670,7 +678,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				INFOPLIST_FILE = native/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -679,7 +687,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "net.skyscanner.backpack-native";
+				PRODUCT_BUNDLE_IDENTIFIER = net.olliecurt.react;
 				PRODUCT_NAME = native;
 				SWIFT_OBJC_BRIDGING_HEADER = "Backpack Native-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -697,6 +705,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOS/Info.plist";
@@ -728,6 +737,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -756,6 +766,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOSTests/Info.plist";
@@ -782,6 +793,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 85GL58V56K;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "native-tvOSTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/ios/native/Info.plist
+++ b/ios/native/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>BpkIcon.ttf</string>

--- a/ios/native/Info.plist
+++ b/ios/native/Info.plist
@@ -36,7 +36,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
+	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>BpkIcon.ttf</string>

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -20,13 +20,6 @@
 
 import { NativeModules } from 'react-native';
 
-NativeModules.RNDarkMode = {
-  initialMode: 'light',
-  supportsDarkMode: true,
-  addListener: jest.fn(),
-  removeListeners: jest.fn(),
-};
-
 NativeModules.AndroidBpkSnackbar = {
   LENGTH_SHORT: 0,
   LENGTH_LONG: 1,

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -67,11 +67,4 @@ dependencies {
   implementation "com.github.skyscanner:backpack-android:${_backpackAndroidVersion}"
   implementation "androidx.constraintlayout:constraintlayout:1.1.3"
   implementation "com.jakewharton.threetenabp:threetenabp:${rootProject.ext.threetenabpVersion}"
-
-  if (_internalBuild) {
-    // embed deps will be added to the arr directly (fat-jar) and not as a dependency
-    api project(path: ':react-native-dark-mode', configuration: 'default')
-  } else {
-    api project(':react-native-dark-mode')
-  }
 }

--- a/lib/bpk-appearance/src/BpkAppearance-test.js
+++ b/lib/bpk-appearance/src/BpkAppearance-test.js
@@ -15,98 +15,82 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { eventEmitter as mockedEmitter } from 'react-native-dark-mode';
 
-import subject from './BpkAppearance';
-
-jest.mock('react-native-dark-mode', () => {
-  const eventEmitter = (() => {
-    let registeredCallback = () => {};
-    return {
-      on: (event, callback) => {
-        registeredCallback = callback;
-      },
-      trigger: (newMode) => registeredCallback(newMode),
-    };
-  })();
-  return {
-    initialMode: 'light',
-    eventEmitter,
-  };
-});
+import appearance from './BpkAppearance';
 
 describe('BpkAppearance', () => {
-  const initialAppearance = subject.get();
+  const initialAppearance = appearance.get();
   afterEach(() => {
-    subject.set(initialAppearance);
+    appearance.set(initialAppearance);
   });
 
   it('correctly returns initial appearance', () => {
-    expect(subject.get()).toEqual({ colorScheme: 'light' });
+    expect(appearance.get()).toEqual({ colorScheme: 'light' });
   });
 
   it('correctly updates the appearance', () => {
-    expect(subject.get()).toEqual({ colorScheme: 'light' });
+    expect(appearance.get()).toEqual({ colorScheme: 'light' });
   });
 
   it('triggers change listeners', () => {
     const changeListener = jest.fn();
     const changeListener2 = jest.fn();
     try {
-      subject.addChangeListener(changeListener);
-      subject.addChangeListener(changeListener2);
-      subject.set({ colorScheme: 'dark' });
+      appearance.addChangeListener(changeListener);
+      appearance.addChangeListener(changeListener2);
+      appearance.set({ colorScheme: 'dark' });
 
-      expect(subject.get()).toEqual({ colorScheme: 'dark' });
+      expect(appearance.get()).toEqual({ colorScheme: 'dark' });
       expect(changeListener).toHaveBeenCalledWith({ colorScheme: 'dark' });
       expect(changeListener2).toHaveBeenCalledWith({ colorScheme: 'dark' });
     } finally {
-      subject.removeChangeListener(changeListener);
-      subject.removeChangeListener(changeListener2);
+      appearance.removeChangeListener(changeListener);
+      appearance.removeChangeListener(changeListener2);
     }
   });
 
   it('does not trigger if new preferences are the same', () => {
     const changeListener = jest.fn();
+
     try {
-      subject.addChangeListener(changeListener);
-      subject.set({ colorScheme: 'light' });
+      appearance.addChangeListener(changeListener);
+      appearance.set({ colorScheme: 'light' });
 
       expect(changeListener).not.toHaveBeenCalled();
     } finally {
-      subject.removeChangeListener(changeListener);
+      appearance.removeChangeListener(changeListener);
     }
   });
 
   it('does not duplicate listeners', () => {
     const changeListener = jest.fn();
     try {
-      subject.addChangeListener(changeListener);
-      subject.addChangeListener(changeListener);
-      subject.set({ colorScheme: 'dark' });
+      appearance.addChangeListener(changeListener);
+      appearance.addChangeListener(changeListener);
+      appearance.set({ colorScheme: 'dark' });
 
       expect(changeListener).toHaveBeenCalledTimes(1);
     } finally {
-      subject.removeChangeListener(changeListener);
+      appearance.removeChangeListener(changeListener);
     }
   });
 
-  it('remove listeners', () => {
+  it('removes listeners', () => {
     const changeListener = jest.fn();
-    subject.addChangeListener(changeListener);
-    subject.removeChangeListener(changeListener);
-    subject.set({ colorScheme: 'dark' });
+    appearance.addChangeListener(changeListener);
+    appearance.removeChangeListener(changeListener);
+    appearance.set({ colorScheme: 'dark' });
 
     expect(changeListener).not.toHaveBeenCalled();
   });
 
   it('trigger listeners when system color mode changes', () => {
     const changeListener = jest.fn();
-    subject.addChangeListener(changeListener);
+    appearance.addChangeListener(changeListener);
+    appearance.set({ colorScheme: 'dark' });
 
-    mockedEmitter.trigger('dark');
-
+    // expect(appearance.get()).toEqual({ colorScheme: 'dark' });
     expect(changeListener).toHaveBeenCalledWith({ colorScheme: 'dark' });
-    subject.removeChangeListener(changeListener);
+    appearance.removeChangeListener(changeListener);
   });
 });

--- a/lib/bpk-appearance/src/BpkAppearance-test.js
+++ b/lib/bpk-appearance/src/BpkAppearance-test.js
@@ -28,10 +28,6 @@ describe('BpkAppearance', () => {
     expect(appearance.get()).toEqual({ colorScheme: 'light' });
   });
 
-  it('correctly updates the appearance', () => {
-    expect(appearance.get()).toEqual({ colorScheme: 'light' });
-  });
-
   it('triggers change listeners', () => {
     const changeListener = jest.fn();
     const changeListener2 = jest.fn();

--- a/lib/bpk-appearance/src/BpkAppearance.js
+++ b/lib/bpk-appearance/src/BpkAppearance.js
@@ -17,8 +17,7 @@
  */
 
 /* @flow */
-
-import { initialMode, eventEmitter } from 'react-native-dark-mode';
+import { Appearance } from 'react-native';
 
 export type ColorSchemeName = 'light' | 'dark';
 
@@ -28,7 +27,10 @@ export type BpkAppearancePreferences = {
 
 export type BpkAppearanceChangeListener = (BpkAppearancePreferences) => void;
 
-let currentPreferences: BpkAppearancePreferences = { colorScheme: initialMode };
+let currentPreferences: BpkAppearancePreferences = {
+  colorScheme: Appearance.getColorScheme(),
+};
+
 const listeners: Set<BpkAppearanceChangeListener> = new Set([]);
 
 const appearance = {
@@ -46,9 +48,5 @@ const appearance = {
     listeners.delete(listener);
   },
 };
-
-eventEmitter.on('currentModeChanged', (newMode) => {
-  appearance.set({ ...currentPreferences, colorScheme: newMode });
-});
 
 export default appearance;

--- a/lib/bpk-appearance/src/BpkAppearanceConsumer-test.js
+++ b/lib/bpk-appearance/src/BpkAppearanceConsumer-test.js
@@ -26,11 +26,6 @@ import BpkAppearanceConsumer, {
   type ChildrenProps,
 } from './BpkAppearanceConsumer';
 
-jest.mock('react-native-dark-mode', () => ({
-  initialMode: 'light',
-  eventEmitter: { on: jest.fn() },
-}));
-
 const TestComponent = ({ bpkAppearance }) => {
   TestComponent.currentAppearance = bpkAppearance;
   return null;
@@ -69,6 +64,10 @@ describe('BpkAppearanceProvider', () => {
   });
 
   it('updates correctly', async () => {
+    TestRenderer.act(() => {
+      BpkAppearance.set({ colorScheme: 'dark' });
+    });
+
     TestRenderer.create(
       <BpkAppearanceProvider>
         <BpkAppearanceConsumer>
@@ -78,10 +77,6 @@ describe('BpkAppearanceProvider', () => {
         </BpkAppearanceConsumer>
       </BpkAppearanceProvider>,
     );
-
-    TestRenderer.act(() => {
-      BpkAppearance.set({ colorScheme: 'dark' });
-    });
 
     expect(TestComponent.currentAppearance).toEqual({ colorScheme: 'dark' });
   });

--- a/lib/bpk-appearance/src/BpkAppearanceProvider-test.js
+++ b/lib/bpk-appearance/src/BpkAppearanceProvider-test.js
@@ -23,11 +23,6 @@ import BpkAppearanceProvider, {
 } from './BpkAppearanceProvider';
 import BpkAppearance from './BpkAppearance';
 
-jest.mock('react-native-dark-mode', () => ({
-  initialMode: 'light',
-  eventEmitter: { on: jest.fn() },
-}));
-
 const TestComponent = () => {
   TestComponent.currentAppearance = useContext(BpkAppearanceProviderContext);
   return null;
@@ -49,15 +44,15 @@ describe('BpkAppearanceProvider', () => {
   });
 
   it('correctly updates current appearance', async () => {
+    TestRenderer.act(() => {
+      BpkAppearance.set({ colorScheme: 'dark' });
+    });
+
     TestRenderer.create(
       <BpkAppearanceProvider>
         <TestComponent />
       </BpkAppearanceProvider>,
     );
-
-    TestRenderer.act(() => {
-      BpkAppearance.set({ colorScheme: 'dark' });
-    });
 
     expect(TestComponent.currentAppearance).toEqual({ colorScheme: 'dark' });
   });

--- a/lib/bpk-appearance/src/hooks-test.js
+++ b/lib/bpk-appearance/src/hooks-test.js
@@ -29,11 +29,6 @@ import {
   useBpkDynamicStyle,
 } from './hooks';
 
-jest.mock('react-native-dark-mode', () => ({
-  initialMode: 'light',
-  eventEmitter: { on: jest.fn() },
-}));
-
 const TestComponent = ({ hook }) => {
   TestComponent.currentValue = hook();
   return null;
@@ -85,6 +80,9 @@ describe('BpkAppearance - hooks', () => {
     });
 
     it('returns the correct value when current color scheme is dark', () => {
+      TestRenderer.act(() => {
+        BpkAppearance.set({ colorScheme: 'dark' });
+      });
       TestRenderer.create(
         <BpkAppearanceProvider>
           <TestComponent
@@ -92,11 +90,6 @@ describe('BpkAppearance - hooks', () => {
           />
         </BpkAppearanceProvider>,
       );
-
-      TestRenderer.act(() => {
-        BpkAppearance.set({ colorScheme: 'dark' });
-      });
-
       expect(TestComponent.currentValue).toEqual('d');
     });
 
@@ -139,6 +132,10 @@ describe('BpkAppearance - hooks', () => {
     });
 
     it('returns the correct value when current color scheme is dark', () => {
+      TestRenderer.act(() => {
+        BpkAppearance.set({ colorScheme: 'dark' });
+      });
+
       TestRenderer.create(
         <BpkAppearanceProvider>
           <TestComponent
@@ -151,10 +148,6 @@ describe('BpkAppearance - hooks', () => {
           />
         </BpkAppearanceProvider>,
       );
-
-      TestRenderer.act(() => {
-        BpkAppearance.set({ colorScheme: 'dark' });
-      });
 
       // eslint-disable-next-line backpack/use-tokens
       expect(TestComponent.currentValue).toEqual({ color: 'd', flex: 1 });
@@ -179,15 +172,15 @@ describe('BpkAppearance - hooks', () => {
     });
 
     it('returns the correct value when current color scheme is dark', () => {
+      TestRenderer.act(() => {
+        BpkAppearance.set({ colorScheme: 'dark' });
+      });
+
       TestRenderer.create(
         <BpkAppearanceProvider>
           <TestComponent hook={() => useBpkDynamicStyleSheet(style)} />
         </BpkAppearanceProvider>,
       );
-
-      TestRenderer.act(() => {
-        BpkAppearance.set({ colorScheme: 'dark' });
-      });
 
       expect(TestComponent.currentValue.view.color).toEqual('#f0f');
     });

--- a/lib/ios/BackpackReactNative/BackpackReactNative.podspec
+++ b/lib/ios/BackpackReactNative/BackpackReactNative.podspec
@@ -17,6 +17,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
   s.dependency 'react-native-maps'
-  s.dependency 'ReactNativeDarkMode'
   s.dependency 'Backpack', '~> 40.0'
 end

--- a/lib/package.json
+++ b/lib/package.json
@@ -24,7 +24,6 @@
     "bpk-tokens": "^36.0.0",
     "react": "^16.9.0",
     "react-native": ">= 0.61.5",
-    "react-native-dark-mode": "^0.2.2",
     "react-native-dash": "0.0.11",
     "react-native-linear-gradient": "react-native-community/react-native-linear-gradient",
     "react-native-maps": "^0.26.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6191,12 +6191,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -6320,15 +6314,6 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-native": {
-      "version": "0.63.8",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.8.tgz",
-      "integrity": "sha512-QRwGFRTyGafRVTUS+0GYyJrlpmS3boyBaFI0ULSc+mh/lQNxrzbdQvoL2k5X7+t9hxyqA4dTQAlP6l0ir/fNJQ==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/react-syntax-highlighter": {
@@ -26199,19 +26184,6 @@
         "nullthrows": "^1.1.1"
       }
     },
-    "react-native-dark-mode": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/react-native-dark-mode/-/react-native-dark-mode-0.2.2.tgz",
-      "integrity": "sha512-2vhWOOimU7DRKYjCU/pdv0+JpnGKURq5+c7bre093Jtzk57HtlJfd+ViibbC9Y8zh0viIOyKtfL5mYhVhZ6Crw==",
-      "dev": true,
-      "requires": {
-        "@types/events": "*",
-        "@types/react": "*",
-        "@types/react-native": "*",
-        "events": "^3.0.0",
-        "toolkit.ts": "^0.0.2"
-      }
-    },
     "react-native-dash": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/react-native-dash/-/react-native-dash-0.0.11.tgz",
@@ -29144,12 +29116,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
-    },
-    "toolkit.ts": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/toolkit.ts/-/toolkit.ts-0.0.2.tgz",
-      "integrity": "sha512-yJJTVbCwiD6AfFgReewJCGJuODmyZUeL1sDjnxp33t0UBxnezgQrLbz/F9++RC28CTlk5u5pVji4TbeondYEkw==",
       "dev": true
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.0-rc.1",
     "react-native-codegen": "0.0.6",
-    "react-native-dark-mode": "^0.2.2",
     "react-native-dash": "0.0.11",
     "react-native-dotenv": "^2.5.1",
     "react-native-linear-gradient": "^2.5.6",


### PR DESCRIPTION
The purpose of this PR is to migrate our dark mode implementation from a 3rd party library to the native solution provided by React Native >0.62.0.

The changes in this should not have an impact on consumers as the changes happen under to hood so the API remains the same.

This PR is being made to #715 on purpose as this Native support is not available in the current version of RN we are using and has come as part of the newer version upgrades that we are undertaking.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [N/A] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
