### PR TITLE
[NO JIRA]: Fixup RN CI to latest

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -32,9 +32,15 @@ jobs:
 
       - name: Gradle build
         run: ./android/gradlew -p android :app:assembleDebug :backpack-react-native:assembleAndroidTest
-
-      - name: Run Android unit tests
-        run: ./android/gradlew -p android :app:Test :backpack-react-native:Test
+      
+      # Only run tests if not in a forked repo as it depends on secrets not available to forks
+      - name: Run Android tests
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: ./scripts/android/ci-tests.sh
+      
+# For now we will run the old tests compared to #715 as they use features that are available in the RN 64 upgrade. Once the PR is merged these can be reinstated and replaced.
+      # - name: Run Android unit tests
+        # run: ./android/gradlew -p android :app:Test :backpack-react-native:Test
   
   # These tests currently fail so we will need a follow up ticket to fix them.
   # Android:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,55 +11,49 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  build:
+
+  Build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup gCloud
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      env:
-        BACKPACK_GKEY: ${{ secrets.BACKPACK_GKEY}}
-        GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
-      run: |
-        gpg --quiet --batch --yes --decrypt --passphrase="$BACKPACK_GKEY" --output $HOME/gcloud-service-key.json gcloud-service-key.json.gpg
-        if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then
-          rm -rf $HOME/google-cloud-sdk
-          export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-          curl https://sdk.cloud.google.com | bash
-        fi
+      - name: Setup NPM
+        run: |
+          nvm install
+          npm ci
 
-        gcloud version
-        gcloud auth activate-service-account --project $GCLOUD_PROJECT_ID --key-file $HOME/gcloud-service-key.json
-    
-    # We install the NDK as the app requires an older version than bundled in the image
-    - name: Install NDK
-      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
 
-    - name: nvm install
-      run: nvm install
+      - name: Gradle Lint
+        run: ./android/gradlew -p android ktlint
 
-    - name: npm install
-      run: |
-        nvm use
-        npm ci
+      - name: Gradle build
+        run: ./android/gradlew -p android :app:assembleDebug :backpack-react-native:assembleAndroidTest
 
-    - name: Run tests
-      run: npm test
+      - name: Run Android unit tests
+        run: ./android/gradlew -p android :app:Test :backpack-react-native:Test
+  
+  # These tests currently fail so we will need a follow up ticket to fix them.
+  # Android:
+  #   name: Android Connected
+  #   runs-on: macos-latest
 
-    - name: Setup JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-    - name: Gradle Lint
-      run: ./android/gradlew -p android ktlint
+  #     - name: Setup NPM
+  #       run: |
+  #         nvm install
+  #         npm ci
 
-    - name: Gradle build
-      run: ./android/gradlew -p android :app:assembleDebug :backpack-react-native:assembleAndroidTest
-
-    # Only run tests if not in a forked repo as it depends on secrets not available to forks
-    - name: Run Android tests
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      run: ./scripts/android/ci-tests.sh
+  #     - name: Run Android connected tests
+  #       uses: reactivecircus/android-emulator-runner@v2
+  #       with:
+  #         target: google_apis
+  #         profile: Nexus 4
+  #         sdcard-path-or-size: 512M
+  #         api-level: 21
+  #         script: ./android/gradlew -p android :backpack-react-native:connectedAndroidTest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,7 @@ name: Deploy docs
 
 on:
   workflow_run:
-    workflows: ["Android CI", "iOS CI"]
+    workflows: ["Android CI", "iOS CI", "Node CI"]
     branches: [main]
     types: 
       - completed

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,33 @@
+name: Node CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+
+  Build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup NPM
+        run: |
+          nvm install
+          npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: |
+          nvm use
+          npm test


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

In #715 we fixed up CI to align more to the correct CI implementation we should be using for Android, and that due to it constantly failing currently. GIven we can't merge #715 yet, bringing the CI changes over separately so that PRs for dependency upgrades can pass.

The changes:

- Android CI - updated to align more to our Skyscanner/backpack-android and also due to failing gCloud setup on CI which we no longer need anymore since we don't use firebase for testing. Currently connected test are commented out as they are failing and will require follow up work to fix the native code.
- Node CI - created this workflow split the node parts from the Android CI, as it didn't make sense to be running here


Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
+ [ ] Any changes have been tested on both Android and iOS.
