### PR TITLE
[KOA-4486]: Adding new zIndex prop to map markers

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -328,6 +328,7 @@ BpkDynamicStyleProp
 pickerContentRef
 onShow
 React.Ref
+zIndex
 
 # Sizes
 xs

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,10 +1,8 @@
 # Unreleased
 
-**Breaking:**
-
-- Improved accessibility of the calendar, `BpkCalendar`. When setting the `selectionType` prop it's no longer enough to use e.g. `SELECTION_TYPES.single`. Instead of `SELECTION_TYPES` there are three new functions to use: `makeSingleSelection`, `makeRangeSelection`, `makeMultipleSelection`. These expect a few additional string arguments for assistive technology users. Read more in the [migration guide](docs/14.0.0-calendar-accessibility-migration.md)
-
-
+**Added:**
+  - bpk-component-map:
+    - Added new `zIndex` prop to map, to control position of markers.
 
 > Place your changes below this line.
 

--- a/lib/bpk-component-map/README.md
+++ b/lib/bpk-component-map/README.md
@@ -120,6 +120,7 @@ export default class App extends Component {
 | longitude | number | true | - |
 | disabled | bool | false | false |
 | status | oneOf(`PRICE_MARKER_STATUSES.default`, `PRICE_MARKER_STATUSES.focused`, `PRICE_MARKER_STATUSES.viewed`) | false | `PRICE_MARKER_STATUSES.default` |
+| zIndex | number | false | null |
 
 #### BpkIconMarker
 
@@ -130,3 +131,4 @@ export default class App extends Component {
 | longitude | number | true | - |
 | disabled | bool | false | false |
 | status | oneOf(`ICON_MARKER_STATUSES.default`, `ICON_MARKER_STATUSES.focused`) | false | `ICON_MARKER_STATUSES.default` |
+| zIndex | number | false | null |

--- a/lib/bpk-component-map/src/BpkIconMarker-test.common.js
+++ b/lib/bpk-component-map/src/BpkIconMarker-test.common.js
@@ -51,6 +51,13 @@ const commonTests = () => {
         expect(tree).toMatchSnapshot();
       });
 
+      it('should render correctly with zIndex', () => {
+        const tree = renderer
+          .create(<WithColorScheme {...requiredProps} zIndex={1000} />)
+          .toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+
       Object.keys(ICON_MARKER_STATUSES).forEach((status) => {
         it(`should render correctly with status=${status}`, () => {
           const tree = renderer

--- a/lib/bpk-component-map/src/BpkIconMarker.android.js
+++ b/lib/bpk-component-map/src/BpkIconMarker.android.js
@@ -39,7 +39,15 @@ import {
 const dynamicStyles = BpkDynamicStyleSheet.create(androidStyles);
 
 const BpkIconMarker = (props: Props) => {
-  const { disabled, icon, latitude, longitude, onPress, status } = props;
+  const {
+    disabled,
+    icon,
+    latitude,
+    longitude,
+    onPress,
+    status,
+    zIndex,
+  } = props;
   const styles = useBpkDynamicStyleSheet(dynamicStyles);
 
   const wrapperStyles = [styles.wrapper];
@@ -69,6 +77,7 @@ const BpkIconMarker = (props: Props) => {
       style={styles.marker}
       coordinate={{ latitude, longitude }}
       onPress={onPressFn}
+      zIndex={zIndex}
     >
       <View style={pointerStyles} />
       <View style={wrapperStyles}>

--- a/lib/bpk-component-map/src/BpkIconMarker.ios.js
+++ b/lib/bpk-component-map/src/BpkIconMarker.ios.js
@@ -39,7 +39,15 @@ import {
 const dynamicStyles = BpkDynamicStyleSheet.create(iOSStyles);
 
 const BpkIconMarker = (props: Props) => {
-  const { disabled, icon, latitude, longitude, onPress, status } = props;
+  const {
+    disabled,
+    icon,
+    latitude,
+    longitude,
+    onPress,
+    status,
+    zIndex,
+  } = props;
   const styles = useBpkDynamicStyleSheet(dynamicStyles);
 
   const wrapperStyles = [styles.wrapper];
@@ -65,7 +73,11 @@ const BpkIconMarker = (props: Props) => {
   };
 
   return (
-    <Marker coordinate={{ latitude, longitude }} onPress={onPressFn}>
+    <Marker
+      coordinate={{ latitude, longitude }}
+      onPress={onPressFn}
+      zIndex={zIndex}
+    >
       <View style={wrapperStyles}>
         <View style={underlayStyles} />
         <View style={pointerStyles} />

--- a/lib/bpk-component-map/src/BpkPriceMarker-test.common.js
+++ b/lib/bpk-component-map/src/BpkPriceMarker-test.common.js
@@ -49,6 +49,13 @@ const commonTests = () => {
         expect(tree).toMatchSnapshot();
       });
 
+      it('should render correctly with zIndex', () => {
+        const tree = renderer
+          .create(<WithColorScheme {...requiredProps} zIndex={1000} />)
+          .toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+
       Object.keys(PRICE_MARKER_STATUSES).forEach((status) => {
         it(`should render correctly with status=${status}`, () => {
           const tree = renderer

--- a/lib/bpk-component-map/src/BpkPriceMarker.js
+++ b/lib/bpk-component-map/src/BpkPriceMarker.js
@@ -122,10 +122,19 @@ export type Props = {
   longitude: number,
   onPress: () => mixed,
   status: $Keys<typeof PRICE_MARKER_STATUSES>,
+  zIndex?: ?number,
 };
 
 const BpkPriceMarker = (props: Props) => {
-  const { disabled, label, latitude, longitude, onPress, status } = props;
+  const {
+    disabled,
+    label,
+    latitude,
+    longitude,
+    onPress,
+    status,
+    zIndex,
+  } = props;
 
   const styles = useBpkDynamicStyleSheet(dynamicStyles);
 
@@ -159,7 +168,11 @@ const BpkPriceMarker = (props: Props) => {
   };
 
   return (
-    <Marker coordinate={{ latitude, longitude }} onPress={onPressFn}>
+    <Marker
+      coordinate={{ latitude, longitude }}
+      onPress={onPressFn}
+      zIndex={zIndex}
+    >
       <View style={wrapperStyles}>
         <View style={pointerStyles} />
         <View style={underlayStyles} />
@@ -181,11 +194,13 @@ BpkPriceMarker.propTypes = {
   longitude: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
   status: PropTypes.oneOf(Object.keys(PRICE_MARKER_STATUSES)),
+  zIndex: PropTypes.number,
 };
 
 BpkPriceMarker.defaultProps = {
   disabled: false,
   status: PRICE_MARKER_STATUSES.default,
+  zIndex: null,
 };
 
 export default BpkPriceMarker;

--- a/lib/bpk-component-map/src/__snapshots__/BpkIconMarker-test.android.js.snap
+++ b/lib/bpk-component-map/src/__snapshots__/BpkIconMarker-test.android.js.snap
@@ -22,6 +22,7 @@ exports[`Android dark mode dark mode should render correctly 1`] = `
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -124,6 +125,7 @@ exports[`Android dark mode dark mode should render correctly with disabled={true
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -235,6 +237,7 @@ exports[`Android dark mode dark mode should render correctly with status=default
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -337,6 +340,7 @@ exports[`Android dark mode dark mode should render correctly with status=focused
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -447,6 +451,109 @@ exports[`Android dark mode dark mode should render correctly with status=focused
 </AIRMapMarker>
 `;
 
+exports[`Android dark mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      Object {
+        "paddingHorizontal": 8,
+        "paddingVertical": 8,
+      },
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(0, 166, 152)",
+          "borderRadius": 4,
+          "bottom": 5,
+          "height": 16,
+          "left": "50%",
+          "position": "absolute",
+          "transform": Array [
+            Object {
+              "rotate": "45deg",
+            },
+          ],
+          "width": 16,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`Android dark mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -469,6 +576,7 @@ exports[`Android dark mode light mode should render correctly 1`] = `
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -571,6 +679,7 @@ exports[`Android dark mode light mode should render correctly with disabled={tru
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -682,6 +791,7 @@ exports[`Android dark mode light mode should render correctly with status=defaul
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -784,6 +894,7 @@ exports[`Android dark mode light mode should render correctly with status=focuse
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -894,6 +1005,109 @@ exports[`Android dark mode light mode should render correctly with status=focuse
 </AIRMapMarker>
 `;
 
+exports[`Android dark mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      Object {
+        "paddingHorizontal": 8,
+        "paddingVertical": 8,
+      },
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(0, 166, 152)",
+          "borderRadius": 4,
+          "bottom": 5,
+          "height": 16,
+          "left": "50%",
+          "position": "absolute",
+          "transform": Array [
+            Object {
+              "rotate": "45deg",
+            },
+          ],
+          "width": 16,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`Android light mode dark mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -916,6 +1130,7 @@ exports[`Android light mode dark mode should render correctly 1`] = `
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1018,6 +1233,7 @@ exports[`Android light mode dark mode should render correctly with disabled={tru
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1129,6 +1345,7 @@ exports[`Android light mode dark mode should render correctly with status=defaul
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1231,6 +1448,7 @@ exports[`Android light mode dark mode should render correctly with status=focuse
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1341,6 +1559,109 @@ exports[`Android light mode dark mode should render correctly with status=focuse
 </AIRMapMarker>
 `;
 
+exports[`Android light mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      Object {
+        "paddingHorizontal": 8,
+        "paddingVertical": 8,
+      },
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(0, 166, 152)",
+          "borderRadius": 4,
+          "bottom": 5,
+          "height": 16,
+          "left": "50%",
+          "position": "absolute",
+          "transform": Array [
+            Object {
+              "rotate": "45deg",
+            },
+          ],
+          "width": 16,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`Android light mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -1363,6 +1684,7 @@ exports[`Android light mode light mode should render correctly 1`] = `
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1465,6 +1787,7 @@ exports[`Android light mode light mode should render correctly with disabled={tr
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1576,6 +1899,7 @@ exports[`Android light mode light mode should render correctly with status=defau
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1678,6 +2002,7 @@ exports[`Android light mode light mode should render correctly with status=focus
       },
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1777,6 +2102,109 @@ exports[`Android light mode light mode should render correctly with status=focus
             },
             Object {
               "color": "rgb(0, 166, 152)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
+exports[`Android light mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      Object {
+        "paddingHorizontal": 8,
+        "paddingVertical": 8,
+      },
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "rgb(0, 166, 152)",
+          "borderRadius": 4,
+          "bottom": 5,
+          "height": 16,
+          "left": "50%",
+          "position": "absolute",
+          "transform": Array [
+            Object {
+              "rotate": "45deg",
+            },
+          ],
+          "width": 16,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
             },
           ],
         ]

--- a/lib/bpk-component-map/src/__snapshots__/BpkIconMarker-test.ios.js.snap
+++ b/lib/bpk-component-map/src/__snapshots__/BpkIconMarker-test.ios.js.snap
@@ -19,6 +19,7 @@ exports[`iOS dark mode dark mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -118,6 +119,7 @@ exports[`iOS dark mode dark mode should render correctly with disabled={true} 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -226,6 +228,7 @@ exports[`iOS dark mode dark mode should render correctly with status=default 1`]
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -325,6 +328,7 @@ exports[`iOS dark mode dark mode should render correctly with status=focused 1`]
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -435,6 +439,106 @@ exports[`iOS dark mode dark mode should render correctly with status=focused 1`]
 </AIRMapMarker>
 `;
 
+exports[`iOS dark mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 4,
+            "bottom": -3,
+            "height": 16,
+            "left": "38%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`iOS dark mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -454,6 +558,7 @@ exports[`iOS dark mode light mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -553,6 +658,7 @@ exports[`iOS dark mode light mode should render correctly with disabled={true} 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -661,6 +767,7 @@ exports[`iOS dark mode light mode should render correctly with status=default 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -760,6 +867,7 @@ exports[`iOS dark mode light mode should render correctly with status=focused 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -870,6 +978,106 @@ exports[`iOS dark mode light mode should render correctly with status=focused 1`
 </AIRMapMarker>
 `;
 
+exports[`iOS dark mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 4,
+            "bottom": -3,
+            "height": 16,
+            "left": "38%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`iOS light mode dark mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -889,6 +1097,7 @@ exports[`iOS light mode dark mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -988,6 +1197,7 @@ exports[`iOS light mode dark mode should render correctly with disabled={true} 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1096,6 +1306,7 @@ exports[`iOS light mode dark mode should render correctly with status=default 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1195,6 +1406,7 @@ exports[`iOS light mode dark mode should render correctly with status=focused 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1305,6 +1517,106 @@ exports[`iOS light mode dark mode should render correctly with status=focused 1`
 </AIRMapMarker>
 `;
 
+exports[`iOS light mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 4,
+            "bottom": -3,
+            "height": 16,
+            "left": "38%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`iOS light mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -1324,6 +1636,7 @@ exports[`iOS light mode light mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1423,6 +1736,7 @@ exports[`iOS light mode light mode should render correctly with disabled={true} 
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1531,6 +1845,7 @@ exports[`iOS light mode light mode should render correctly with status=default 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1630,6 +1945,7 @@ exports[`iOS light mode light mode should render correctly with status=focused 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1729,6 +2045,106 @@ exports[`iOS light mode light mode should render correctly with status=focused 1
             },
             Object {
               "color": "rgb(0, 166, 152)",
+            },
+          ],
+        ]
+      }
+    >
+      
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
+exports[`iOS light mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 6,
+          "paddingVertical": 6,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 40,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(0, 166, 152)",
+            "borderRadius": 4,
+            "bottom": -3,
+            "height": 16,
+            "left": "38%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "BpkIcon",
+            "fontSize": 24,
+            "includeFontPadding": false,
+          },
+          Object {
+            "fontSize": 16,
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
             },
           ],
         ]

--- a/lib/bpk-component-map/src/__snapshots__/BpkPriceMarker-test.android.js.snap
+++ b/lib/bpk-component-map/src/__snapshots__/BpkPriceMarker-test.android.js.snap
@@ -19,6 +19,7 @@ exports[`Android dark mode dark mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -120,6 +121,7 @@ exports[`Android dark mode dark mode should render correctly with disabled={true
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -230,6 +232,7 @@ exports[`Android dark mode dark mode should render correctly with status=default
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -331,6 +334,7 @@ exports[`Android dark mode dark mode should render correctly with status=focused
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -446,6 +450,7 @@ exports[`Android dark mode dark mode should render correctly with status=viewed 
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -537,6 +542,108 @@ exports[`Android dark mode dark mode should render correctly with status=viewed 
 </AIRMapMarker>
 `;
 
+exports[`Android dark mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "sans-serif",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "textAlign": "left",
+          },
+          Object {
+            "fontFamily": "sans-serif-medium",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`Android dark mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -556,6 +663,7 @@ exports[`Android dark mode light mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -657,6 +765,7 @@ exports[`Android dark mode light mode should render correctly with disabled={tru
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -767,6 +876,7 @@ exports[`Android dark mode light mode should render correctly with status=defaul
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -868,6 +978,7 @@ exports[`Android dark mode light mode should render correctly with status=focuse
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -983,6 +1094,7 @@ exports[`Android dark mode light mode should render correctly with status=viewed
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1074,6 +1186,108 @@ exports[`Android dark mode light mode should render correctly with status=viewed
 </AIRMapMarker>
 `;
 
+exports[`Android dark mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "sans-serif",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "textAlign": "left",
+          },
+          Object {
+            "fontFamily": "sans-serif-medium",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`Android light mode dark mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -1093,6 +1307,7 @@ exports[`Android light mode dark mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1194,6 +1409,7 @@ exports[`Android light mode dark mode should render correctly with disabled={tru
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1304,6 +1520,7 @@ exports[`Android light mode dark mode should render correctly with status=defaul
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1405,6 +1622,7 @@ exports[`Android light mode dark mode should render correctly with status=focuse
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1520,6 +1738,7 @@ exports[`Android light mode dark mode should render correctly with status=viewed
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1611,6 +1830,108 @@ exports[`Android light mode dark mode should render correctly with status=viewed
 </AIRMapMarker>
 `;
 
+exports[`Android light mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "sans-serif",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "textAlign": "left",
+          },
+          Object {
+            "fontFamily": "sans-serif-medium",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`Android light mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -1630,6 +1951,7 @@ exports[`Android light mode light mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1731,6 +2053,7 @@ exports[`Android light mode light mode should render correctly with disabled={tr
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1841,6 +2164,7 @@ exports[`Android light mode light mode should render correctly with status=defau
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1942,6 +2266,7 @@ exports[`Android light mode light mode should render correctly with status=focus
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -2057,6 +2382,7 @@ exports[`Android light mode light mode should render correctly with status=viewe
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -2137,6 +2463,108 @@ exports[`Android light mode light mode should render correctly with status=viewe
             },
             Object {
               "color": "rgb(7, 112, 227)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
+exports[`Android light mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": undefined,
+          "shadowOffset": Object {
+            "height": undefined,
+            "width": undefined,
+          },
+          "shadowOpacity": undefined,
+          "shadowRadius": undefined,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "sans-serif",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0,
+            "textAlign": "left",
+          },
+          Object {
+            "fontFamily": "sans-serif-medium",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
             },
           ],
         ]

--- a/lib/bpk-component-map/src/__snapshots__/BpkPriceMarker-test.ios.js.snap
+++ b/lib/bpk-component-map/src/__snapshots__/BpkPriceMarker-test.ios.js.snap
@@ -19,6 +19,7 @@ exports[`iOS dark mode dark mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -120,6 +121,7 @@ exports[`iOS dark mode dark mode should render correctly with disabled={true} 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -230,6 +232,7 @@ exports[`iOS dark mode dark mode should render correctly with status=default 1`]
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -331,6 +334,7 @@ exports[`iOS dark mode dark mode should render correctly with status=focused 1`]
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -446,6 +450,7 @@ exports[`iOS dark mode dark mode should render correctly with status=viewed 1`] 
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -537,6 +542,108 @@ exports[`iOS dark mode dark mode should render correctly with status=viewed 1`] 
 </AIRMapMarker>
 `;
 
+exports[`iOS dark mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0.154,
+            "textAlign": "left",
+          },
+          Object {
+            "fontWeight": "700",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`iOS dark mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -556,6 +663,7 @@ exports[`iOS dark mode light mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -657,6 +765,7 @@ exports[`iOS dark mode light mode should render correctly with disabled={true} 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -767,6 +876,7 @@ exports[`iOS dark mode light mode should render correctly with status=default 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -868,6 +978,7 @@ exports[`iOS dark mode light mode should render correctly with status=focused 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -983,6 +1094,7 @@ exports[`iOS dark mode light mode should render correctly with status=viewed 1`]
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1074,6 +1186,108 @@ exports[`iOS dark mode light mode should render correctly with status=viewed 1`]
 </AIRMapMarker>
 `;
 
+exports[`iOS dark mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0.154,
+            "textAlign": "left",
+          },
+          Object {
+            "fontWeight": "700",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`iOS light mode dark mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -1093,6 +1307,7 @@ exports[`iOS light mode dark mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1194,6 +1409,7 @@ exports[`iOS light mode dark mode should render correctly with disabled={true} 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1304,6 +1520,7 @@ exports[`iOS light mode dark mode should render correctly with status=default 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1405,6 +1622,7 @@ exports[`iOS light mode dark mode should render correctly with status=focused 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1520,6 +1738,7 @@ exports[`iOS light mode dark mode should render correctly with status=viewed 1`]
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1611,6 +1830,108 @@ exports[`iOS light mode dark mode should render correctly with status=viewed 1`]
 </AIRMapMarker>
 `;
 
+exports[`iOS light mode dark mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(255, 255, 255)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0.154,
+            "textAlign": "left",
+          },
+          Object {
+            "fontWeight": "700",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
 exports[`iOS light mode light mode should render correctly 1`] = `
 <AIRMapMarker
   coordinate={
@@ -1630,6 +1951,7 @@ exports[`iOS light mode light mode should render correctly 1`] = `
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1731,6 +2053,7 @@ exports[`iOS light mode light mode should render correctly with disabled={true} 
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1841,6 +2164,7 @@ exports[`iOS light mode light mode should render correctly with status=default 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -1942,6 +2266,7 @@ exports[`iOS light mode light mode should render correctly with status=focused 1
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -2057,6 +2382,7 @@ exports[`iOS light mode light mode should render correctly with status=viewed 1`
       undefined,
     ]
   }
+  zIndex={null}
 >
   <View
     style={
@@ -2137,6 +2463,108 @@ exports[`iOS light mode light mode should render correctly with status=viewed 1`
             },
             Object {
               "color": "rgb(7, 112, 227)",
+            },
+          ],
+        ]
+      }
+    >
+      123€
+    </Text>
+  </View>
+</AIRMapMarker>
+`;
+
+exports[`iOS light mode light mode should render correctly with zIndex 1`] = `
+<AIRMapMarker
+  coordinate={
+    Object {
+      "latitude": 52.516379,
+      "longitude": 13.378026,
+    }
+  }
+  onPress={[Function]}
+  stopPropagation={false}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "position": "absolute",
+      },
+      undefined,
+    ]
+  }
+  zIndex={1000}
+>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingHorizontal": 8,
+          "paddingVertical": 4,
+          "shadowColor": "rgb(17, 18, 54)",
+          "shadowOffset": Object {
+            "height": 0.5,
+            "width": 0,
+          },
+          "shadowOpacity": 0.15,
+          "shadowRadius": 1.5,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": -4,
+            "height": 16,
+            "left": "50%",
+            "position": "absolute",
+            "transform": Array [
+              Object {
+                "rotate": "45deg",
+              },
+            ],
+            "width": 16,
+          },
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgb(7, 112, 227)",
+            "borderRadius": 4,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+        ]
+      }
+    />
+    <Text
+      allowFontScaling={false}
+      style={
+        Array [
+          Object {
+            "color": "rgb(17, 18, 54)",
+            "fontFamily": "System",
+            "fontSize": 14,
+            "fontWeight": "400",
+            "letterSpacing": 0.154,
+            "textAlign": "left",
+          },
+          Object {
+            "fontWeight": "700",
+          },
+          Array [
+            Object {
+              "color": "rgb(255, 255, 255)",
             },
           ],
         ]

--- a/lib/bpk-component-map/src/icon-marker-common-types.js
+++ b/lib/bpk-component-map/src/icon-marker-common-types.js
@@ -32,6 +32,7 @@ export type Props = {
   longitude: number,
   onPress: () => mixed,
   status: $Keys<typeof ICON_MARKER_STATUSES>,
+  zIndex?: ?number,
 };
 
 export const propTypes = {
@@ -40,9 +41,11 @@ export const propTypes = {
   longitude: PropTypes.number.isRequired,
   disabled: PropTypes.bool,
   status: PropTypes.oneOf(Object.keys(ICON_MARKER_STATUSES)),
+  zIndex: PropTypes.number,
 };
 
 export const defaultProps = {
   disabled: false,
   status: ICON_MARKER_STATUSES.default,
+  zIndex: null,
 };

--- a/lib/bpk-component-map/stories.js
+++ b/lib/bpk-component-map/stories.js
@@ -76,6 +76,22 @@ const StatefulPriceMarkersExample = () => {
       price: 'Sold out',
       disabled: true,
     },
+    {
+      id: '6',
+      name: 'Suites',
+      latitude: 35.667,
+      longitude: 139.7,
+      price: '£155',
+      disabled: false,
+    },
+    {
+      id: '7',
+      name: 'Inn & Suites',
+      latitude: 35.674,
+      longitude: 139.7,
+      price: '£100',
+      disabled: false,
+    },
   ];
 
   const onPressVenue = (venue) => {
@@ -92,6 +108,13 @@ const StatefulPriceMarkersExample = () => {
       return PRICE_MARKER_STATUSES.viewed;
     }
     return PRICE_MARKER_STATUSES.default;
+  };
+
+  const getZIndex = (status) => {
+    if (status === PRICE_MARKER_STATUSES.focused) {
+      return 1000;
+    }
+    return null;
   };
 
   return (
@@ -115,6 +138,7 @@ const StatefulPriceMarkersExample = () => {
           longitude={venue.longitude}
           status={getVenueStatus(venue.id)}
           disabled={venue.disabled}
+          zIndex={getZIndex(getVenueStatus(venue.id))}
         />
       ))}
     </BpkMap>
@@ -165,6 +189,22 @@ const StatefulIconMarkersExample = () => {
       disabled: true,
       icon: icons.leisure,
     },
+    {
+      id: '6',
+      name: 'Tochigi Car Park',
+      latitude: 35.667,
+      longitude: 139.7,
+      disabled: false,
+      icon: icons.parking,
+    },
+    {
+      id: '7',
+      name: 'Harbour Lake',
+      latitude: 35.673,
+      longitude: 139.7,
+      disabled: false,
+      icon: icons.landmark,
+    },
   ];
 
   const onPressVenue = (venue) => {
@@ -177,6 +217,13 @@ const StatefulIconMarkersExample = () => {
       return ICON_MARKER_STATUSES.focused;
     }
     return ICON_MARKER_STATUSES.default;
+  };
+
+  const getZIndex = (status) => {
+    if (status === ICON_MARKER_STATUSES.focused) {
+      return 1000;
+    }
+    return null;
   };
 
   return (
@@ -201,6 +248,7 @@ const StatefulIconMarkersExample = () => {
           longitude={venue.longitude}
           status={getVenueStatus(venue.id)}
           disabled={venue.disabled}
+          zIndex={getZIndex(getVenueStatus(venue.id))}
         />
       ))}
     </BpkMap>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Adding new `zIndex` prop to fix an issue where when a map marker was selected in a cluster of markers it would be selected behind unselected markers.

| **Price Marker Before** | **Price Marker After** |
| -- | -- |
| ![Screenshot_20210414-114256](https://user-images.githubusercontent.com/8831547/114698344-eadb1600-9d16-11eb-8fcb-1f8bc77d362e.png) | ![Screenshot_20210414-114104](https://user-images.githubusercontent.com/8831547/114698518-178f2d80-9d17-11eb-8aaa-37f30caac14a.png)

| **Icon Marker Before** | **Icon Marker After** |
| -- | -- |
| ![Screenshot_20210414-114320](https://user-images.githubusercontent.com/8831547/114698667-460d0880-9d17-11eb-8a16-971337704c9b.png) | ![Screenshot_20210414-114133](https://user-images.githubusercontent.com/8831547/114698626-38f01980-9d17-11eb-82cc-07ac736defa4.png)

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
