### PR TITLE
Enable openssl legacy use for android builds

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -39,9 +39,9 @@ jobs:
         run: ./android/gradlew -p android :app:assembleDebug :backpack-react-native:assembleAndroidTest
 
       - name: Run Android unit tests
-        run: |
-          export NODE_OPTIONS=--openssl-legacy-provider
-          ./android/gradlew -p android :app:Test :backpack-react-native:Test
+        run: ./android/gradlew -p android :app:Test :backpack-react-native:Test
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
 
   
   # KOA-4695 - These tests currently fail so we will need to fix them.

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -39,7 +39,10 @@ jobs:
         run: ./android/gradlew -p android :app:assembleDebug :backpack-react-native:assembleAndroidTest
 
       - name: Run Android unit tests
-        run: ./android/gradlew -p android :app:Test :backpack-react-native:Test
+        run: |
+          export NODE_OPTIONS=--openssl-legacy-provider
+          ./android/gradlew -p android :app:Test :backpack-react-native:Test
+
   
   # KOA-4695 - These tests currently fail so we will need to fix them.
   # Android:


### PR DESCRIPTION
The version of the github action runner has changed, with it the version of ubuntu, and the version of the default nodejs. 
We jumped from 16 to 18, which caused problems when building RN. To fix the issue I've reset the node version with nvm during the android test stage.


Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Any changes have been tested on both Android and iOS.
