### PR TITLE
[BPK-4433] Calendar accessibility improvements(iOS)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+**Breaking:**
+
+- Improved accessibility of the calendar, `BpkCalendar`. When setting the `selectionType` prop it's no longer enough to use e.g. `SELECTION_TYPES.single`. Instead of `SELECTION_TYPES` there are three new functions to use: `makeSingleSelection`, `makeRangeSelection`, `makeMultipleSelection`. These expect a few additional string arguments for assistive technology users. Read more in the [migration guide](docs/14.0.0-calendar-accessibility-migration.md)
+
+
+
 > Place your changes below this line.
 
 ## How to write a good changelog entry

--- a/docs/14.0.0-calendar-accessibility-migration.md
+++ b/docs/14.0.0-calendar-accessibility-migration.md
@@ -1,0 +1,162 @@
+# 14.0.0 BpkCalendar Migration Guide
+
+This guide explains how to migrate use of `BpkCalendar` in the `14.0.0` release.
+
+In common for all the scenarios described below is the fact that you'll need to provide more strings for accessibility purposes. These strings should be localised in the traveller's language.
+
+
+**Note:** All of the relevant strings are required, this is enforced via prop types and Flow. The component will throw an error if any are missing or empty.
+
+## Single Selection
+
+Single selection is the simplest case.
+
+### Before
+
+```javascript
+import React, { Component } from 'react';
+import BpkCalendar, { SELECTION_TYPES } from 'backpack-react-native/bpk-component-calendar';
+
+const MyCalendar = (props) => <BpkCalendar selectionType={SELECTION_TYPES.single} {...rest} />;
+
+```
+
+### After
+
+```javascript
+import React, { Component } from 'react';
+import BpkCalendar, { makeSingleSelection } from 'backpack-react-native/bpk-component-calendar';
+
+const singleSelection = makeSingleSelection({
+
+  // `CALENDAR_SINGLE_SELECT_HINT_LABEL` should be a string that provides a
+  // hint to the user on how to select a date.
+  //
+  // English example: "Double tap to select date"
+  selectHint: I18n.translate('CALENDAR_SINGLE_SELECT_HINT_LABEL'),
+});
+
+const MyCalendar = (props) => <BpkCalendar selectionType={singleSelection} {...rest} />;
+
+```
+
+## Range Selection
+
+Range selection is very complex and requires quite a few strings to provide a good screen reader experience.
+
+### Before
+
+```javascript
+import React, { Component } from 'react';
+import BpkCalendar, { SELECTION_TYPES } from 'backpack-react-native/bpk-component-calendar';
+
+const MyCalendar = (props) => <BpkCalendar selectionType={SELECTION_TYPES.range} {...rest} />;
+
+```
+
+### After
+
+```javascript
+import React, { Component } from 'react';
+import BpkCalendar, { makeRangeSelection } from 'backpack-react-native/bpk-component-calendar';
+
+const rangeSelection = makeRangeSelection({
+
+  // `CALENDAR_RANGE_SELECT_HINT_LABEL` should be
+  // a hint that is read out to screen reader users
+  // when no dates have been selected. Should explain how
+  // to select the start date i.e. by double tapping.
+  //
+  // English example: "Double tap to select departure date"
+  startDateSelectHint: I18n.translate('CALENDAR_RANGE_START_DATE_SELECT_HINT_LABEL'),
+
+  // `CALENDAR_RANGE_END_DATE_SELECT_HINT_LABEL` should be
+  // a hint that is read out to screen reader users
+  // when only the start date has been selected. Should explain how
+  // to select the end date i.e. by double tapping.
+  //
+  // English example: "Double tap to select return date"
+  endDateSelectHint: I18n.translate('CALENDAR_RANGE_END_DATE_SELECT_HINT_LABEL'),
+
+  // CALENDAR_RANGE_START_DATE_SELECTED_STATE_LABEL should be
+  // a string that is read out to screen reader users
+  // when the selected start date has focus.
+  //
+  // English example: "Selected as departure date"
+  startDateSelectedState: I18n.translate('CALENDAR_RANGE_START_DATE_SELECTED_STATE_LABEL'),
+
+  // CALENDAR_RANGE_END_DATE_SELECTED_STATE_LABEL should be
+  // a string that is read out to screen reader users
+  // when the selected end date has focus.
+  //
+  // English example: "Selected as return date"
+  endDateSelectedState: I18n.translate('CALENDAR_RANGE_END_DATE_SELECTED_STATE_LABEL'),
+
+  // CALENDAR_RANGE_END_AND_START_DATE_SELECTED_STATE_LABEL should be
+  // a string that is read out to screen reader users
+  // when the selected end date is the same as the start date and
+  // this date has focus.
+  //
+  // English example: "Selected as both departure and return date"
+  endAndStartDateSelectedState: I18n.translate('CALENDAR_RANGE_END_AND_START_DATE_SELECTED_STATE_LABEL'),
+
+  // CALENDAR_RANGE_DATE_BETWEEN_START_AND_END_SELECTED_STATE_LABEL
+  // should be a string that is read out to screen reader users
+  // when a date between the start and end date has focus. e.g.
+  // when the start date is 01/03/2021 and the end date is 05/03/2021
+  // and the date with focus is 03/03/2021.
+  //
+  // English example: "Selected between departure and return date"
+  dateBetweenStartAndEndSelectedState: I18n.translate('CALENDAR_RANGE_DATE_BETWEEN_START_AND_END_SELECTED_STATE_LABEL'),
+
+  // CALENDAR_RANGE_NEXT_SELECTION_PROMPT_LABEL should be
+  // a prompt that is read out to screen reader users
+  // when a start date is selected. Should explain to the user
+  // that they should select an end date for the range.
+  //
+  // English example: "Now select a return date (if required)"
+  makeNextSelectionPrompt: I18n.translate('CALENDAR_RANGE_NEXT_SELECTION_PROMPT_LABEL'),
+});
+
+const MyCalendar = (props) => <BpkCalendar selectionType={rangeSelection} {...rest} />;
+
+```
+
+## Multiple Selection
+
+
+### Before
+
+```javascript
+import React, { Component } from 'react';
+import BpkCalendar, { SELECTION_TYPES } from 'backpack-react-native/bpk-component-calendar';
+
+const MyCalendar = (props) => <BpkCalendar selectionType={SELECTION_TYPES.multiple} {...rest} />;
+
+```
+
+### After
+
+```javascript
+import React, { Component } from 'react';
+import BpkCalendar, { makeMultipleSelection } from 'backpack-react-native/bpk-component-calendar';
+
+const multipleSelection = makeMultipleSelection({
+
+  // `CALENDAR_SINGLE_SELECT_HINT_LABEL` should be a string that provides a
+  // hint to the user on how to select a date.
+  //
+  // English example: "Double tap to select date"
+  selectHint: I18n.translate('CALENDAR_SINGLE_SELECT_HINT_LABEL'),
+
+  // `CALENDAR_SINGLE_DESELECT_HINT_LABEL` should be a string that provides a
+  // hint to the user on how to deselect a selected date.
+  //
+  // English example: "Double tap to deselect date"
+  selectHint: I18n.translate('CALENDAR_SINGLE_DESELECT_HINT_LABEL'),
+});
+
+const MyCalendar = (props) => <BpkCalendar selectionType={multipleSelection} {...rest} />;
+
+```
+

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,7 +37,7 @@ target 'Backpack Native' do
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec', :modular_headers => false
 
   # RN Bridging Pods
