### PR TITLE
[KOA-4189] fix disabled highlighted dates calendar

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,9 @@
 
 Bumped supported Node version to `lts/fermium` (`v14`) to move away from EOL Node 12.
 
-Fix calendar range to be inclusive on iOS
+## Fixed
+
+Fixed calendar range to be inclusive on iOS
 
 ## How to write a good changelog entry
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 Bumped supported Node version to `lts/fermium` (`v14`) to move away from EOL Node 12.
 
+Fix calendar range to be inclusive on iOS
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - FSCalendar (~> 2.8.2)
     - MBProgressHUD (~> 1.2.0)
     - TTTAttributedLabel (~> 2.0.0)
-  - BackpackReactNative (20.0.2):
+  - BackpackReactNative (20.1.0):
     - Backpack
     - React
     - react-native-maps
@@ -397,12 +397,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Backpack: 980e3f60acf7d11c813fb0f032ca0a1b6c143550
-  BackpackReactNative: 22e414cb4c1320a27c6d3a358653ad5309d01188
+  BackpackReactNative: a83839e0469e53cccf97a9483802205b9cb6c9a9
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 75ae1c4daf5feaf185042949263bde6d94c94a43
+  FBReactNativeSpec: d6bf4e829b14502684c7eaf03763e3a382f0c68e
   FloatingPanel: 5fe605e073e60395bc4bb416fd513d0fa38a6558
   FSCalendar: 2d1d0d9398f12d439f55c1fe0f01525b151b8260
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
@@ -436,4 +436,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: fcf9d1ebed9e236314299522a2ebb30069ee9556
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.10.1

--- a/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKCalendarDateUtils.h
+++ b/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKCalendarDateUtils.h
@@ -88,6 +88,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)date:(NSDate *)date isBeforeDate:(NSDate *)reference;
 
+/**
+ * Determine if a date is the same date
+ *
+ * @param date The date which you want to compare.
+ * @param reference The reference date.
+
+ * @return YES if `date` is the same to `reference`.
+ */
++ (BOOL)date:(NSDate *)date isSameDate:(NSDate *)reference;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKCalendarDateUtils.m
+++ b/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKCalendarDateUtils.m
@@ -49,5 +49,10 @@ NS_ASSUME_NONNULL_BEGIN
     return ordering == NSOrderedDescending;
 }
 
++ (BOOL)date:(NSDate *)date isSameDate:(NSDate *)reference {
+    NSComparisonResult ordering = [reference compare:date];
+    return ordering == NSOrderedSame;
+}
+
 @end
 NS_ASSUME_NONNULL_END

--- a/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKDateMatcher.m
+++ b/lib/ios/BackpackReactNative/Classes/CalendarBridge/RCTBPKDateMatcher.m
@@ -36,10 +36,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)matchesDate:(NSDate *)date {
     switch (self.matcherType) {
     case RCTBPKDateMatcherTypeRange:
+        if ([RCTBPKCalendarDateUtils date:date isSameDate:self.dates[0]] ||
+            [RCTBPKCalendarDateUtils date:date isSameDate:self.dates[1]]) {
+            return YES;
+        }
+
         if ([RCTBPKCalendarDateUtils date:date isAfterDate:self.dates[0]] &&
             [RCTBPKCalendarDateUtils date:date isBeforeDate:self.dates[1]]) {
             return YES;
         }
+
         break;
     case RCTBPKDateMatcherTypeBefore:
         if ([RCTBPKCalendarDateUtils date:date isBeforeDate:self.dates[0]]) {


### PR DESCRIPTION
`RCTBPKDateMatcher` uses isBeforeDate and isAfterDate from `RCTBPKCalendarDateUtils`. 

These functions are 'non-inclusive', we have added a new 'isSameDate' function to make sure the start and end date are included when `range` is used on the iOS calendar

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
+ [ ] Any changes have been tested on both Android and iOS.
