### PR TITLE
[NO JIRA]: Migrate supported Node version from 12 to 14

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/erbium
+lts/fermium

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+## Added 
+
+Bumped supported Node version to `lts/fermium` (`v14`) to move away from EOL Node 12.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - FSCalendar (~> 2.8.2)
     - MBProgressHUD (~> 1.2.0)
     - TTTAttributedLabel (~> 2.0.0)
-  - BackpackReactNative (20.0.0):
+  - BackpackReactNative (20.0.1):
     - Backpack
     - React
     - react-native-maps
@@ -397,12 +397,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Backpack: 9e9c791ccb9b0df15187077640a8441fdaa417da
-  BackpackReactNative: 5bdbb0f70b22c13e23d828fe4a5fa0f01b189823
+  BackpackReactNative: 2287ae05e0af0a76ad8f433179b392742ed7a469
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 75ae1c4daf5feaf185042949263bde6d94c94a43
+  FBReactNativeSpec: 4ba18e430cfa7c809aace6e901f5a505c4059a12
   FloatingPanel: 5fe605e073e60395bc4bb416fd513d0fa38a6558
   FSCalendar: e6a2eb9c571bf0719ed797ef807e08426753c241
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62

--- a/lib/package.json
+++ b/lib/package.json
@@ -3,8 +3,8 @@
   "name": "backpack-react-native",
   "version": "20.0.1",
   "engines": {
-    "node": "^12.13.0",
-    "npm": "^6.12.0"
+    "node": "^14.19.0",
+    "npm": "^6.14.16"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "name": "backpack-react-native-example",
   "version": "0.0.0",
   "engines": {
-    "node": "^12.13.0",
-    "npm": "^6.12.0"
+    "node": "^14.19.0",
+    "npm": "^6.14.16"
   },
   "repository": {
     "type": "git",
@@ -13,7 +13,6 @@
   "author": "Backpack Design System <backpack@skyscanner.net>",
   "license": "Apache-2.0",
   "scripts": {
-    "preinstall": "npx ensure-node-env",
     "postinstall": "if [ ! -f .env ]; then cp .env.template .env; fi",
     "install:cocoapods": "(cd ios && bundle install && bundle exec pod install)",
     "clean:node_modules": "rm -rf node_modules",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As Node 12 reaches EOL on 31st April 2022 - we need to upgrade the version of node we are using.

Here we have decided to just go 12 -> 14 as our current RN version supports that and is a stopgap between jumping to Node 16 as this will require a full RN version upgrade which is more involved, so to begin we have taken the simple step/solution to at least move to a minimum supported version with an idea to do an RN upgrade later this year.

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
+ [ ] Any changes have been tested on both Android and iOS.