-  pod 'Backpack', '~> 41.0'
+  pod 'Backpack', '~> 42.0'
   pod 'BackpackReactNative', path: '../node_modules/backpack-react-native/ios/BackpackReactNative', :modular_headers => false
 
   # Third party pods

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Backpack (41.0.0):
+  - Backpack (42.0.0):
     - FloatingPanel (= 1.6.6)
     - FSCalendar (~> 2.8.2)
     - MBProgressHUD (~> 1.2.0)
     - TTTAttributedLabel (~> 2.0.0)
   - BackpackReactNative (13.0.2):
-    - Backpack (~> 41.0)
+    - Backpack (~> 42.0)
     - React
     - react-native-maps
     - ReactNativeDarkMode
@@ -240,7 +240,7 @@ PODS:
   - Yoga (1.14.0)
 
 DEPENDENCIES:
-  - Backpack (~> 41.0)
+  - Backpack (~> 42.0)
   - BackpackReactNative (from `../node_modules/backpack-react-native/ios/BackpackReactNative`)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -344,8 +344,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Backpack: f5338180ddc0d38ba47efe76aa549e1ac1ca8f91
-  BackpackReactNative: 6d381bfb814db9755deaa07caa62f3f08eae0bb6
+  Backpack: dbf1705684a494f9e26f87c5b38369349639aca2
+  BackpackReactNative: 44a291617ce1d72e22342cc05c2142d62009a159
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
@@ -380,6 +380,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
-PODFILE CHECKSUM: ea99fb9069ff4b627019026755c861e7d8d1c9f9
+PODFILE CHECKSUM: e66bdae243cb801e73d1a7e9a6e3928c8b2f4832
 
 COCOAPODS: 1.8.4

--- a/lib/bpk-component-calendar/index.js
+++ b/lib/bpk-component-calendar/index.js
@@ -19,7 +19,15 @@
 /* @flow */
 
 import BpkCalendar, { type Props } from './src/BpkCalendar';
