### PR TITLE
Use correct inits in RCTBPKCalendarSelectionConfigurationConstants

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+
+- Fixed issue that caused BackpackReactNative to fail to compile on Xcode 12.5.
 
 ## How to write a good changelog entry
 

--- a/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKCalendarSelectionConfigurationConstants.m
+++ b/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKCalendarSelectionConfigurationConstants.m
@@ -23,15 +23,22 @@
 @implementation RCTBPKCalendarSelectionConfigurationConstants
 
 + (BPKCalendarSelectionConfiguration *)single {
-    return [BPKCalendarSelectionConfigurationSingle new];
+    return [[BPKCalendarSelectionConfigurationSingle alloc] initWithSelectionHint:@""];
 }
 
 + (BPKCalendarSelectionConfiguration *)range {
-    return [BPKCalendarSelectionConfigurationRange new];
+    return [[BPKCalendarSelectionConfigurationRange alloc] initWithStartSelectionHint:@""
+                                                                     endSelectionHint:@""
+                                                                  startSelectionState:@""
+                                                                    endSelectionState:@""
+                                                                betweenSelectionState:@""
+                                                            startAndEndSelectionState:@""
+                                                                     returnDatePrompt:@""];
 }
 
 + (BPKCalendarSelectionConfiguration *)multiple {
-    return [BPKCalendarSelectionConfigurationMultiple new];
+    return [[BPKCalendarSelectionConfigurationMultiple alloc] initWithSelectionHint:@""
+                                                                    deselectionHint:@""];
 }
 
 @end


### PR DESCRIPTION
The `init` of the `BPKCalendarSelectionConfiguration*` family of classes is marked as unavailable. However `RCTBPKCalendarSelectionConfigurationConstants` managed to workaround that restriction by using `new`.

Xcode 12.5 is now able to detect these cases and code fails to compile. In order to fix it, we need to pass required parameters to the designated initializers.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-react-native/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