-import { SELECTION_TYPES, type SelectionType } from './src/common-types';
+import {
+  makeSingleSelection,
+  makeRangeSelection,
+  makeMultipleSelection,
+  type SelectionType,
+  type SelectionTypeSingle,
+  type SelectionTypeRange,
+  type SelectionTypeMultiple,
+} from './src/common-types';
 import DateMatchers, { type DateMatcher } from './src/DateMatchers';
 import colorBucket, {
   colorBucketNegative,
@@ -37,6 +45,9 @@ import {
 export type {
   Props as BpkCalendarProps,
   SelectionType as BpkCalendarSelectionType,
+  SelectionTypeSingle as BpkCalendarSelectionTypeSingle,
+  SelectionTypeRange as BpkCalendarSelectionTypeRange,
+  SelectionTypeMultiple as BpkCalendarSelectionTypeMultiple,
   DateMatcher as BpkCalendarDateMatcher,
   ColorBucket as BpkCalendarColorBucket,
   FooterView as BpkCalendarFooterView,
@@ -45,7 +56,9 @@ export type {
 
 export default BpkCalendar;
 export {
-  SELECTION_TYPES,
+  makeSingleSelection,
+  makeRangeSelection,
+  makeMultipleSelection,
   DateMatchers,
   colorBucket,
   colorBucketNegative,

--- a/lib/bpk-component-calendar/src/BpkCalendar-test.common.js
+++ b/lib/bpk-component-calendar/src/BpkCalendar-test.common.js
@@ -24,9 +24,33 @@ import { colorSagano, colorPanjin } from 'bpk-tokens/tokens/base.react.native';
 
 import DateMatchers from './DateMatchers';
 import BpkCalendar from './BpkCalendar';
-import { SELECTION_TYPES } from './common-types';
+import {
+  makeSingleSelection,
+  makeRangeSelection,
+  makeMultipleSelection,
+} from './common-types';
 import colorBucket from './colorBucket';
 import { highlightedDaysFooterView } from './footerView';
+
+const singleSelection = makeSingleSelection({
+  selectHint: 'Double tap to select date',
+});
+
+const rangeSelection = makeRangeSelection({
+  startDateSelectHint: 'Double tap to select departure date',
+  endDateSelectHint: 'Double tap to select return date',
+  startDateSelectedState: 'Selected as departure date',
+  endDateSelectedState: 'Selected as return date',
+  endAndStartDateSelectedState: 'Selected as both departure and return date',
+  dateBetweenStartAndEndSelectedState:
+    'Selected between departure and return date',
+  makeNextSelectionPrompt: 'Now select a return date',
+});
+
+const multipleSelection = makeMultipleSelection({
+  selectHint: 'Double tap to select date',
+  deselectHint: 'Double tap to deselect date',
+});
 
 const defaultProps = {
   locale: 'en_GB',
@@ -37,10 +61,7 @@ const commonTests = () => {
     it('should render correctly', () => {
       const tree = renderer
         .create(
-          <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
-            {...defaultProps}
-          />,
+          <BpkCalendar selectionType={singleSelection} {...defaultProps} />,
         )
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -50,7 +71,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             minDate={new Date(Date.UTC(2019, 4, 19))}
           />,
@@ -63,7 +84,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             maxDate={new Date(Date.UTC(2020, 4, 19))}
           />,
@@ -76,7 +97,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             minDate={new Date(Date.UTC(2019, 4, 19))}
             maxDate={new Date(Date.UTC(2020, 4, 19))}
@@ -90,7 +111,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             selectedDates={[new Date(Date.UTC(2019, 4, 19))]}
             {...defaultProps}
           />,
@@ -103,7 +124,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.range}
+            selectionType={rangeSelection}
             selectedDates={[
               new Date(Date.UTC(2019, 4, 19)),
               new Date(Date.UTC(2019, 4, 21)),
@@ -119,7 +140,7 @@ const commonTests = () => {
       jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
       renderer.create(
         <BpkCalendar
-          selectionType={SELECTION_TYPES.single}
+          selectionType={singleSelection}
           selectedDates={[new Date(2019, 4, 19), new Date(2019, 4, 20)]}
           {...defaultProps}
         />,
@@ -131,7 +152,7 @@ const commonTests = () => {
       expect(() => {
         renderer.create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             minDate={new Date(2020, 4, 19)}
             maxDate={new Date(2019, 4, 19)}
             {...defaultProps}
@@ -144,7 +165,7 @@ const commonTests = () => {
       jest.spyOn(console, 'error').mockImplementation(() => jest.fn());
       renderer.create(
         <BpkCalendar
-          selectionType={SELECTION_TYPES.range}
+          selectionType={rangeSelection}
           selectedDates={[
             new Date(2019, 4, 19),
             new Date(2019, 4, 20),
@@ -160,7 +181,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.multiple}
+            selectionType={multipleSelection}
             selectedDates={[
               new Date(Date.UTC(2019, 4, 19)),
               new Date(Date.UTC(2019, 4, 21)),
@@ -173,16 +194,18 @@ const commonTests = () => {
       expect(tree).toMatchSnapshot();
     });
 
-    Object.keys(SELECTION_TYPES).forEach((selectionType) => {
-      it(`should render correctly for selectionType={'${selectionType}'}`, () => {
-        const tree = renderer
-          .create(
-            <BpkCalendar selectionType={selectionType} {...defaultProps} />,
-          )
-          .toJSON();
-        expect(tree).toMatchSnapshot();
-      });
-    });
+    [singleSelection, rangeSelection, multipleSelection].forEach(
+      (selectionType) => {
+        it(`should render correctly for selectionType={'${selectionType.type}'}`, () => {
+          const tree = renderer
+            .create(
+              <BpkCalendar selectionType={selectionType} {...defaultProps} />,
+            )
+            .toJSON();
+          expect(tree).toMatchSnapshot();
+        });
+      },
+    );
 
     it('should render correctly with custom style', () => {
       const styles = StyleSheet.create({
@@ -194,7 +217,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             style={styles.custom}
           />,
@@ -207,7 +230,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             testID="123" // <- Arbitrary prop.
           />,
@@ -221,7 +244,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             disabledDates={DateMatchers.after(Date.UTC(2019, 11, 16))}
           />,
@@ -234,7 +257,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             colorBuckets={[
               colorBucket(
@@ -257,7 +280,7 @@ const commonTests = () => {
       const tree = renderer
         .create(
           <BpkCalendar
-            selectionType={SELECTION_TYPES.single}
+            selectionType={singleSelection}
             {...defaultProps}
             androidFooterView={highlightedDaysFooterView({
               days: [

--- a/lib/bpk-component-calendar/src/__snapshots__/BpkCalendar-test.android.js.snap
+++ b/lib/bpk-component-calendar/src/__snapshots__/BpkCalendar-test.android.js.snap
@@ -8,7 +8,12 @@ exports[`Android BpkCalendar should render correctly 1`] = `
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -21,7 +26,13 @@ exports[`Android BpkCalendar should render correctly for selectionType={'multipl
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="multiple"
+  selectionType={
+    Object {
+      "deselectHint": "Double tap to deselect date",
+      "selectHint": "Double tap to select date",
+      "type": "multiple",
+    }
+  }
   style={null}
 />
 `;
@@ -34,7 +45,18 @@ exports[`Android BpkCalendar should render correctly for selectionType={'range'}
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="range"
+  selectionType={
+    Object {
+      "dateBetweenStartAndEndSelectedState": "Selected between departure and return date",
+      "endAndStartDateSelectedState": "Selected as both departure and return date",
+      "endDateSelectHint": "Double tap to select return date",
+      "endDateSelectedState": "Selected as return date",
+      "makeNextSelectionPrompt": "Now select a return date",
+      "startDateSelectHint": "Double tap to select departure date",
+      "startDateSelectedState": "Selected as departure date",
+      "type": "range",
+    }
+  }
   style={null}
 />
 `;
@@ -47,7 +69,12 @@ exports[`Android BpkCalendar should render correctly for selectionType={'single'
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -71,7 +98,12 @@ exports[`Android BpkCalendar should render correctly with androidFooterView 1`] 
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -84,7 +116,12 @@ exports[`Android BpkCalendar should render correctly with arbitrary props 1`] = 
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
   testID="123"
 />
@@ -98,7 +135,12 @@ exports[`Android BpkCalendar should render correctly with both minDate and maxDa
   minDate={1558224000}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -135,7 +177,12 @@ exports[`Android BpkCalendar should render correctly with color buckets 1`] = `
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -148,7 +195,12 @@ exports[`Android BpkCalendar should render correctly with custom style 1`] = `
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={
     Object {
       "flex": 1,
@@ -172,7 +224,12 @@ exports[`Android BpkCalendar should render correctly with disabled dates 1`] = `
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -185,7 +242,12 @@ exports[`Android BpkCalendar should render correctly with maxDate 1`] = `
   minDate={null}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -198,7 +260,12 @@ exports[`Android BpkCalendar should render correctly with minDate 1`] = `
   minDate={1558224000}
   onChange={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -216,7 +283,13 @@ exports[`Android BpkCalendar should render correctly with selection type "multip
       1558396800,
     ]
   }
-  selectionType="multiple"
+  selectionType={
+    Object {
+      "deselectHint": "Double tap to deselect date",
+      "selectHint": "Double tap to select date",
+      "type": "multiple",
+    }
+  }
   style={null}
 />
 `;
@@ -234,7 +307,18 @@ exports[`Android BpkCalendar should render correctly with selection type "range"
       1558396800,
     ]
   }
-  selectionType="range"
+  selectionType={
+    Object {
+      "dateBetweenStartAndEndSelectedState": "Selected between departure and return date",
+      "endAndStartDateSelectedState": "Selected as both departure and return date",
+      "endDateSelectHint": "Double tap to select return date",
+      "endDateSelectedState": "Selected as return date",
+      "makeNextSelectionPrompt": "Now select a return date",
+      "startDateSelectHint": "Double tap to select departure date",
+      "startDateSelectedState": "Selected as departure date",
+      "type": "range",
+    }
+  }
   style={null}
 />
 `;
@@ -251,7 +335,12 @@ exports[`Android BpkCalendar should render correctly with selection type "single
       1558224000,
     ]
   }
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;

--- a/lib/bpk-component-calendar/src/__snapshots__/BpkCalendar-test.ios.js.snap
+++ b/lib/bpk-component-calendar/src/__snapshots__/BpkCalendar-test.ios.js.snap
@@ -8,7 +8,12 @@ exports[`iOS BpkCalendar should render correctly 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -21,7 +26,13 @@ exports[`iOS BpkCalendar should render correctly for selectionType={'multiple'} 
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="multiple"
+  selectionType={
+    Object {
+      "deselectHint": "Double tap to deselect date",
+      "selectHint": "Double tap to select date",
+      "type": "multiple",
+    }
+  }
   style={null}
 />
 `;
@@ -34,7 +45,18 @@ exports[`iOS BpkCalendar should render correctly for selectionType={'range'} 1`]
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="range"
+  selectionType={
+    Object {
+      "dateBetweenStartAndEndSelectedState": "Selected between departure and return date",
+      "endAndStartDateSelectedState": "Selected as both departure and return date",
+      "endDateSelectHint": "Double tap to select return date",
+      "endDateSelectedState": "Selected as return date",
+      "makeNextSelectionPrompt": "Now select a return date",
+      "startDateSelectHint": "Double tap to select departure date",
+      "startDateSelectedState": "Selected as departure date",
+      "type": "range",
+    }
+  }
   style={null}
 />
 `;
@@ -47,7 +69,12 @@ exports[`iOS BpkCalendar should render correctly for selectionType={'single'} 1`
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -71,7 +98,12 @@ exports[`iOS BpkCalendar should render correctly with androidFooterView 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -84,7 +116,12 @@ exports[`iOS BpkCalendar should render correctly with arbitrary props 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
   testID="123"
 />
@@ -98,7 +135,12 @@ exports[`iOS BpkCalendar should render correctly with both minDate and maxDate 1
   minDate={1558224000000}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -135,7 +177,12 @@ exports[`iOS BpkCalendar should render correctly with color buckets 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -148,7 +195,12 @@ exports[`iOS BpkCalendar should render correctly with custom style 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={
     Object {
       "flex": 1,
@@ -172,7 +224,12 @@ exports[`iOS BpkCalendar should render correctly with disabled dates 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -185,7 +242,12 @@ exports[`iOS BpkCalendar should render correctly with maxDate 1`] = `
   minDate={null}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -198,7 +260,12 @@ exports[`iOS BpkCalendar should render correctly with minDate 1`] = `
   minDate={1558224000000}
   onDateSelection={[Function]}
   selectedDates={Array []}
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;
@@ -217,7 +284,13 @@ exports[`iOS BpkCalendar should render correctly with selection type "multiple" 
       1559088000000,
     ]
   }
-  selectionType="multiple"
+  selectionType={
+    Object {
+      "deselectHint": "Double tap to deselect date",
+      "selectHint": "Double tap to select date",
+      "type": "multiple",
+    }
+  }
   style={null}
 />
 `;
@@ -235,7 +308,18 @@ exports[`iOS BpkCalendar should render correctly with selection type "range" and
       1558396800000,
     ]
   }
-  selectionType="range"
+  selectionType={
+    Object {
+      "dateBetweenStartAndEndSelectedState": "Selected between departure and return date",
+      "endAndStartDateSelectedState": "Selected as both departure and return date",
+      "endDateSelectHint": "Double tap to select return date",
+      "endDateSelectedState": "Selected as return date",
+      "makeNextSelectionPrompt": "Now select a return date",
+      "startDateSelectHint": "Double tap to select departure date",
+      "startDateSelectedState": "Selected as departure date",
+      "type": "range",
+    }
+  }
   style={null}
 />
 `;
@@ -252,7 +336,12 @@ exports[`iOS BpkCalendar should render correctly with selection type "single" an
       1558224000000,
     ]
   }
-  selectionType="single"
+  selectionType={
+    Object {
+      "selectHint": "Double tap to select date",
+      "type": "single",
+    }
+  }
   style={null}
 />
 `;

--- a/lib/bpk-component-calendar/src/common-types-test.js
+++ b/lib/bpk-component-calendar/src/common-types-test.js
@@ -1,0 +1,135 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @flow
+
+import {
+  assertString,
+  makeSingleSelection,
+  makeRangeSelection,
+  makeMultipleSelection,
+} from './common-types';
+
+describe('common-types', () => {
+  describe('assertStrings', () => {
+    it('throws when a key is missing', () => {
+      expect(() => {
+        assertString({ a: 'hello' }, 'b', 'myTest');
+      }).toThrow();
+    });
+
+    it('throws when the value for a key is empty', () => {
+      expect(() => {
+        assertString({ a: 'hello', b: '' }, 'b', 'myTest');
+      }).toThrow();
+    });
+
+    it('does not throw when the key is present with a non-empty value', () => {
+      expect(() => {
+        assertString({ a: 'hello', b: 'test' }, 'b', 'myTest');
+      }).not.toThrow();
+    });
+  });
+
+  describe('makeSingleSelection', () => {
+    it('should return an appropriate object', () => {
+      expect(makeSingleSelection({ selectHint: 'Test' })).toEqual({
+        type: 'single',
+        selectHint: 'Test',
+      });
+    });
+
+    it('should throw when `selectHint` is missing', () => {
+      expect(() => {
+        // NOTE: We intentionally disable flow here as the purpose
+        // of this test is to verify that the underlying code throws
+        // in this case.
+        // $FlowFixMe
+        makeSingleSelection({});
+      }).toThrow();
+    });
+  });
+
+  describe('makeMultipleSelection', () => {
+    let expectedArgs;
+
+    beforeEach(() => {
+      expectedArgs = ['selectHint', 'deselectHint'].reduce((acc, k) => {
+        acc[k] = `Test_${k}`;
+        return acc;
+      }, {});
+    });
+
+    it('should return an appropriate object', () => {
+      expect(makeMultipleSelection(expectedArgs)).toEqual({
+        type: 'multiple',
+        selectHint: 'Test_selectHint',
+        deselectHint: 'Test_deselectHint',
+      });
+    });
+
+    it('should throw when one key is missing', () => {
+      delete expectedArgs.deselectHint;
+
+      expect(() => {
+        makeMultipleSelection(expectedArgs);
+      }).toThrow();
+    });
+  });
+
+  describe('makeRangeSelection', () => {
+    let expectedArgs;
+
+    beforeEach(() => {
+      expectedArgs = [
+        'startDateSelectHint',
+        'endDateSelectHint',
+        'startDateSelectedState',
+        'endDateSelectedState',
+        'endAndStartDateSelectedState',
+        'dateBetweenStartAndEndSelectedState',
+        'makeNextSelectionPrompt',
+      ].reduce((acc, k) => {
+        acc[k] = `Test_${k}`;
+        return acc;
+      }, {});
+    });
+
+    it('should return an appropriate object', () => {
+      expect(makeRangeSelection(expectedArgs)).toEqual({
+        type: 'range',
+        dateBetweenStartAndEndSelectedState:
+          'Test_dateBetweenStartAndEndSelectedState',
+        endAndStartDateSelectedState: 'Test_endAndStartDateSelectedState',
+        endDateSelectHint: 'Test_endDateSelectHint',
+        endDateSelectedState: 'Test_endDateSelectedState',
+        makeNextSelectionPrompt: 'Test_makeNextSelectionPrompt',
+        startDateSelectHint: 'Test_startDateSelectHint',
+        startDateSelectedState: 'Test_startDateSelectedState',
+      });
+    });
+
+    it('should throw when one key is missing', () => {
+      delete expectedArgs.endDateSelectHint;
+
+      expect(() => {
+        makeRangeSelection(expectedArgs);
+      }).toThrow();
+    });
+  });
+});

--- a/lib/bpk-component-calendar/src/common-types.js
+++ b/lib/bpk-component-calendar/src/common-types.js
@@ -30,13 +30,148 @@ import { type FooterView } from './footerView';
 type ViewProps = ElementProps<typeof View>;
 type ViewStyleProp = $PropertyType<ViewProps, 'style'>;
 
-export const SELECTION_TYPES = {
-  single: 'single',
-  range: 'range',
-  multiple: 'multiple',
+// NOTE: This array needs to be kept in sync with
+// SelectionTypeSingle below.
+//
+// TODO: Figure out if there's a way to create the
+// type SelectionTypeSingle from this array instead of
+// having duplication.
+const SINGLE_SELECTION_PROPS = ['selectHint'];
+export type SelectionTypeSingle = {|
+  +type: 'single',
+
+  // A hint that is read out to screen reader users
+  // when focus is on an unselected date. Should explain how
+  // to select the date i.e. by double tapping.
+  +selectHint: string,
+|};
+
+// NOTE: This array needs to be kept in sync with
+// SelectionTypeRange below.
+//
+// TODO: Figure out if there's a way to create the
+// type SelectionTypeRange from this array instead of
+// having duplication.
+const RANGE_SELECTION_PROPS = [
+  'startDateSelectHint',
+  'endDateSelectHint',
+  'startDateSelectedState',
+  'endDateSelectedState',
+  'endAndStartDateSelectedState',
+  'dateBetweenStartAndEndSelectedState',
+  'makeNextSelectionPrompt',
+];
+
+export type SelectionTypeRange = {|
+  +type: 'range',
+
+  // A hint that is read out to screen reader users
+  // when no dates have been selected. Should explain how
+  // to select the start date i.e. by double tapping.
+  +startDateSelectHint: string,
+
+  // A hint that is read out to screen reader users
+  // when only the start date has been selected. Should explain how
+  // to select the end date i.e. by double tapping.
+  +endDateSelectHint: string,
+
+  // A string that is read out to screen reader users
+  // when the selected start date has focus.
+  +startDateSelectedState: string,
+
+  // A string that is read out to screen reader users
+  // when the selected end date has focus.
+  +endDateSelectedState: string,
+
+  // A string that is read out to screen reader users
+  // when the selected end date is the same as the start date and
+  // this date has focus.
+  +endAndStartDateSelectedState: string,
+
+  // A string that is read out to screen reader users
+  // when a date between the start and end date has focus. e.g.
+  // when the start date is 01/03/2021 and the end date is 05/03/2021
+  // and the date with focus is 03/03/2021.
+  +dateBetweenStartAndEndSelectedState: string,
+
+  // A prompt that is read out to screen reader users
+  // when a start date is selected. Should explain to the user
+  // that they should select an end date for the range.
+  +makeNextSelectionPrompt: string,
+|};
+
+// NOTE: This array needs to be kept in sync with
+// SelectionTypeMultiple below.
+//
+// TODO: Figure out if there's a way to create the
+// type SelectionTypeMultiple from this array instead of
+// having duplication.
+const MULTIPLE_SELECTION_PROPS = ['selectHint', 'deselectHint'];
+export type SelectionTypeMultiple = {|
+  +type: 'multiple',
+
+  // A hint that is read out to screen reader users
+  // when focus is on an unselected date. Should explain how
+  // to select the date i.e. by double tapping.
+  +selectHint: string,
+
+  // A hint that is read out to screen reader users
+  // when focus is on a selected date. Should explain how
+  // to unselect the date i.e. by double tapping.
+  +deselectHint: string,
+|};
+
+export type SelectionType =
+  | SelectionTypeSingle
+  | SelectionTypeRange
+  | SelectionTypeMultiple;
+
+export const assertString = (
+  object: { [string]: string },
+  key: string,
+  fn: string,
+): void => {
+  if (!Object.prototype.hasOwnProperty.call(object, key)) {
+    throw new Error(`Missing key \`${key}\` in argument for \`${fn}\``);
+  }
+
+  if (object[key].length === 0) {
+    throw new Error(
+      `Value of \`${key}\` in argument for \`${fn}\` cannot be empty`,
+    );
+  }
 };
 
-export type SelectionType = $Keys<typeof SELECTION_TYPES>;
+export const makeSingleSelection = (
+  strings: $Exact<$Diff<SelectionTypeSingle, {| type: 'single' |}>>,
+): SelectionType => {
+  SINGLE_SELECTION_PROPS.forEach((key) =>
+    assertString(strings, key, 'makeSingleSelection'),
+  );
+
+  return { type: 'single', ...strings };
+};
+
+export const makeRangeSelection = (
+  strings: $Exact<$Diff<SelectionTypeRange, {| type: 'range' |}>>,
+): SelectionType => {
+  RANGE_SELECTION_PROPS.forEach((key) =>
+    assertString(strings, key, 'makeRangeSelection'),
+  );
+
+  return { type: 'range', ...strings };
+};
+
+export const makeMultipleSelection = (
+  strings: $Exact<$Diff<SelectionTypeMultiple, {| type: 'multiple' |}>>,
+): SelectionType => {
+  MULTIPLE_SELECTION_PROPS.forEach((key) =>
+    assertString(strings, key, 'makeMultipleSelection'),
+  );
+
+  return { type: 'multiple', ...strings };
+};
+
 export type SelectedDatesChanged = ?(Date[]) => mixed;
 export type NativeEvent = SyntheticEvent<
   $ReadOnly<{| selectedDates: number[] |}>,
@@ -80,18 +215,12 @@ const selectedDatesPropType = (
 ) => {
   if (props[propName]) {
     const selectedDatesCount = props[propName].length;
-    if (
-      props.selectionType === SELECTION_TYPES.single &&
-      selectedDatesCount > 1
-    ) {
+    if (props.selectionType.type === 'single' && selectedDatesCount > 1) {
       return new Error(
         `${componentName}: When "selectionType" is "single", only supply one date to "selectedDates"`,
       );
     }
-    if (
-      props.selectionType === SELECTION_TYPES.range &&
-      selectedDatesCount > 2
-    ) {
+    if (props.selectionType.type === 'range' && selectedDatesCount > 2) {
       return new Error(
         `${componentName}: When "selectionType" is "range", only supply one or two dates to "selectedDates"`,
       );
@@ -116,7 +245,29 @@ export const commonPropTypes = {
   maxDate: datePropType,
   onChangeSelectedDates: PropTypes.func,
   selectedDates: selectedDatesPropType,
-  selectionType: PropTypes.oneOf(Object.keys(SELECTION_TYPES)),
+  selectionType: PropTypes.oneOfType([
+    PropTypes.shape({
+      type: PropTypes.oneOf(['single']),
+      ...SINGLE_SELECTION_PROPS.reduce((acc, k) => {
+        acc[k] = PropTypes.string.isRequired;
+        return acc;
+      }, {}),
+    }),
+    PropTypes.shape({
+      type: PropTypes.oneOf(['range']),
+      ...RANGE_SELECTION_PROPS.reduce((acc, k) => {
+        acc[k] = PropTypes.string.isRequired;
+        return acc;
+      }, {}),
+    }),
+    PropTypes.shape({
+      type: PropTypes.oneOf(['multiple']),
+      ...MULTIPLE_SELECTION_PROPS.reduce((acc, k) => {
+        acc[k] = PropTypes.string.isRequired;
+        return acc;
+      }, {}),
+    }),
+  ]).isRequired,
   style: ViewPropTypes.style,
   androidFooterView: PropTypes.object,
 };
@@ -126,7 +277,6 @@ export const commonDefaultProps = {
   maxDate: null,
   onChangeSelectedDates: null,
   selectedDates: [],
-  selectionType: SELECTION_TYPES.single,
   style: null,
   disabledDates: null,
   colorBuckets: undefined,

--- a/lib/bpk-component-calendar/stories.js
+++ b/lib/bpk-component-calendar/stories.js
@@ -36,7 +36,9 @@ import BpkText from '../bpk-component-text';
 import CenterDecorator from '../../storybook/CenterDecorator';
 
 import BpkCalendar, {
-  SELECTION_TYPES,
+  makeSingleSelection,
+  makeRangeSelection,
+  makeMultipleSelection,
   DateMatchers,
   colorBucket,
   colorBucketNegative,
@@ -69,6 +71,32 @@ const styles = StyleSheet.create({
 const locales = {
   en_GB: 'en-gb',
   pt_BR: 'pt-br',
+};
+
+const singleSelection = makeSingleSelection({
+  selectHint: 'Double tap to select date',
+});
+
+const rangeSelection = makeRangeSelection({
+  startDateSelectHint: 'Double tap to select departure date',
+  endDateSelectHint: 'Double tap to select return date',
+  startDateSelectedState: 'Selected as departure date',
+  endDateSelectedState: 'Selected as return date',
+  endAndStartDateSelectedState: 'Selected as both departure and return date',
+  dateBetweenStartAndEndSelectedState:
+    'Selected between departure and return date',
+  makeNextSelectionPrompt: 'Now select a return date',
+});
+
+const multipleSelection = makeMultipleSelection({
+  selectHint: 'Double tap to select date',
+  deselectHint: 'Double tap to deselect date',
+});
+
+const selectionOptions = {
+  single: singleSelection,
+  range: rangeSelection,
+  multiple: multipleSelection,
 };
 
 const padLeft = (number) => {
@@ -229,7 +257,7 @@ class ExampleWithLinkedInputs extends Component<
         )}
         <BpkCalendarExample
           style={styles.calendar}
-          selectionType={range ? SELECTION_TYPES.range : SELECTION_TYPES.single}
+          selectionType={range ? rangeSelection : singleSelection}
           selectedDates={this.state.selectedDates}
           onChangeSelectedDates={this.handleNewDates}
         />
@@ -287,8 +315,11 @@ const CalendarWithPicker = (props: CalendarWithPickerProps) => {
 };
 
 const ChangeableSelectionTypeStory = () => {
-  const options = Object.keys(SELECTION_TYPES).reduce(
-    (acc, type) => ({ ...acc, [type]: { value: type, label: type } }),
+  const options = Object.keys(selectionOptions).reduce(
+    (acc, type) => ({
+      ...acc,
+      [type]: { value: type, label: type },
+    }),
     {},
   );
 
@@ -297,7 +328,7 @@ const ChangeableSelectionTypeStory = () => {
       {({ selectedValue }) => (
         <BpkCalendarExample
           style={styles.calendar}
-          selectionType={(selectedValue: any)}
+          selectionType={selectionOptions[selectedValue]}
         />
       )}
     </CalendarWithPicker>
@@ -309,19 +340,19 @@ storiesOf('bpk-component-calendar', module)
   .add('docs:single', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.single}
+      selectionType={singleSelection}
     />
   ))
   .add('docs:multiple', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.multiple}
+      selectionType={multipleSelection}
     />
   ))
   .add('docs:range', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.range}
+      selectionType={rangeSelection}
     />
   ))
   .add('Changeable selection type', () => <ChangeableSelectionTypeStory />)
@@ -334,7 +365,7 @@ storiesOf('bpk-component-calendar', module)
   .add('With min and max dates', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.single}
+      selectionType={singleSelection}
       minDate={new Date(Date.UTC(today.getFullYear(), 0, 2))}
       maxDate={new Date(Date.UTC(today.getFullYear() + 1, 11, 31))}
     />
@@ -342,7 +373,7 @@ storiesOf('bpk-component-calendar', module)
   .add('With selected dates (UTC)', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.range}
+      selectionType={rangeSelection}
       minDate={new Date(Date.UTC(today.getFullYear(), 0, 2))}
       maxDate={new Date(Date.UTC(today.getFullYear() + 1, 11, 31))}
       initiallySelectedDates={[
@@ -354,7 +385,7 @@ storiesOf('bpk-component-calendar', module)
   .add('With selected dates (UTC number)', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.range}
+      selectionType={rangeSelection}
       minDate={Date.UTC(today.getFullYear(), 0, 2)}
       maxDate={Date.UTC(today.getFullYear() + 1, 11, 31)}
       initiallySelectedDates={[
@@ -366,7 +397,7 @@ storiesOf('bpk-component-calendar', module)
   .add('With different locale', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.single}
+      selectionType={singleSelection}
       locale={locales.pt_BR}
     />
   ))
@@ -381,7 +412,7 @@ storiesOf('bpk-component-calendar', module)
         {({ selectedValue }) => (
           <BpkCalendarExample
             style={styles.calendar}
-            selectionType={SELECTION_TYPES.range}
+            selectionType={rangeSelection}
             minDate={minDate}
             maxDate={maxDate}
             disabledDates={dateMatchers[selectedValue].descriptor}
@@ -401,7 +432,7 @@ storiesOf('bpk-component-calendar', module)
       <BpkCalendarExample
         onChangeSelectedDates={setSelectedDates}
         style={styles.calendarOnly}
-        selectionType={SELECTION_TYPES.range}
+        selectionType={rangeSelection}
         minDate={new Date(Date.UTC(today.getFullYear(), 0, 2))}
         maxDate={new Date(Date.UTC(today.getFullYear() + 1, 11, 31))}
         disabledDates={disabledDates || null}
@@ -419,7 +450,7 @@ storiesOf('bpk-component-calendar', module)
         {({ selectedValue }) => (
           <BpkCalendarExample
             style={styles.calendarOnly}
-            selectionType={SELECTION_TYPES.range}
+            selectionType={rangeSelection}
             minDate={minDate}
             maxDate={maxDate}
             colorBuckets={[
@@ -457,7 +488,7 @@ storiesOf('bpk-component-calendar', module)
     return (
       <BpkCalendarExample
         style={styles.calendarOnly}
-        selectionType={SELECTION_TYPES.range}
+        selectionType={rangeSelection}
         minDate={minDate}
         maxDate={maxDate}
         colorBuckets={buckets}
@@ -467,7 +498,7 @@ storiesOf('bpk-component-calendar', module)
   .add('Footer view: Highlighted days', () => (
     <BpkCalendarExample
       style={styles.calendarOnly}
-      selectionType={SELECTION_TYPES.range}
+      selectionType={rangeSelection}
       minDate={new Date(Date.UTC(today.getFullYear(), 0, 2))}
       maxDate={new Date(Date.UTC(today.getFullYear() + 1, 11, 31))}
       colorBuckets={[

--- a/lib/ios/BackpackReactNative/BackpackReactNative.podspec
+++ b/lib/ios/BackpackReactNative/BackpackReactNative.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'react-native-maps'
   s.dependency 'ReactNativeDarkMode'
-  s.dependency 'Backpack', '~> 41.0'
+  s.dependency 'Backpack', '~> 42.0'
 end


### PR DESCRIPTION
This PR adopts and aligns RN with the accessibility improvements on iOS. It doesn't change anything about Android. Sibling PR: https://github.com/Skyscanner/backpack-ios/pull/919

My plan is that we'll evolve the api to require consumers to call one of the `make*` functions with the appropriate arguments required by Flow etc.

Usage is would be something like 

```javascript
<BpkCalendar selectionType={makeSingleSelection(I18n.localize('CALENDAR_SINGLE_SELECTION_HINT')} {..rest}
```

I'm mostly interested in a review of this API. For a consumer the change will be switching from something like `SELECTION_TYPES.single` to the above. 

Other options:

* Make each selection type a JS class with the same flow typing. Would require a `new` which doesn't really work nicely inside the middle of a component being rendered. This could possibly mean we don't need the `_type` field as we could use `instanceof`. However, we still need something like `_type` to distinguish between the different kinds on the native side.


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/main/CONTRIBUTING.md)

Remember to include the following changes:

+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Create a migration guide
+ [x] Write tests for `assertStrings` and other new introductions in `common-types.js`
+ [x] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
